### PR TITLE
Add documentation explaining how to generate a code coverage report.

### DIFF
--- a/docs/Coverage.md
+++ b/docs/Coverage.md
@@ -1,0 +1,11 @@
+# Coverage Report
+```shell script
+git clone git@github.com:awslabs/aws-lc.git
+mkdir build
+cd build
+cmake -GNinja -DGCOV=1 ../aws-lc
+ninja run_tests
+lcov --directory . --capture --output-file aws-lc-combined.info
+genhtml  aws-lc-combined.info
+```
+Open the report at build/index.html in a browser.


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
This adds instructions to generate a user friendly HTML report using existing CMake config and tools.

### Call-outs:
None

### Testing:
Ran the steps locally on an Ubuntu 18.04 host and verified it worked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
