### PR TITLE
Temporarily turn off DefaultTicketKeyInitialization

### DIFF
--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -2513,7 +2513,8 @@ TEST_P(SSLVersionTest, SessionTimeout) {
   }
 }
 
-TEST_P(SSLVersionTest, DefaultTicketKeyInitialization) {
+// These tests fail intermittently in Docker containers. Tracking root cause in CryptoAlg-534
+TEST_P(SSLVersionTest, DISABLED_DefaultTicketKeyInitialization) {
   static const uint8_t kZeroKey[kTicketKeyLen] = {};
   uint8_t ticket_key[kTicketKeyLen];
   ASSERT_EQ(1, SSL_CTX_get_tlsext_ticket_keys(server_ctx_.get(), ticket_key,


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-534

### Description of changes: 
This change disables the parameterized test DefaultTicketKeyInitialization which has been failing in our CI. The fix is being investigated in CryptoAlg-534 and in the mean time to reduce interruptions we're turning it off. This is safe for two reasons:
1. The libssl portion of AWS-LC should not be used, it is only kept for testing
2. It only fails in Docker which leads us to believe it is an issue with our CI setup and not AWS-LC

### Testing:
Before:
```
./ssl/ssl_test --gtest_filter='*DefaultTicketKeyInitialization*'
Note: Google Test filter = *DefaultTicketKeyInitialization*
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from WithVersion/SSLVersionTest
[ RUN      ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/TLS1
[       OK ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/TLS1 (1 ms)
[ RUN      ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/TLS1_1
[       OK ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/TLS1_1 (0 ms)
[ RUN      ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/TLS1_2
[       OK ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/TLS1_2 (1 ms)
[ RUN      ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/TLS1_3
[       OK ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/TLS1_3 (0 ms)
[ RUN      ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/DTLS1
[       OK ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/DTLS1 (1 ms)
[ RUN      ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/DTLS1_2
[       OK ] WithVersion/SSLVersionTest.DefaultTicketKeyInitialization/DTLS1_2 (0 ms)
[----------] 6 tests from WithVersion/SSLVersionTest (3 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 6 tests.
```
After:
```
./ssl/ssl_test --gtest_filter='*DefaultTicketKeyInitialization*'
Note: Google Test filter = *DefaultTicketKeyInitialization*
[==========] Running 0 tests from 0 test suites.
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.

  YOU HAVE 6 DISABLED TESTS
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
