### PR TITLE
Enable urandom_test and CodeBuild priviledge mode.

### DIFF
--- a/tests/ci/cdk/app.py
+++ b/tests/ci/cdk/app.py
@@ -23,10 +23,10 @@ EcrStack(app, "aws-lc-ecr-linux-x86", LINUX_X86_ECR_REPO, env=env)
 EcrStack(app, "aws-lc-ecr-linux-aarch", LINUX_AARCH_ECR_REPO, env=env)
 EcrStack(app, "aws-lc-ecr-windows-x86", WINDOWS_X86_ECR_REPO, env=env)
 
-# Define CodeBuild Batch job for testing code.
+# Define CodeBuild Batch job for building Docker images.
 LinuxDockerImageBatchBuildStack(app, "aws-lc-docker-image-build-linux", env=env)
 
-# DIND is not supported on Windows and, therefore, AWS CodeBuild is not used to build Windows Server container images.
+# AWS CodeBuild cannot build Windows Docker images because DIND (Docker In Docker) is not supported on Windows.
 # Windows Docker images are created by running commands in Windows EC2 instance.
 WindowsDockerImageBuildStack(app, "aws-lc-docker-image-build-windows", env=env)
 

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -26,7 +26,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-18.04_clang-6x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-18.04_clang-6x_latest
 
@@ -34,7 +34,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-18.04_gcc-7x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-18.04_gcc-7x_latest
 
@@ -42,7 +42,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-19.10_gcc-9x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-19.10_gcc-9x_latest
 
@@ -50,7 +50,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-19.10_clang-9x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-19.10_clang-9x_latest
 
@@ -58,7 +58,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-20.04_gcc-9x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-20.04_gcc-9x_latest
 
@@ -66,7 +66,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-20.04_clang-10x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-20.04_clang-10x_latest
 
@@ -74,7 +74,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-19.04_gcc-8x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-19.04_gcc-8x_latest
 
@@ -82,7 +82,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-19.04_clang-8x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-19.04_clang-8x_latest
 
@@ -98,7 +98,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/centos-7_gcc-4x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:centos-7_gcc-4x_latest
 
@@ -106,7 +106,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
 
@@ -122,7 +122,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/fedora-31_gcc-9x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:fedora-31_gcc-9x_latest
 
@@ -130,7 +130,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/fedora-31_clang-9x.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:fedora-31_clang-9x_latest
 
@@ -138,6 +138,6 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-19.10_clang-9x_sanitizer.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-19.10_clang-9x_sanitizer_latest

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -244,8 +244,8 @@ func runTest(test test) (bool, error) {
 }
 
 func fileExists(filename string) bool {
-    _, err := os.Stat(filename)
-    return err == nil
+	_, err := os.Stat(filename)
+	return err == nil
 }
 
 // setWorkingDirectory walks up directories as needed until the current working
@@ -391,8 +391,6 @@ func main() {
 	flag.Parse()
 	setWorkingDirectory()
 
-	inDocker := fileExists("/.dockerenv")
-
 	testCases, err := testconfig.ParseTestConfig("util/all_tests.json")
 	if err != nil {
 		fmt.Printf("Failed to parse input: %s\n", err)
@@ -431,9 +429,6 @@ func main() {
 					testForCPU.cpu = cpu
 					tests <- testForCPU
 				}
-			} else if inDocker && strings.Contains(baseTest.Cmd[0], "urandom_test") {
-				fmt.Printf("Running in Docker, skipping: %v\n", baseTest)
-				continue
 			} else {
 				shards, err := test.getGTestShards()
 				if err != nil {


### PR DESCRIPTION
### Issues:
CryptoAlg-578

### Description of changes: 
This PR is to re-enable `urandom_test`.

### Call-outs:
* `Running CodeBuild with least privilege -- seccomp` seems not supported. A feature request ticket (see CryptoAlg-578) has been cut to AWS CodeBuild.

### Testing:
* CI set up in my personal account has priviledged mode enabled and ran on branch `urandom_test`. Test links are available in CryptoAlg-578.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
