### PR TITLE
Replace BORINGSSL_API_VERSION with AWSLC_API_VERSION.

### DIFF
--- a/patches/0012-replace-boringssl-api-version-macro.patch
+++ b/patches/0012-replace-boringssl-api-version-macro.patch
@@ -2,16 +2,16 @@ Index: aws-lc/third_party/boringssl/include/openssl/base.h
 ===================================================================
 --- aws-lc.orig/third_party/boringssl/include/openssl/base.h
 +++ aws-lc/third_party/boringssl/include/openssl/base.h
-@@ -176,6 +176,9 @@ extern "C" {
+@@ -176,6 +176,8 @@ extern "C" {
  #define OPENSSL_VERSION_NUMBER 0x1010007f
  #define SSLEAY_VERSION_NUMBER OPENSSL_VERSION_NUMBER
  
 +// BORINGSSL_API_VERSION is replaced with AWSLC_API_VERSION to avoid users interpreting AWSLC as BoringSSL.
-+// Below is comments from BorringSSL on BORINGSSL_API_VERSION.
++// Below are BorringSSL's comments on BORINGSSL_API_VERSION.
  // BORINGSSL_API_VERSION is a positive integer that increments as BoringSSL
  // changes over time. The value itself is not meaningful. It will be incremented
  // whenever is convenient to coordinate an API change with consumers. This will
-@@ -184,7 +187,7 @@ extern "C" {
+@@ -184,7 +186,7 @@ extern "C" {
  // A consumer may use this symbol in the preprocessor to temporarily build
  // against multiple revisions of BoringSSL at the same time. It is not
  // recommended to do so for longer than is necessary.

--- a/patches/0012-replace-boringssl-api-version-macro.patch
+++ b/patches/0012-replace-boringssl-api-version-macro.patch
@@ -6,7 +6,7 @@ Index: aws-lc/third_party/boringssl/include/openssl/base.h
  #define OPENSSL_VERSION_NUMBER 0x1010007f
  #define SSLEAY_VERSION_NUMBER OPENSSL_VERSION_NUMBER
  
-+// BORINGSSL_API_VERSION is replaced with AWSLC_API_VERSION to avoid users intepreting AWSLC as BoringSSL.
++// BORINGSSL_API_VERSION is replaced with AWSLC_API_VERSION to avoid users interpreting AWSLC as BoringSSL.
 +// Below is comments from BorringSSL on BORINGSSL_API_VERSION.
  // BORINGSSL_API_VERSION is a positive integer that increments as BoringSSL
  // changes over time. The value itself is not meaningful. It will be incremented

--- a/patches/0012-replace-boringssl-api-version-macro.patch
+++ b/patches/0012-replace-boringssl-api-version-macro.patch
@@ -1,0 +1,22 @@
+Index: aws-lc/third_party/boringssl/include/openssl/base.h
+===================================================================
+--- aws-lc.orig/third_party/boringssl/include/openssl/base.h
++++ aws-lc/third_party/boringssl/include/openssl/base.h
+@@ -176,6 +176,9 @@ extern "C" {
+ #define OPENSSL_VERSION_NUMBER 0x1010007f
+ #define SSLEAY_VERSION_NUMBER OPENSSL_VERSION_NUMBER
+ 
++// BORINGSSL_API_VERSION is replaced with AWSLC_API_VERSION to avoid users intepreting AWSLC as BoringSSL.
++// Below is comments from BorringSSL on BORINGSSL_API_VERSION.
+ // BORINGSSL_API_VERSION is a positive integer that increments as BoringSSL
+ // changes over time. The value itself is not meaningful. It will be incremented
+ // whenever is convenient to coordinate an API change with consumers. This will
+@@ -184,7 +187,7 @@ extern "C" {
+ // A consumer may use this symbol in the preprocessor to temporarily build
+ // against multiple revisions of BoringSSL at the same time. It is not
+ // recommended to do so for longer than is necessary.
+-#define BORINGSSL_API_VERSION 10
++#define AWSLC_API_VERSION 10
+ 
+ #if defined(BORINGSSL_SHARED_LIBRARY)
+ 

--- a/patches/series
+++ b/patches/series
@@ -9,3 +9,4 @@
 0009-add-macro-openssl-is-awslc.patch
 0010-reduce-threads-num-in-rsa-test.patch
 0011-fix-fuzz-test-path-to-libc.patch
+0012-replace-boringssl-api-version-macro.patch


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-413

### Description of changes: 
This PR replaces BORINGSSL_API_VERSION with AWSLC_API_VERSION to avoid users interpreting AWSLC as BoringSSL.

### Call-outs:
N/A.

### Testing:
See CIs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
