### PR TITLE
Fix typo

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -52,4 +52,4 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:amazonlinux-2-aarch_gcc-7x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:amazonlinux-2_gcc-7x_latest

--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -152,9 +152,11 @@ function deploy() {
     "ubuntu-19.10_clang-9x_latest"
     "ubuntu-19.10_clang-9x_sanitizer_latest")
   images_pushed_to_ecr "${ECR_LINUX_AARCH_REPO_NAME}" "${linux_aarch_img_tags[@]}"
-  linux_x86_img_tags=("ubuntu-18.04_gcc-7x_latest"
-    "ubuntu-16.04_gcc-5x_latest"
+  linux_x86_img_tags=("ubuntu-16.04_gcc-5x_latest"
+    "ubuntu-18.04_gcc-7x_latest"
     "ubuntu-18.04_clang-6x_latest"
+    "ubuntu-19.04_gcc-8x_latest"
+    "ubuntu-19.04_clang-8x_latest"
     "ubuntu-19.10_gcc-9x_latest"
     "ubuntu-19.10_clang-9x_sanitizer_latest"
     "ubuntu-19.10_clang-9x_latest"

--- a/tests/ci/docker_images/linux-aarch/push_images.sh
+++ b/tests/ci/docker_images/linux-aarch/push_images.sh
@@ -13,8 +13,8 @@ echo "Uploading docker images to ${ECS_REPO}."
 $(aws ecr get-login --no-include-email --region us-west-2)
 
 # Tag images with date to help find old images, CodeBuild uses the latest tag and gets updated automatically
-docker tag amazonlinux-2-aarch:gcc-7x ${ECS_REPO}:amazonlinux-2-aarch_gcc-7x_`date +%Y-%m-%d`
-docker tag amazonlinux-2-aarch:gcc-7x ${ECS_REPO}:amazonlinux-2-aarch_gcc-7x_latest
+docker tag amazonlinux-2-aarch:gcc-7x ${ECS_REPO}:amazonlinux-2_gcc-7x_`date +%Y-%m-%d`
+docker tag amazonlinux-2-aarch:gcc-7x ${ECS_REPO}:amazonlinux-2_gcc-7x_latest
 docker push ${ECS_REPO}:amazonlinux-2_gcc-7x_latest
 docker push ${ECS_REPO}:amazonlinux-2_gcc-7x_`date +%Y-%m-%d`
 

--- a/tests/ci/docker_images/linux-aarch/push_images.sh
+++ b/tests/ci/docker_images/linux-aarch/push_images.sh
@@ -15,8 +15,8 @@ $(aws ecr get-login --no-include-email --region us-west-2)
 # Tag images with date to help find old images, CodeBuild uses the latest tag and gets updated automatically
 docker tag amazonlinux-2-aarch:gcc-7x ${ECS_REPO}:amazonlinux-2-aarch_gcc-7x_`date +%Y-%m-%d`
 docker tag amazonlinux-2-aarch:gcc-7x ${ECS_REPO}:amazonlinux-2-aarch_gcc-7x_latest
-docker push ${ECS_REPO}:amazonlinux-2-aarch_gcc-7x_latest
-docker push ${ECS_REPO}:amazonlinux-2-aarch_gcc-7x_`date +%Y-%m-%d`
+docker push ${ECS_REPO}:amazonlinux-2_gcc-7x_latest
+docker push ${ECS_REPO}:amazonlinux-2_gcc-7x_`date +%Y-%m-%d`
 
 docker tag ubuntu-19.10-aarch:gcc-9x ${ECS_REPO}:ubuntu-19.10_gcc-9x_`date +%Y-%m-%d`
 docker tag ubuntu-19.10-aarch:gcc-9x ${ECS_REPO}:ubuntu-19.10_gcc-9x_latest

--- a/tests/ci/docker_images/linux-x86/push_images.sh
+++ b/tests/ci/docker_images/linux-x86/push_images.sh
@@ -53,6 +53,16 @@ docker tag ubuntu-19.10:sanitizer ${ECS_REPO}:ubuntu-19.10_clang-9x_sanitizer_la
 docker push ${ECS_REPO}:ubuntu-19.10_clang-9x_sanitizer_latest
 docker push ${ECS_REPO}:ubuntu-19.10_clang-9x_sanitizer_`date +%Y-%m-%d`
 
+docker tag ubuntu-20.04:gcc-9x ${ECS_REPO}:ubuntu-20.04_gcc-9x_`date +%Y-%m-%d`
+docker tag ubuntu-20.04:gcc-9x ${ECS_REPO}:ubuntu-20.04_gcc-9x_latest
+docker push ${ECS_REPO}:ubuntu-20.04_gcc-9x_latest
+docker push ${ECS_REPO}:ubuntu-20.04_gcc-9x_`date +%Y-%m-%d`
+
+docker tag ubuntu-20.04:clang-10x ${ECS_REPO}:ubuntu-20.04_clang-10x_`date +%Y-%m-%d`
+docker tag ubuntu-20.04:clang-10x ${ECS_REPO}:ubuntu-20.04_clang-10x_latest
+docker push ${ECS_REPO}:ubuntu-20.04_clang-10x_latest
+docker push ${ECS_REPO}:ubuntu-20.04_clang-10x_`date +%Y-%m-%d`
+
 docker tag centos-7:gcc-4x ${ECS_REPO}:centos-7_gcc-4x_`date +%Y-%m-%d`
 docker tag centos-7:gcc-4x ${ECS_REPO}:centos-7_gcc-4x_latest
 docker push ${ECS_REPO}:centos-7_gcc-4x_latest
@@ -77,13 +87,3 @@ docker tag integration:s2n ${ECS_REPO}:s2n_integration_clang-9x_`date +%Y-%m-%d`
 docker tag integration:s2n ${ECS_REPO}:s2n_integration_clang-9x_latest
 docker push ${ECS_REPO}:s2n_integration_clang-9x_latest
 docker push ${ECS_REPO}:s2n_integration_clang-9x_`date +%Y-%m-%d`
-
-docker tag ubuntu-20.04:gcc-9x ${ECS_REPO}:ubuntu-20.04_gcc-9x_`date +%Y-%m-%d`
-docker tag ubuntu-20.04:gcc-9x ${ECS_REPO}:ubuntu-20.04_gcc-9x_latest
-docker push ${ECS_REPO}:ubuntu-20.04_gcc-9x_latest
-docker push ${ECS_REPO}:ubuntu-20.04_gcc-9x_`date +%Y-%m-%d`
-
-docker tag ubuntu-20.04:clang-10x ${ECS_REPO}:ubuntu-20.04_clang-10x_`date +%Y-%m-%d`
-docker tag ubuntu-20.04:clang-10x ${ECS_REPO}:ubuntu-20.04_clang-10x_latest
-docker push ${ECS_REPO}:ubuntu-20.04_clang-10x_latest
-docker push ${ECS_REPO}:ubuntu-20.04_clang-10x_`date +%Y-%m-%d`


### PR DESCRIPTION
### Description of changes: 
The name of the ARM AL2 docker image pushed to ECR is out-of-sync with the name in the ARM docker image list in `run-cdk.sh`:
```
  linux_aarch_img_tags=("ubuntu-19.10_gcc-9x_latest"
    "amazonlinux-2_gcc-7x_latest"
    "ubuntu-20.04_gcc-9x_latest"
    "ubuntu-20.04_clang-10x_latest"
    "ubuntu-19.10_clang-9x_latest"
    "ubuntu-19.10_clang-9x_sanitizer_latest")
```

While the name in `push-images.sh` is:
```
docker push ${ECS_REPO}:amazonlinux-2-aarch_gcc-7x_latest
docker push ${ECS_REPO}:amazonlinux-2-aarch_gcc-7x_`date +%Y-%m-%d`
```

The `run-cdk.sh` script will error after 2.5 hours in the function `images_pushed_to_ecr` because it can't match the list of expected images (linux_aarch_img_tags) with what is in the ECR repository.

Change the name in `push-images.sh` to align with the naming convention used for the other docker images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
