### PR TITLE
 Add Valgrind target to CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,6 +667,14 @@ add_custom_target(
     DEPENDS all_tests bssl_shim handshaker
     ${MAYBE_USES_TERMINAL})
 
+add_custom_target(
+    run_tests_valgrind
+    COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
+            ${CMAKE_BINARY_DIR} -valgrind=true -valgrind-supp-dir "tests/ci"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEPENDS all_tests
+    ${MAYBE_USES_TERMINAL})
+
 # Copy awslc-config.cmake to build artifacts. 
 configure_file("cmake/awslc-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/awslc-config.cmake"

--- a/crypto/cipher_extra/aead_test.cc
+++ b/crypto/cipher_extra/aead_test.cc
@@ -728,6 +728,7 @@ TEST_P(PerAEADTest, ABI) {
       GetParam().ad_len != 0 ? GetParam().ad_len : sizeof(ad_buf) - 1;
 
   uint8_t nonce[EVP_AEAD_MAX_NONCE_LENGTH];
+  OPENSSL_memset(nonce, 'T', sizeof(nonce));
   const size_t nonce_len = EVP_AEAD_nonce_length(aead());
   ASSERT_LE(nonce_len, sizeof(nonce));
 

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -88,6 +88,3 @@ The following Valgrind tests are run for a subset of targets in `utils/all_tests
 CI Tool|Compiler|CPU platform|OS| memcheck 
 ------------ | -------------| -------------|-------------|-------------
 CodeBuild|gcc 7.3.1|x86-64|AL2 | X
-(Disabled) CodeBuild|gcc 7.3.1|aarch64|AL2 | X
-
-Valgrind target for ARM is disabled due to time out.

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -88,4 +88,6 @@ The following Valgrind tests are run for a subset of targets in `utils/all_tests
 CI Tool|Compiler|CPU platform|OS| memcheck 
 ------------ | -------------| -------------|-------------|-------------
 CodeBuild|gcc 7.3.1|x86-64|AL2 | X
-CodeBuild|gcc 7.3.1|aarch64|AL2 | X
+(Disabled) CodeBuild|gcc 7.3.1|aarch64|AL2 | X
+
+Valgrind target for ARM is disabled due to time out.

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -80,3 +80,12 @@ CI Tool|Compiler|CPU platform|OS
 ------------ | -------------| -------------|-------------
 CodeBuild|clang 9.0.0|x86-64|Ubuntu 19.10
 CodeBuild|clang 9.0.0|aarch64|ubuntu 19.10
+
+### Valgrind tests
+
+The following Valgrind tests are run for a subset of targets in `utils/all_tests.json` using the debug build of AWS-LC:
+
+CI Tool|Compiler|CPU platform|OS| memcheck 
+------------ | -------------| -------------|-------------|-------------
+CodeBuild|gcc 7.3.1|x86-64|AL2 | X
+CodeBuild|gcc 7.3.1|aarch64|AL2 | X

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -53,3 +53,11 @@ batch:
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
+
+    - identifier: amazonlinux2_gcc7x_aarch_valgrind
+      buildspec: ./tests/ci/codebuild/linux-aarch/amazonlinux-2_gcc-7x_valgrind.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:amazonlinux-2_gcc-7x_latest

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -53,11 +53,3 @@ batch:
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
-
-    - identifier: amazonlinux2_gcc7x_aarch_valgrind
-      buildspec: ./tests/ci/codebuild/linux-aarch/amazonlinux-2_gcc-7x_valgrind.yml
-      env:
-        type: ARM_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:amazonlinux-2_gcc-7x_latest

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -114,7 +114,7 @@ batch:
       buildspec: ./tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_valgrind.yml
       env:
         type: LINUX_CONTAINER
-        privileged-mode: false
+        privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
 

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -110,6 +110,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
 
+    - identifier: amazonlinux2_gcc7x_x86_64_valgrind
+      buildspec: ./tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_valgrind.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
+
     - identifier: s2n_integration
       buildspec: ./tests/ci/codebuild/linux-x86/s2n_integration.yml
       env:

--- a/tests/ci/codebuild/linux-aarch/amazonlinux-2_gcc-7x_valgrind.yml
+++ b/tests/ci/codebuild/linux-aarch/amazonlinux-2_gcc-7x_valgrind.yml
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - if [ $(gcc -dumpfullversion) == 7.3.1 ]; then echo "Found correct gcc version 7"; else gcc --version && echo "gcc version mismatch" && exit 1; fi
+      - export CC=gcc
+      - export CXX=g++
+      - export GO111MODULE=on
+  build:
+    commands:
+      - ./tests/ci/run_valgrind_tests.sh

--- a/tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_valgrind.yml
+++ b/tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_valgrind.yml
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - if [ $(gcc -dumpfullversion) == 7.3.1 ]; then echo "Found correct gcc version 7"; else gcc --version && echo "gcc version mismatch" && exit 1; fi
+      - export CC=gcc
+      - export CXX=g++
+      - export GO111MODULE=on
+  build:
+    commands:
+      - ./tests/ci/run_valgrind_tests.sh

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -37,3 +37,12 @@ function build_and_test {
   run_build "$@"
   run_test 
 }
+
+function run_test_valgrind {
+  $BUILD_COMMAND -C test_build_dir run_tests_valgrind
+}
+
+function build_and_test_valgrind {
+  run_build "$@"
+  run_test_valgrind
+}

--- a/tests/ci/docker_images/linux-aarch/amazonlinux-2_gcc-7x/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/amazonlinux-2_gcc-7x/Dockerfile
@@ -8,7 +8,8 @@ SHELL ["/bin/bash", "-c"]
 # Enable the EPEL repository on Amazon Linux 2 before installing packages
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/add-repositories.html
 
-# gcc 7.3.1 is the latest version versions `yum --showduplicates list gcc`
+# gcc 7.3.1 is the latest version versions `yum --showduplicates list gcc`.
+# Install Valgrind for Valgrind test target even though it is not needed for the base test target.
 RUN set -ex && \
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum -y update && yum install -y \
@@ -17,7 +18,8 @@ RUN set -ex && \
     cmake \
     ninja-build \
     perl \
-    golang && \
+    golang \
+    valgrind && \
     yum clean packages && \
     yum clean metadata && \
     yum clean all && \

--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x/Dockerfile
@@ -9,6 +9,7 @@ SHELL ["/bin/bash", "-c"]
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/add-repositories.html
 
 # gcc 7.3.1 is the latest version versions `yum --showduplicates list gcc`
+# Install Valgrind for Valgrind test target even though it is not needed for the base test target.
 RUN set -ex && \
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum -y update && yum install -y \
@@ -17,7 +18,8 @@ RUN set -ex && \
     cmake \
     ninja-build \
     perl \
-    golang && \
+    golang \
+    valgrind && \
     yum clean packages && \
     yum clean metadata && \
     yum clean all && \

--- a/tests/ci/run_valgrind_tests.sh
+++ b/tests/ci/run_valgrind_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+source tests/ci/common_posix_setup.sh
+
+echo "Testing AWS-LC in debug mode under Valgrind."
+build_and_test_valgrind

--- a/tests/ci/valgrind_suppressions_crypto_test.supp
+++ b/tests/ci/valgrind_suppressions_crypto_test.supp
@@ -1,0 +1,77 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+###############################################################################
+# Suppression file produced by running:
+# valgrind --gen-suppressions=yes ./test_build_dir/crypto/crypto_test
+# https://www.valgrind.org/docs/manual/manual-core.html#manual-core.suppress
+#
+# These errors are specific to the internals of the Gtest framework.
+###############################################################################
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:_itoa_word
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+   fun:_ZN7testing12_GLOBAL__N_124PrintBytesInObjectToImplEPKhmPSo
+   fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+   fun:_ZN7testing9internal220TypeWithoutFormatterI13ASN1TestParamLNS0_8TypeKindE2EE10PrintValueERKS2_PSo
+   fun:_ZN7testing9internal2lsIcSt11char_traitsIcE13ASN1TestParamEERSt13basic_ostreamIT_T0_ES9_RKT1_
+   fun:_ZN16testing_internal26DefaultPrintNonContainerToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal14DefaultPrintToI13ASN1TestParamEEvNS0_15WrapPrinterTypeILNS0_18DefaultPrinterTypeE3EEERKT_PSo
+   fun:_ZN7testing8internal7PrintToI13ASN1TestParamEEvRKT_PSo
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:_itoa_word
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+   fun:_ZN7testing12_GLOBAL__N_124PrintBytesInObjectToImplEPKhmPSo
+   fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+   fun:_ZN7testing9internal220TypeWithoutFormatterI13ASN1TestParamLNS0_8TypeKindE2EE10PrintValueERKS2_PSo
+   fun:_ZN7testing9internal2lsIcSt11char_traitsIcE13ASN1TestParamEERSt13basic_ostreamIT_T0_ES9_RKT1_
+   fun:_ZN16testing_internal26DefaultPrintNonContainerToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal14DefaultPrintToI13ASN1TestParamEEvNS0_15WrapPrinterTypeILNS0_18DefaultPrinterTypeE3EEERKT_PSo
+   fun:_ZN7testing8internal7PrintToI13ASN1TestParamEEvRKT_PSo
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+   fun:_ZN7testing12_GLOBAL__N_124PrintBytesInObjectToImplEPKhmPSo
+   fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+   fun:_ZN7testing9internal220TypeWithoutFormatterI13ASN1TestParamLNS0_8TypeKindE2EE10PrintValueERKS2_PSo
+   fun:_ZN7testing9internal2lsIcSt11char_traitsIcE13ASN1TestParamEERSt13basic_ostreamIT_T0_ES9_RKT1_
+   fun:_ZN16testing_internal26DefaultPrintNonContainerToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal14DefaultPrintToI13ASN1TestParamEEvNS0_15WrapPrinterTypeILNS0_18DefaultPrinterTypeE3EEERKT_PSo
+   fun:_ZN7testing8internal7PrintToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal16UniversalPrinterI13ASN1TestParamE5PrintERKS2_PSo
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+   fun:_ZN7testing12_GLOBAL__N_124PrintBytesInObjectToImplEPKhmPSo
+   fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+   fun:_ZN7testing9internal220TypeWithoutFormatterI13ASN1TestParamLNS0_8TypeKindE2EE10PrintValueERKS2_PSo
+   fun:_ZN7testing9internal2lsIcSt11char_traitsIcE13ASN1TestParamEERSt13basic_ostreamIT_T0_ES9_RKT1_
+   fun:_ZN16testing_internal26DefaultPrintNonContainerToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal14DefaultPrintToI13ASN1TestParamEEvNS0_15WrapPrinterTypeILNS0_18DefaultPrinterTypeE3EEERKT_PSo
+   fun:_ZN7testing8internal7PrintToI13ASN1TestParamEEvRKT_PSo
+   fun:_ZN7testing8internal16UniversalPrinterI13ASN1TestParamE5PrintERKS2_PSo
+}

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -108,7 +108,7 @@ var armCPUs = []string{
 
 func valgrindOf(dbAttach bool, supp string, path string, args ...string) *exec.Cmd {
 	valgrindArgs := []string{"--error-exitcode=99", "--track-origins=yes", "--leak-check=full", "--quiet"}
-	if len(supp) > 1 {
+	if len(supp) > 0 {
 		valgrindArgs = append(valgrindArgs, "--suppressions=" + *valgrindSuppDir + "/" + supp)
 	}
 	if dbAttach {

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -106,9 +106,9 @@ var armCPUs = []string{
 	"crypto", // Support for NEON and crypto extensions.
 }
 
-func valgrindOf(dbAttach bool, supp string, path string, args ...string) *exec.Cmd {
-	valgrindArgs := []string{"--error-exitcode=99", "--track-origins=yes", "--leak-check=full", "--quiet"}
-	if len(supp) > 0 {
+func valgrindOf(dbAttach bool, supps []string, path string, args ...string) *exec.Cmd {
+	valgrindArgs := []string{"--error-exitcode=99", "--track-origins=yes", "--leak-check=full", "--trace-children=yes", "--quiet"}
+	for _, supp := range supps {
 		valgrindArgs = append(valgrindArgs, "--suppressions=" + *valgrindSuppDir + "/" + supp)
 	}
 	if dbAttach {
@@ -169,11 +169,7 @@ func runTestOnce(test test, mallocNumToFail int64) (passed bool, err error) {
 	}
 	var cmd *exec.Cmd
 	if *useValgrind {
-		supp := ""
-		if len(test.ValgrindSupp) > 0 {
-			supp = test.ValgrindSupp[0]
-		}
-		cmd = valgrindOf(false, supp, prog, args...)
+		cmd = valgrindOf(false, test.ValgrindSupp, prog, args...)
 	} else if *useCallgrind {
 		cmd = callgrindOf(prog, args...)
 	} else if *useGDB {

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -1,49 +1,61 @@
 [
   {
-    "cmd": ["crypto/crypto_test"]
+    "cmd": ["crypto/crypto_test"],
+    "valgrind_supp": ["valgrind_suppressions_crypto_test.supp"]
   },
   {
-    "cmd": ["crypto/crypto_test", "--gtest_also_run_disabled_tests", "--gtest_filter=BNTest.DISABLED_WycheproofPrimality"]
+    "cmd": ["crypto/crypto_test", "--gtest_also_run_disabled_tests", "--gtest_filter=BNTest.DISABLED_WycheproofPrimality"],
+    "skip_valgrind": true
   },
   {
     "cmd": ["crypto/crypto_test", "--gtest_also_run_disabled_tests", "--gtest_filter=RSATest.DISABLED_BlindingCacheConcurrency"],
-    "skip_sde": true
+    "skip_sde": true,
+    "skip_valgrind": true
   },
   {
-    "cmd": ["crypto/urandom_test"]
+    "cmd": ["crypto/urandom_test"],
+    "skip_valgrind": true
   },
   {
     "comment": "Without RDRAND",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x4000000000000000"]
+    "env": ["OPENSSL_ia32cap=~0x4000000000000000"],
+    "skip_valgrind": true
   },
   {
     "comment": "Potentially with RDRAND, but not Intel",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x0000000040000000"]
+    "env": ["OPENSSL_ia32cap=~0x0000000040000000"],
+    "skip_valgrind": true
   },
   {
     "comment": "Potentially with RDRAND, and forced to Intel",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=|0x0000000040000000"]
+    "env": ["OPENSSL_ia32cap=|0x0000000040000000"],
+    "skip_valgrind": true
   },
   {
     "comment": "No RDRAND and without WIPEONFORK",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x4000000000000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1"]
+    "env": ["OPENSSL_ia32cap=~0x4000000000000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
+    "skip_valgrind": true
   },
   {
     "comment": "Potentially with RDRAND, but not Intel, and no WIPEONFORK",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x0000000040000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1"]
+    "env": ["OPENSSL_ia32cap=~0x0000000040000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
+    "skip_valgrind": true
   },
   {
-    "cmd": ["crypto/crypto_test", "--fork_unsafe_buffering", "--gtest_filter=RandTest.*:-RandTest.Fork"]
+    "cmd": ["crypto/crypto_test", "--fork_unsafe_buffering", "--gtest_filter=RandTest.*:-RandTest.Fork"],
+    "skip_valgrind": true
   },
   {
-    "cmd": ["decrepit/decrepit_test"]
+    "cmd": ["decrepit/decrepit_test"],
+    "skip_valgrind": true
   },
   {
-    "cmd": ["ssl/ssl_test"]
+    "cmd": ["ssl/ssl_test"],
+    "skip_valgrind": true
   }
 ]

--- a/util/testconfig/testconfig.go
+++ b/util/testconfig/testconfig.go
@@ -20,9 +20,11 @@ import (
 )
 
 type Test struct {
-	Cmd     []string `json:"cmd"`
-	Env     []string `json:"env"`
-	SkipSDE bool     `json:"skip_sde"`
+	Cmd           	[]string `json:"cmd"`
+	Env           	[]string `json:"env"`
+	SkipSDE       	bool     `json:"skip_sde"`
+	SkipValgrind 	bool 	 `json:"skip_valgrind"`
+	ValgrindSupp  	[]string `json:"valgrind_supp"`
 }
 
 func ParseTestConfig(filename string) ([]Test, error) {

--- a/util/whitespace.txt
+++ b/util/whitespace.txt
@@ -1,2 +1,2 @@
 This file is ignored. It exists to make no-op commits to trigger new builds. 
- 
+  


### PR DESCRIPTION
### Issues:
CryptoAlg-597


### Description of changes:
This PR adds a Valgrind test target to the CI.

The target is implemented for AL2 x86 and Arm. Only x86 is currently enabled in the CI due to the Arm tests hitting the 2 hour time out limit in Codebuild (track resolution in CryptoAlg-597).

The only unit test suite that is run is `crypto_test`. The reason is that it takes +1 hour for only this test suite.


### Call-outs:
Valgrind picked up an uninitialised memory usage that is also fixed as part of this PR. See change in `aead_test.cc`.


### Testing:
Tested on a replica of the CI in my personal account.
It also running now in the CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
