### PR TITLE
Increase ARM CodeBuild timeout.

### DIFF
--- a/tests/ci/cdk/cdk/github_codebuild_stack.py
+++ b/tests/ci/cdk/cdk/github_codebuild_stack.py
@@ -52,6 +52,13 @@ class GitHubCodeBuildStack(core.Stack):
                             iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEC2ContainerRegistryReadOnly")
                         ])
 
+        # Define timeout.
+        if env_type is 'ARM':
+            # ARM sanitizer code build takes 90 minutes to complete.
+            timeout = core.Duration.minutes(120)
+        else:
+            timeout = core.Duration.minutes(60)
+
         # Define CodeBuild.
         build = codebuild.Project(
             scope=self,
@@ -59,6 +66,7 @@ class GitHubCodeBuildStack(core.Stack):
             project_name=id,
             source=git_hub_source,
             role=role,
+            timeout=timeout,
             environment=codebuild.BuildEnvironment(compute_type=codebuild.ComputeType.LARGE,
                                                    privileged=privileged,
                                                    build_image=build_image),


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-533

### Description of changes: 
This PR updates CDK CodeBuild timeout to provide enough time for ARM sanitizer test. 

### Call-outs:
N/A

### Testing:
* `cdk synth`
* `cdk deploy aws-lc-test-ubuntu-19-10--clang-9x--sanitizer`
   * Timeout of the CodeBuild is changed to 2 hours now. Before this deployment, the timeout was set to 5 hours manually.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
