### PR TITLE
Have check fail if copyright header is missing

### DIFF
--- a/cmake/apply-quilt-patches.cmake
+++ b/cmake/apply-quilt-patches.cmake
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set(_doc "Command line tool to manage a series of patches")
 
 message(STATUS "Finding Quilt and applying patches")

--- a/tests/check_licenses.go
+++ b/tests/check_licenses.go
@@ -14,22 +14,23 @@ import (
 
 func main() {
 	license_regex, _ := regexp.Compile("(?i)(SPDX-License-Identifier: Apache-2.0" +
-		"|Brian Smith" +
-		"|CloudFlare Ltd." +
-		"|Eric Young" +
-		"|Google" +
-		"|Intel" +
-		"|Marc Bevand" +
-		"|OpenSSL license|OpenSSL Project)")
+        "|Brian Smith" +
+        "|CloudFlare Ltd." +
+        "|Eric Young" +
+        "|Google" +
+        "|Intel" +
+        "|Marc Bevand" +
+        "|OpenSSL license|OpenSSL Project)")
 	filematcher, _ := regexp.Compile("(Dockerfile|\\.(ASM|c|cc|cmake|h|sh|go|pl|ps1|yml|s|S))$")
 
 	var files []string
 	var unlicensed_files []string
 
 	excludes := []string {
-		".peg", // exlude all .peg.go files
-		"build",
-		"third_party",
+        ".github",
+        ".peg", // exlude all .peg.go files
+        "build",
+        "third_party",
 	}
 
 	// Collect all non-excluded source files into |files|
@@ -58,8 +59,7 @@ func main() {
 			fmt.Println(fmt.Sprintf("%s is missing a copyright header", failure))
 		}
 
-		// TODO: re-enable Copyright check when patch is ready.
-		// panic("FAILED Copyright Check")
+		panic("FAILED Copyright Check")
 	} else {
 		fmt.Println("PASSED Copyright Check")
 	}


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
This re-enables a step in `check_licenses.go` that fails if a copyright header is missing.

This change also adds a missing copyright header to `apply-quilt-patches.cmake`

### Testing:
This was tested locally by removing a copyright header from a file (cmake/awslc-config.cmake) and running `check_licenses.go`:
```
go run ./tests/check_licenses.go
```

This resulted in:
```
cmake/awslc-config.cmake is missing a copyright header
panic: FAILED Copyright Check
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
