### PR TITLE
Replace BORINGSSL_API_VERSION with AWSLC_API_VERSION.

### DIFF
--- a/patches/0012-replace-boringssl-api-version-macro.patch
+++ b/patches/0012-replace-boringssl-api-version-macro.patch
@@ -1,0 +1,23 @@
+Index: aws-lc/third_party/boringssl/include/openssl/base.h
+===================================================================
+--- aws-lc.orig/third_party/boringssl/include/openssl/base.h
++++ aws-lc/third_party/boringssl/include/openssl/base.h
+@@ -176,6 +176,9 @@ extern "C" {
+ #define OPENSSL_VERSION_NUMBER 0x1010007f
+ #define SSLEAY_VERSION_NUMBER OPENSSL_VERSION_NUMBER
+ 
++// BORINGSSL_API_VERSION is replaced with AWSLC_API_VERSION to avoid users intepreting lib as BoringSSL.
++// AWSLC_API_VERSION is not recommended to be used.
++// Below is previous comments relating to BORINGSSL_API_VERSION.
+ // BORINGSSL_API_VERSION is a positive integer that increments as BoringSSL
+ // changes over time. The value itself is not meaningful. It will be incremented
+ // whenever is convenient to coordinate an API change with consumers. This will
+@@ -184,7 +187,7 @@ extern "C" {
+ // A consumer may use this symbol in the preprocessor to temporarily build
+ // against multiple revisions of BoringSSL at the same time. It is not
+ // recommended to do so for longer than is necessary.
+-#define BORINGSSL_API_VERSION 10
++#define AWSLC_API_VERSION 10
+ 
+ #if defined(BORINGSSL_SHARED_LIBRARY)
+ 

--- a/patches/series
+++ b/patches/series
@@ -8,3 +8,4 @@
 0008-fix-abi-test-compilation.patch
 0009-add-macro-openssl-is-awslc.patch
 0010-reduce-threads-num-in-rsa-test.patch
+0012-replace-boringssl-api-version-macro.patch


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-413

### Description of changes: 
This PR replaces BORINGSSL_API_VERSION with AWSLC_API_VERSION to avoid users intepreting lib as BoringSSL.

### Call-outs:
N/A

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
