### PR TITLE
Fix fuzz CI targets by pointing it to proper libcxx location

### DIFF
--- a/patches/0007-fix-fuzz-test-path-to-libc.patch
+++ b/patches/0007-fix-fuzz-test-path-to-libc.patch
@@ -1,0 +1,54 @@
+Index: aws-lc/third_party/boringssl/CMakeLists.txt
+===================================================================
+--- aws-lc.orig/third_party/boringssl/CMakeLists.txt
++++ aws-lc/third_party/boringssl/CMakeLists.txt
+@@ -525,6 +525,16 @@ if(USE_CUSTOM_LIBCXX)
+     message(FATAL_ERROR "USE_CUSTOM_LIBCXX only supported with Clang")
+   endif()
+ 
++  # The docker images set an environement variable to the llvm project directory which the sandbox builds will use,
++  # you can also pass in the llvm project path as a CMake parameter which takes precedance over the environment variable
++  if(DEFINED ENV{LLVM_PROJECT_HOME} AND NOT LLVM_PROJECT_HOME)
++    set(LLVM_PROJECT_HOME $ENV{LLVM_PROJECT_HOME})
++  endif()
++
++  if(NOT LLVM_PROJECT_HOME)
++    message(FATAL "Could not find path to LLVM project, must set LLVM_PROJECT_HOME environment variable or pass in -DLLVM_PROJECT_HOME")
++  endif()
++
+   # CMAKE_CXX_FLAGS ends up in the linker flags as well, so use
+   # add_compile_options. There does not appear to be a way to set
+   # language-specific compile-only flags.
+@@ -532,24 +542,25 @@ if(USE_CUSTOM_LIBCXX)
+   set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -nostdlib++")
+   include_directories(
+     SYSTEM
+-    util/bot/libcxx/include
+-    util/bot/libcxxabi/include
++    ${LLVM_PROJECT_HOME}/libcxx/include
++    ${LLVM_PROJECT_HOME}/libcxxabi/include
+   )
+ 
+   # This is patterned after buildtools/third_party/libc++/BUILD.gn and
+   # buildtools/third_party/libc++abi/BUILD.gn in Chromium.
+ 
+-  file(GLOB LIBCXX_SOURCES "util/bot/libcxx/src/*.cpp")
+-  file(GLOB LIBCXXABI_SOURCES "util/bot/libcxxabi/src/*.cpp")
++  file(GLOB LIBCXX_SOURCES "${LLVM_PROJECT_HOME}/libcxx/src/*.cpp")
++  file(GLOB LIBCXXABI_SOURCES "${LLVM_PROJECT_HOME}/libcxxabi/src/*.cpp")
+ 
+   # This file is meant for exception-less builds.
+-  list(REMOVE_ITEM LIBCXXABI_SOURCES "trunk/src/cxa_noexception.cpp")
++  list(REMOVE_ITEM LIBCXXABI_SOURCES "${LLVM_PROJECT_HOME}/libcxxabi/src/cxa_noexception.cpp")
++
+   # libc++ also defines new and delete.
+-  list(REMOVE_ITEM LIBCXXABI_SOURCES "trunk/src/stdlib_new_delete.cpp")
++  list(REMOVE_ITEM LIBCXXABI_SOURCES "${LLVM_PROJECT_HOME}/libcxxabi/src/stdlib_new_delete.cpp")
+   if(TSAN)
+     # ThreadSanitizer tries to intercept these symbols. Skip them to avoid
+     # symbol conflicts.
+-    list(REMOVE_ITEM LIBCXXABI_SOURCES "trunk/src/cxa_guard.cpp")
++    list(REMOVE_ITEM LIBCXXABI_SOURCES "${LLVM_PROJECT_HOME}/libcxxabi/src/cxa_guard.cpp")
+   endif()
+ 
+   add_library(libcxxabi ${LIBCXXABI_SOURCES})

--- a/patches/series
+++ b/patches/series
@@ -4,3 +4,4 @@
 0004-disable-urandom-test-docker.patch
 0005-fix-ssl-test-runner-output.patch
 0006-fix-gcc4-compile-errors.patch
+0007-fix-fuzz-test-path-to-libc.patch

--- a/tests/ci/codebuild/ubuntu-19.10_clang-9x_aarch64.yml
+++ b/tests/ci/codebuild/ubuntu-19.10_clang-9x_aarch64.yml
@@ -8,6 +8,6 @@ phases:
     commands:
       - export CC=clang-9
       - export CXX=clang++-9
-  # build:
-  #   commands:
-  #     - ./tests/ci/run_posix_tests.sh
+  build:
+    commands:
+      - ./tests/ci/run_posix_tests.sh

--- a/tests/ci/codebuild/ubuntu-19.10_clang-9x_aarch64_sanitizer.yml
+++ b/tests/ci/codebuild/ubuntu-19.10_clang-9x_aarch64_sanitizer.yml
@@ -8,6 +8,6 @@ phases:
     commands:
       - export CC=clang-9
       - export CXX=clang++-9
-  # build:
-  #   commands:
-  #     - ./tests/ci/run_posix_sanitizers.sh
+  build:
+    commands:
+      - ./tests/ci/run_posix_sanitizers.sh

--- a/tests/ci/codebuild/ubuntu-19.10_clang-9x_x86-64_sanitizer.yml
+++ b/tests/ci/codebuild/ubuntu-19.10_clang-9x_x86-64_sanitizer.yml
@@ -8,7 +8,6 @@ phases:
     commands:
       - export CC=clang-9
       - export CXX=clang++-9
-  # TODO: re-enable sanitizers when patch is ready.
-  # build:
-  #   commands:
-  #     - ./tests/ci/run_posix_sanitizers.sh
+  build:
+    commands:
+     - ./tests/ci/run_posix_sanitizers.sh

--- a/tests/ci/codebuild/ubuntu-19.10_gcc-9x_aarch64.yml
+++ b/tests/ci/codebuild/ubuntu-19.10_gcc-9x_aarch64.yml
@@ -8,6 +8,6 @@ phases:
     commands:
       - export CC=gcc-9
       - export CXX=g++-9
-  # build:
-  #   commands:
-  #     - ./tests/ci/run_posix_tests.sh
+  build:
+    commands:
+      - ./tests/ci/run_posix_tests.sh

--- a/tests/ci/docker_images/linux-aarch/ubuntu-19.10_clang-9x/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/ubuntu-19.10_clang-9x/Dockerfile
@@ -19,7 +19,7 @@ RUN set -ex && \
     ca-certificates \
     wget && \
     cd /tmp && \
-    wget https://dl.google.com/go/go1.13.12.linux-amd64.tar.gz && \
+    wget https://dl.google.com/go/go1.13.12.linux-arm64.tar.gz && \
     tar -xvf go1.13.12.linux-amd64.tar.gz && \
     mv go /usr/local && \
     apt-get autoremove --purge -y && \

--- a/tests/ci/docker_images/linux-aarch/ubuntu-19.10_clang-9x/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/ubuntu-19.10_clang-9x/Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex && \
     wget && \
     cd /tmp && \
     wget https://dl.google.com/go/go1.13.12.linux-arm64.tar.gz && \
-    tar -xvf go1.13.12.linux-amd64.tar.gz && \
+    tar -xvf go1.13.12.linux-arm64.tar.gz && \
     mv go /usr/local && \
     apt-get autoremove --purge -y && \
     apt-get clean && \

--- a/tests/ci/docker_images/linux-aarch/ubuntu-19.10_gcc-9x/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/ubuntu-19.10_gcc-9x/Dockerfile
@@ -18,8 +18,8 @@ RUN set -ex && \
     ca-certificates \
     wget && \
     cd /tmp && \
-    wget https://dl.google.com/go/go1.13.12.linux-amd64.tar.gz && \
-    tar -xvf go1.13.12.linux-amd64.tar.gz && \
+    wget https://dl.google.com/go/go1.13.12.linux-arm64.tar.gz && \
+    tar -xvf go1.13.12.linux-arm64.tar.gz && \
     mv go /usr/local && \
     apt-get autoremove --purge -y && \
     apt-get clean && \


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Our docker containers have a copy of llvm and libcxx and set an environment variable that points to it. This change uses that location instead of the bot user location which doesn't exist. This change also enables the fuzz CI targets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
