### PR TITLE
Add valgrind test script, valgrind suppression config and docker config

### DIFF
--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x_valgrind/dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x_valgrind/dockerfile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM amazonlinux:2
+
+SHELL ["/bin/bash", "-c"]
+
+# Enable the EPEL repository on Amazon Linux 2 before installing packages
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/add-repositories.html
+
+# gcc 7.3.1 is the latest version versions `yum --showduplicates list gcc`
+RUN set -ex && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum -y update && yum install -y \
+    gcc \
+    gcc-c++ \
+    cmake \
+    ninja-build \
+    valgrind \
+    perl \
+    golang && \
+    yum clean packages && \
+    yum clean metadata && \
+    yum clean all && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/yum
+
+ENV CC=gcc
+ENV CXX=g++

--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x_valgrind/dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x_valgrind/dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM amazonlinux:2
+FROM amazonlinux-2:gcc-7x
 
 SHELL ["/bin/bash", "-c"]
 
@@ -10,15 +10,8 @@ SHELL ["/bin/bash", "-c"]
 
 # gcc 7.3.1 is the latest version versions `yum --showduplicates list gcc`
 RUN set -ex && \
-    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum -y update && yum install -y \
-    gcc \
-    gcc-c++ \
-    cmake \
-    ninja-build \
     valgrind \
-    perl \
-    golang && \
     yum clean packages && \
     yum clean metadata && \
     yum clean all && \

--- a/tests/ci/run_valgrind_tests.sh
+++ b/tests/ci/run_valgrind_tests.sh
@@ -27,8 +27,8 @@ VALGRIND_SUPPRESSIONS_FILE_CRYPTO_TEST=tests/ci/valgrind_suppressions_crypto_tes
 #   1: Executable to be executed under Valgrind
 #   2: Valgrind suppression file for $1
 # Output:
-#   0                       if Valgrind exists without any errors
-#   ${VALGRIND_ERROR_CODE}  if Valgrind exists with errors
+#   0                       if Valgrind exist without any errors
+#   ${VALGRIND_ERROR_CODE}  if Valgrind exist with errors
 ################################################################################
 run_valgrind () {
 

--- a/tests/ci/run_valgrind_tests.sh
+++ b/tests/ci/run_valgrind_tests.sh
@@ -1,0 +1,79 @@
+#!/bin/bash -xu
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+################################################################################
+# set -e is disabled in this script because we need the script to continue
+# even if |run_valgrind| returns an error.
+#
+# Assumes execution from root of AWS-LC folder.
+################################################################################
+
+source tests/ci/common_posix_setup.sh
+
+SCRIPT_EXIT_STATUS=0
+
+VALGRIND_COMMAND=valgrind
+VALGRIND_ERROR_CODE=99
+
+# crypto_test setup
+# Suppression file produced by running:
+# valgrind --gen-suppressions=yes ./test_build_dir/crypto/crypto_test
+CRYPTO_TEST_EXE=test_build_dir/crypto/crypto_test
+VALGRIND_SUPPRESSIONS_FILE_CRYPTO_TEST=tests/ci/valgrind_suppressions_crypto_test.supp
+
+################################################################################
+# Input:
+#   1: Executable to be executed under Valgrind
+#   2: Valgrind suppression file for $1
+# Output:
+#   0                       if Valgrind exists without any errors
+#   ${VALGRIND_ERROR_CODE}  if Valgrind exists with errors
+################################################################################
+run_valgrind () {
+
+    TEST_EXE=$1
+    VALGRIND_SUPPRESSIONS_FILE=$2
+    VALGRIND_ARGS=("--error-exitcode=${VALGRIND_ERROR_CODE}" "--track-origins=yes" "--leak-check=full" "--trace-children=yes" "--suppressions=${VALGRIND_SUPPRESSIONS_FILE}")
+
+    echo "-----Test configuration start-----"
+    echo "Test executable: ${TEST_EXE}"
+    echo "Valgrind arguments: ${VALGRIND_ARGS}"
+    echo "Valgrind suppressions:"
+    cat ${VALGRIND_SUPPRESSIONS_FILE}
+    echo "-----Test configuration end-----"
+
+    ${VALGRIND_COMMAND} "${VALGRIND_ARGS[@]}" ${TEST_EXE}
+
+    return $?
+}
+
+################################################################################
+# Input:
+#   1: Error code of previous run_valgrind execution
+#   2: Executable that was executed under Valgrind
+################################################################################
+check_and_handle_error() {
+
+    ERROR_CODE=$1
+    TEST_EXE=$2
+
+    if [[ ${ERROR_CODE} -eq ${VALGRIND_ERROR_CODE} ]]; then
+        echo "TEST FAILED"
+        echo "Executable that failed under Valgrind: ${TEST_EXE}"
+        # Set exit status to error in CI
+        SCRIPT_EXIT_STATUS=-1
+    else
+        echo "TEST SUCCEEDED"
+        echo "Executable that succeeded under Valgrind: ${TEST_EXE}"
+    fi
+}
+
+echo "Build AWS-LC in debug mode."
+run_build
+
+echo "Run AWS-LC crypto_test with Valgrind."
+run_valgrind ${CRYPTO_TEST_EXE} ${VALGRIND_SUPPRESSIONS_FILE_CRYPTO_TEST}
+check_and_handle_error $? ${CRYPTO_TEST_EXE}
+
+exit ${SCRIPT_EXIT_STATUS}

--- a/tests/ci/run_valgrind_tests.sh
+++ b/tests/ci/run_valgrind_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xu
+#!/bin/bash -x
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ci/valgrind_suppressions_crypto_test.supp
+++ b/tests/ci/valgrind_suppressions_crypto_test.supp
@@ -1,0 +1,67 @@
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:_itoa_word
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+   fun:_ZN7testing12_GLOBAL__N_124PrintBytesInObjectToImplEPKhmPSo
+   fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+   fun:_ZN7testing9internal220TypeWithoutFormatterI13ASN1TestParamLNS0_8TypeKindE2EE10PrintValueERKS2_PSo
+   fun:_ZN7testing9internal2lsIcSt11char_traitsIcE13ASN1TestParamEERSt13basic_ostreamIT_T0_ES9_RKT1_
+   fun:_ZN16testing_internal26DefaultPrintNonContainerToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal14DefaultPrintToI13ASN1TestParamEEvNS0_15WrapPrinterTypeILNS0_18DefaultPrinterTypeE3EEERKT_PSo
+   fun:_ZN7testing8internal7PrintToI13ASN1TestParamEEvRKT_PSo
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:_itoa_word
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+   fun:_ZN7testing12_GLOBAL__N_124PrintBytesInObjectToImplEPKhmPSo
+   fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+   fun:_ZN7testing9internal220TypeWithoutFormatterI13ASN1TestParamLNS0_8TypeKindE2EE10PrintValueERKS2_PSo
+   fun:_ZN7testing9internal2lsIcSt11char_traitsIcE13ASN1TestParamEERSt13basic_ostreamIT_T0_ES9_RKT1_
+   fun:_ZN16testing_internal26DefaultPrintNonContainerToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal14DefaultPrintToI13ASN1TestParamEEvNS0_15WrapPrinterTypeILNS0_18DefaultPrinterTypeE3EEERKT_PSo
+   fun:_ZN7testing8internal7PrintToI13ASN1TestParamEEvRKT_PSo
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+   fun:_ZN7testing12_GLOBAL__N_124PrintBytesInObjectToImplEPKhmPSo
+   fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+   fun:_ZN7testing9internal220TypeWithoutFormatterI13ASN1TestParamLNS0_8TypeKindE2EE10PrintValueERKS2_PSo
+   fun:_ZN7testing9internal2lsIcSt11char_traitsIcE13ASN1TestParamEERSt13basic_ostreamIT_T0_ES9_RKT1_
+   fun:_ZN16testing_internal26DefaultPrintNonContainerToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal14DefaultPrintToI13ASN1TestParamEEvNS0_15WrapPrinterTypeILNS0_18DefaultPrinterTypeE3EEERKT_PSo
+   fun:_ZN7testing8internal7PrintToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal16UniversalPrinterI13ASN1TestParamE5PrintERKS2_PSo
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+   fun:_ZN7testing12_GLOBAL__N_124PrintBytesInObjectToImplEPKhmPSo
+   fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+   fun:_ZN7testing9internal220TypeWithoutFormatterI13ASN1TestParamLNS0_8TypeKindE2EE10PrintValueERKS2_PSo
+   fun:_ZN7testing9internal2lsIcSt11char_traitsIcE13ASN1TestParamEERSt13basic_ostreamIT_T0_ES9_RKT1_
+   fun:_ZN16testing_internal26DefaultPrintNonContainerToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal14DefaultPrintToI13ASN1TestParamEEvNS0_15WrapPrinterTypeILNS0_18DefaultPrinterTypeE3EEERKT_PSo
+   fun:_ZN7testing8internal7PrintToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal16UniversalPrinterI13ASN1TestParamE5PrintERKS2_PSo
+}

--- a/tests/ci/valgrind_suppressions_crypto_test.supp
+++ b/tests/ci/valgrind_suppressions_crypto_test.supp
@@ -1,3 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+###############################################################################
+# Suppression file produced by running:
+# valgrind --gen-suppressions=yes ./test_build_dir/crypto/crypto_test
+# https://www.valgrind.org/docs/manual/manual-core.html#manual-core.suppress
+#
+# These errors are specific to the internals of the Gtest framework.
+###############################################################################
 {
    <insert_a_suppression_name_here>
    Memcheck:Value8


### PR DESCRIPTION
### Issues:

CryptoAlg-597

### Description of changes:

This adds a script that executes `crypto_test` under Valgrind. In addition, it adds a docker config file that configures a docker container that can run the script.

Execution target is Amazon Linux 2 with gcc 7.

### Call-outs:
Running `valgrind ./crypto_test` produces 4 errors that seems related to Gtest and printing. This should not be a blocker for enabling Valgrind in CI, so suppressing these through `valgrind_suppressions_crypto_test.supp`.

This PR is not supposed to have this test running in the CI yet. See "Next steps" below.

### Next steps:

Update CI to execute script in docker container.

After that, I will add a Valgrind target for Arm.
 
### Testing:

Tested in docker:
```
docker build -t amazonlinux2:gcc-7x tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x_valgrind
docker run -v `pwd`:`pwd` -w `pwd` -it amazonlinux2:gcc-7x
./tests/ci/run_valgrind_tests.sh 
```
Script execution also tested locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
