### PR TITLE
Add Travis CI config to build aws-lc on Mac OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+git:
+  depth: 1
 language: c
 
 # Install additional dependencies first
@@ -19,4 +21,6 @@ compiler: clang
 
 # Run the script which contains all the build logic
 script:
+  - cmake --version
+  - quilt --version
   - tests/ci/run_posix_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ git:
   depth: 1
 language: c
 
-# Install additional dependencies first
+# Install additional dependencies first. brew update is required to find quilt on xcode10.3
 addons:
   homebrew:
+    update: true
     packages:
       - ninja
       - quilt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sudo: required
 language: c
 
+# Install additional dependencies first
 addons:
   homebrew:
     packages:
       - ninja
       - quilt
 
-matrix:
-  include:
-    - os: osx
-      osx_image:
-        - xcode10.3
-        - xcode12u
-      compiler: clang
+# Build matrix: test OSX with two versions of xcode/clang
+os: osx
+osx_image:
+  - xcode10.3
+  - xcode12u
+compiler: clang
 
+# Run the script which contains all the build logic
 script:
   - tests/ci/run_posix_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sudo: required
+language: c
+
+addons:
+  homebrew:
+    packages:
+      - ninja
+      - quilt
+
+matrix:
+  include:
+    - os: osx
+      osx_image:
+        - xcode10.3
+        - xcode12u
+      compiler: clang
+
+script:
+  - tests/ci/run_posix_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ compiler: clang
 script:
   - cmake --version
   - quilt --version
-  - tests/ci/run_posix_tests.sh
+  - tests/ci/run_mac_tests.sh

--- a/cmake/apply-quilt-patches.cmake
+++ b/cmake/apply-quilt-patches.cmake
@@ -4,8 +4,11 @@ message(STATUS "Finding Quilt and applying patches")
 find_program(QUILT_EXECUTABLE
     NAMES quilt
     DOC ${_doc}
-    REQUIRED
-    )
+)
+
+if(NOT QUILT_EXECUTABLE)
+    message(FATAL_ERROR "Unable to find Quilt")
+endif()
 
 # Display list of patches being applied
 execute_process(

--- a/cmake/apply-quilt-patches.cmake
+++ b/cmake/apply-quilt-patches.cmake
@@ -4,7 +4,7 @@ message(STATUS "Finding Quilt and applying patches")
 find_program(QUILT_EXECUTABLE
     NAMES quilt
     DOC ${_doc}
-)
+    )
 
 if(NOT QUILT_EXECUTABLE)
     message(FATAL_ERROR "Unable to find Quilt")

--- a/cmake/apply-quilt-patches.cmake
+++ b/cmake/apply-quilt-patches.cmake
@@ -1,8 +1,10 @@
 set(_doc "Command line tool to manage a series of patches")
 
+message(STATUS "Finding Quilt and applying patches")
 find_program(QUILT_EXECUTABLE
     NAMES quilt
     DOC ${_doc}
+    REQUIRED
     )
 
 # Display list of patches being applied

--- a/tests/ci/run_mac_tests.sh
+++ b/tests/ci/run_mac_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -ex
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+source tests/ci/common_posix_setup.sh
+
+# Only run a subset of the tests due to limited Travis resources
+echo "Testing AWS-LC in debug mode."
+run_build
+./test_build_dir/third_party/boringssl/crypto/crypto_test
+
+echo "Testing AWS-LC in release mode."
+run_build -DCMAKE_BUILD_TYPE=Release
+./test_build_dir/third_party/boringssl/crypto/crypto_test
+
+echo "Testing AWS-LC small compilation."
+run_build -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release
+./test_build_dir/third_party/boringssl/crypto/crypto_test
+
+echo "Testing AWS-LC in no asm mode."
+run_build -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
+./test_build_dir/third_party/boringssl/crypto/crypto_test
+
+echo "Testing building shared lib."
+run_build -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This adds the Travis config to run two Mac builds once Travis is enabled on this repository. I choose xcode10.3 to cover default developer config and 12u to test the latest version.

More info:
* https://docs.travis-ci.com/user/reference/osx/
* https://docs.travis-ci.com/user/languages/c/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
