### PR TITLE
Fix patch warning.

### DIFF
--- a/patches/0007-extend_evp_pkey_tls_encoding_functions.patch
+++ b/patches/0007-extend_evp_pkey_tls_encoding_functions.patch
@@ -771,4 +771,4 @@ Index: aws-lc/third_party/boringssl/include/openssl/evp.h
 +// uncompressed form.
  OPENSSL_EXPORT size_t EVP_PKEY_get1_tls_encodedpoint(const EVP_PKEY *pkey,
                                                       uint8_t **out_ptr);
- 
+


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
The patch file 007 does not have new line ending. When `patch push -av` command is executed, some warnings are print out.

### Call-outs:
Fix or not does not affect functionality but current code generates unnecessary warnings.

### Testing:
See CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
