### PR TITLE
Fix MSVC compile error - C3861.

### DIFF
--- a/crypto/fipsmodule/ec/p256-nistz_test.cc
+++ b/crypto/fipsmodule/ec/p256-nistz_test.cc
@@ -41,11 +41,13 @@
 
 TEST(P256_NistzTest, SelectW5) {
   // Fill a table with some garbage input.
-  // A bug on aarch not fixed in gcc 7 and 9 prevents the alignas usage.
-  // See references
-  // 1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57271
-  // 2. https://github.com/facebook/folly/issues/1098
   #if defined(__aarch64__)
+    // A bug on aarch not fixed in gcc 7 and 9 prevents the alignas usage 
+    // in cpp files where the argument to alignas is "seemingly" larger than the size of the array being aligned (faulty check).
+    // See references
+    // 1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89357#c3
+    // 2. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57271
+    // 3. https://github.com/facebook/folly/issues/1098
     __attribute__((aligned(64))) P256_POINT table[16];
   #else
     alignas(64) P256_POINT table[16];
@@ -79,11 +81,13 @@ TEST(P256_NistzTest, SelectW5) {
 
 TEST(P256_NistzTest, SelectW7) {
   // Fill a table with some garbage input.
-  // A bug on aarch not fixed in gcc 7 and 9 prevents the alignas usage.
-  // See references
-  // 1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57271
-  // 2. https://github.com/facebook/folly/issues/1098
   #if defined(__aarch64__)
+    // A bug on aarch not fixed in gcc 7 and 9 prevents the alignas usage 
+    // in cpp files where the argument to alignas is "seemingly" larger than the size of the array being aligned (faulty check).
+    // See references
+    // 1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89357#c3
+    // 2. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57271
+    // 3. https://github.com/facebook/folly/issues/1098
     __attribute__((aligned(64))) P256_POINT_AFFINE table[64];
   #else
     alignas(64) P256_POINT_AFFINE table[64];

--- a/crypto/fipsmodule/ec/p256-nistz_test.cc
+++ b/crypto/fipsmodule/ec/p256-nistz_test.cc
@@ -41,7 +41,15 @@
 
 TEST(P256_NistzTest, SelectW5) {
   // Fill a table with some garbage input.
-  alignas(64) P256_POINT table[16];
+  // A bug on aarch not fixed in gcc 7 and 9 prevents the alignas usage.
+  // See references
+  // 1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57271
+  // 2. https://github.com/facebook/folly/issues/1098
+  #if defined(__aarch64__)
+    __attribute__((aligned(64))) P256_POINT table[16];
+  #else
+    alignas(64) P256_POINT table[16];
+  #endif
   for (size_t i = 0; i < 16; i++) {
     OPENSSL_memset(table[i].X, 3 * i, sizeof(table[i].X));
     OPENSSL_memset(table[i].Y, 3 * i + 1, sizeof(table[i].Y));
@@ -71,7 +79,15 @@ TEST(P256_NistzTest, SelectW5) {
 
 TEST(P256_NistzTest, SelectW7) {
   // Fill a table with some garbage input.
-  alignas(64) P256_POINT_AFFINE table[64];
+  // A bug on aarch not fixed in gcc 7 and 9 prevents the alignas usage.
+  // See references
+  // 1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57271
+  // 2. https://github.com/facebook/folly/issues/1098
+  #if defined(__aarch64__)
+    __attribute__((aligned(64))) P256_POINT_AFFINE table[64];
+  #else
+    alignas(64) P256_POINT_AFFINE table[64];
+  #endif
   for (size_t i = 0; i < 64; i++) {
     OPENSSL_memset(table[i].X, 2 * i, sizeof(table[i].X));
     OPENSSL_memset(table[i].Y, 2 * i + 1, sizeof(table[i].Y));

--- a/crypto/fipsmodule/ec/p256-nistz_test.cc
+++ b/crypto/fipsmodule/ec/p256-nistz_test.cc
@@ -41,7 +41,7 @@
 
 TEST(P256_NistzTest, SelectW5) {
   // Fill a table with some garbage input.
-  __attribute__((aligned(64))) P256_POINT table[16];
+  alignas(64) P256_POINT table[16];
   for (size_t i = 0; i < 16; i++) {
     OPENSSL_memset(table[i].X, 3 * i, sizeof(table[i].X));
     OPENSSL_memset(table[i].Y, 3 * i + 1, sizeof(table[i].Y));
@@ -71,7 +71,7 @@ TEST(P256_NistzTest, SelectW5) {
 
 TEST(P256_NistzTest, SelectW7) {
   // Fill a table with some garbage input.
-  __attribute__((aligned(64))) P256_POINT_AFFINE table[64];
+  alignas(64) P256_POINT_AFFINE table[64];
   for (size_t i = 0; i < 64; i++) {
     OPENSSL_memset(table[i].X, 2 * i, sizeof(table[i].X));
     OPENSSL_memset(table[i].Y, 2 * i + 1, sizeof(table[i].Y));


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-560

### Description of changes: 
Below errors are reported when compiled with MSVC. This PR fixed the compile errors by replacing `__attribute__((aligned(64)))` with [`alignas`](https://en.cppreference.com/w/cpp/language/alignas). The ARM platform using gcc (6 - 7) will continue with `__attribute__((aligned(64)))` due to [gcc bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57271).
```
0 -wd4820 -wd5026 -wd5027 -wd5045  -w44265 /MD /O2 /Ob2 /DNDEBUG /showIncludes /Focrypto\CMakeFiles\crypto_test.dir\fipsmodule\ec\p256-nistz_test.cc.obj /Fdcrypto\CMakeFiles\crypto_test.dir\ /FS -c ..\crypto\fipsmodule\ec\p256-nistz_test.cc
..\crypto\fipsmodule\ec\p256-nistz_test.cc(44): error C3861: 'aligned': identifier not found
..\crypto\fipsmodule\ec\p256-nistz_test.cc(44): error C3861: '__attribute__': identifier not found
..\crypto\fipsmodule\ec\p256-nistz_test.cc(44): error C2146: syntax error: missing ';' before identifier 'P256_POINT'
..\crypto\fipsmodule\ec\p256-nistz_test.cc(74): error C3861: 'aligned': identifier not found
..\crypto\fipsmodule\ec\p256-nistz_test.cc(74): error C3861: '__attribute__': identifier not found
..\crypto\fipsmodule\ec\p256-nistz_test.cc(74): error C2146: syntax error: missing ';' before identifier 'P256_POINT_AFFINE'-
```

More references
 1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89357#c3
 2. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57271
 3. https://github.com/facebook/folly/issues/1098

### Call-outs:
This PR is one of multiple patches of making code compatible with MSVC compiler.

### Testing:
* Current CI set in team's AWS account.
* Windows CI set in my personal account.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
