### PR TITLE
Enable the SHA extension implementation of SHA-256/512 on x86

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,14 @@ add_custom_target(
     DEPENDS all_tests
     ${MAYBE_USES_TERMINAL})
 
+add_custom_target(
+    run_tests_with_sde
+    COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
+            ${CMAKE_BINARY_DIR} -sde true -sde-path "$ENV{SDEROOT}/sde"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEPENDS all_tests
+    ${MAYBE_USES_TERMINAL})
+
 # Copy awslc-config.cmake to build artifacts. 
 configure_file("cmake/awslc-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/awslc-config.cmake"

--- a/crypto/fipsmodule/sha/asm/sha512-x86_64.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-x86_64.pl
@@ -271,7 +271,7 @@ $code.=<<___ if ($SZ==4 || $avx);
 ___
 $code.=<<___ if ($SZ==4 && $shaext);
 	test	\$`1<<29`,%r11d		# check for SHA
-	jnz	_shaext_shortcut
+	jnz	.Lshaext_shortcut
 ___
     # XOP codepath removed.
 $code.=<<___ if ($avx>1);
@@ -555,7 +555,7 @@ $code.=<<___;
 .type	sha256_block_data_order_shaext,\@function,3
 .align	64
 sha256_block_data_order_shaext:
-_shaext_shortcut:
+.Lshaext_shortcut:
 .cfi_startproc
 ___
 $code.=<<___ if ($win64);

--- a/crypto/fipsmodule/sha/asm/sha512-x86_64.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-x86_64.pl
@@ -557,6 +557,10 @@ $code.=<<___;
 sha256_block_data_order_shaext:
 .Lshaext_shortcut:
 .cfi_startproc
+#ifdef BORINGSSL_DISPATCH_TEST
+.extern BORINGSSL_function_hit
+	movb \$1,BORINGSSL_function_hit+6(%rip)
+#endif
 ___
 $code.=<<___ if ($win64);
 	lea	`-8-5*16`(%rsp),%rsp

--- a/crypto/fipsmodule/sha/asm/sha512-x86_64.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-x86_64.pl
@@ -130,11 +130,7 @@ die "can't locate x86_64-xlate.pl";
 # necessary to disable AVX2 code when SHA Extensions code is disabled? Upstream
 # did not tie them together until after $shaext was added.
 $avx = 1;
-
-# TODO(davidben): Consider enabling the Intel SHA Extensions code once it's
-# been tested.
-$shaext=0;	### set to zero if compiling for 1.0.1
-$avx=1		if (!$shaext && $avx);
+$shaext=1;	### set to zero if compiling for 1.0.1
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT=*OUT;
@@ -560,6 +556,7 @@ $code.=<<___;
 .align	64
 sha256_block_data_order_shaext:
 _shaext_shortcut:
+.cfi_startproc
 ___
 $code.=<<___ if ($win64);
 	lea	`-8-5*16`(%rsp),%rsp
@@ -703,6 +700,7 @@ $code.=<<___ if ($win64);
 ___
 $code.=<<___;
 	ret
+.cfi_endproc
 .size	sha256_block_data_order_shaext,.-sha256_block_data_order_shaext
 ___
 }}}

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -38,13 +38,13 @@ class ImplDispatchTest : public ::testing::Test {
     aesni_ = OPENSSL_ia32cap_P[1] & (1 << (57 - 32));
     avx_movbe_ = ((OPENSSL_ia32cap_P[1] >> 22) & 0x41) == 0x41;
     ssse3_ = OPENSSL_ia32cap_P[1] & (1 << (41 - 32));
+    sha_ext_ = OPENSSL_ia32cap_P[2] & (1 << 29);
     is_x86_64_ =
 #if defined(OPENSSL_X86_64)
         true;
 #else
         false;
 #endif
-    sha_ext_ = OPENSSL_ia32cap_P[2] & (1 << 29);
 #endif  // X86 || X86_64
   }
 
@@ -77,8 +77,8 @@ class ImplDispatchTest : public ::testing::Test {
   bool aesni_ = false;
   bool avx_movbe_ = false;
   bool ssse3_ = false;
-  bool is_x86_64_ = false;
   bool sha_ext_ = false;
+  bool is_x86_64_ = false;
 #endif
 };
 

--- a/include/openssl/cpu.h
+++ b/include/openssl/cpu.h
@@ -201,6 +201,7 @@ extern unsigned long OPENSSL_ppc64le_hwcap2;
 //   3: aes_hw_set_encrypt_key
 //   4: vpaes_encrypt
 //   5: vpaes_set_encrypt_key
+//   6: sha256_block_data_order_shaext
 extern uint8_t BORINGSSL_function_hit[7];
 #endif  // BORINGSSL_DISPATCH_TEST
 

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -94,6 +94,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
 
+    - identifier: amazonlinux2_gcc7x_intel_sde_x86_64
+      buildspec: ./tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_intel-sde.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:amazonlinux-2_gcc-7x_intel-sde_latest
+
     - identifier: amazonlinux2_gcc7x_x86_64_valgrind
       buildspec: ./tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_valgrind.yml
       env:

--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -171,6 +171,7 @@ function deploy() {
     "ubuntu-20.04_clang-10x_formal-verification_latest"
     "centos-7_gcc-4x_latest"
     "amazonlinux-2_gcc-7x_latest"
+    "amazonlinux-2_gcc-7x_intel-sde_latest"
     "s2n_integration_clang-9x_latest")
   images_pushed_to_ecr "${ECR_LINUX_X86_REPO_NAME}" "${linux_x86_img_tags[@]}"
   windows_img_tags=("vs2015_latest" "vs2017_latest")

--- a/tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_intel-sde.yml
+++ b/tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_intel-sde.yml
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - if [ $(gcc -dumpfullversion) == 7.3.1 ]; then echo "Found correct gcc version 7"; else gcc --version && echo "gcc version mismatch" && exit 1; fi
+      # # Based on Interl SDE README, SELinux should be turned off to allow pin to work.
+      # https://software.intel.com/content/www/us/en/develop/articles/intel-software-development-emulator.html#system-configuration
+      - if [ $(getenforce) == 'Disabled' ]; then echo "SELinux is disabled. Disabling SELinux is needed by sde to allow pin work." ; else echo "SELinux should be turned off to allow sde pin to work." && exit 1; fi
+      - export CC=gcc
+      - export CXX=g++
+      - export GO111MODULE=on
+  build:
+    commands:
+      - ./tests/ci/run_tests_with_sde.sh

--- a/tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_intel-sde.yml
+++ b/tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_intel-sde.yml
@@ -7,7 +7,7 @@ phases:
   pre_build:
     commands:
       - if [ $(gcc -dumpfullversion) == 7.3.1 ]; then echo "Found correct gcc version 7"; else gcc --version && echo "gcc version mismatch" && exit 1; fi
-      # # Based on Interl SDE README, SELinux should be turned off to allow pin to work.
+      # Based on Intel SDE README, SELinux should be turned off to allow pin to work.
       # https://software.intel.com/content/www/us/en/develop/articles/intel-software-development-emulator.html#system-configuration
       - if [ $(getenforce) == 'Disabled' ]; then echo "SELinux is disabled. Disabling SELinux is needed by sde to allow pin work." ; else echo "SELinux should be turned off to allow sde pin to work." && exit 1; fi
       - export CC=gcc

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -46,3 +46,12 @@ function build_and_test_valgrind {
   run_build "$@"
   run_test_valgrind
 }
+
+function run_test_with_sde {
+  $BUILD_COMMAND -C test_build_dir run_tests_with_sde
+}
+
+function build_and_test_with_sde {
+  run_build "$@"
+  run_test_with_sde
+}

--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x-intel-sde/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x-intel-sde/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM amazonlinux-2:gcc-7x
+
+SHELL ["/bin/bash", "-c"]
+
+# Enable the EPEL repository on Amazon Linux 2 before installing packages
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/add-repositories.html
+
+# gcc 7.3.1 is the latest version versions `yum --showduplicates list gcc`
+# Install Valgrind for Valgrind test target even though it is not needed for the base test target.
+RUN set -ex && \
+    yum -y update && yum install -y \
+    # Without glibc.i686, running "./sde --help" generates error "bash: ./sde: /lib/ld-linux.so.2: bad ELF interpreter: No such file or directory"
+    glibc.i686 \
+    # This provides command `getenforce`, which can tell the current status of SELinux.
+    # Based on Interl SDE README, SELinux should be turned off to allow pin to work.
+    libselinux-utils \
+    wget \
+    bzip2 \
+    tar && \
+    # Install Intel® Software Development Emulator
+    # This emulator is needed when running BoringSSL/AWS-LC code under Intel's SDE for each supported chip (like ice lake).
+    # https://software.intel.com/content/www/us/en/develop/articles/intel-software-development-emulator.html#system-configuration
+    wget https://software.intel.com/content/dam/develop/external/us/en/documents/downloads/sde-external-8.59.0-2020-10-05-lin.tar.bz2 && \
+    tar -xvjf sde-external-8.59.0-2020-10-05-lin.tar.bz2 && \
+    cd sde-external-8.59.0-2020-10-05-lin \
+    yum clean packages && \
+    yum clean metadata && \
+    yum clean all && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/yum
+
+ENV CC=gcc
+ENV CXX=g++
+ENV SDEROOT=/sde-external-8.59.0-2020-10-05-lin
+ENV PATH="$SDEROOT:$PATH"

--- a/tests/ci/docker_images/linux-x86/build_images.sh
+++ b/tests/ci/docker_images/linux-x86/build_images.sh
@@ -15,6 +15,7 @@ docker build -t ubuntu-19.10:clang-9x ubuntu-19.10_clang-9x
 docker build -t ubuntu-19.10:sanitizer ubuntu-19.10_clang-9x_sanitizer
 docker build -t centos-7:gcc-4x centos-7_gcc-4x
 docker build -t amazonlinux-2:gcc-7x amazonlinux-2_gcc-7x
+docker build -t amazonlinux-2:gcc-7x-intel-sde amazonlinux-2_gcc-7x-intel-sde
 docker build -t fedora-31:clang-9x fedora-31_clang-9x
 docker build -t integration:s2n s2n_integration_clang-9x
 docker build -t ubuntu-20.04:clang-10x ubuntu-20.04_clang-10x

--- a/tests/ci/docker_images/linux-x86/push_images.sh
+++ b/tests/ci/docker_images/linux-x86/push_images.sh
@@ -63,6 +63,11 @@ docker tag amazonlinux-2:gcc-7x ${ECS_REPO}:amazonlinux-2_gcc-7x_latest
 docker push ${ECS_REPO}:amazonlinux-2_gcc-7x_latest
 docker push ${ECS_REPO}:amazonlinux-2_gcc-7x_`date +%Y-%m-%d`
 
+docker tag amazonlinux-2:gcc-7x-intel-sde ${ECS_REPO}:amazonlinux-2_gcc-7x_intel-sde_`date +%Y-%m-%d`
+docker tag amazonlinux-2:gcc-7x-intel-sde ${ECS_REPO}:amazonlinux-2_gcc-7x_intel-sde_latest
+docker push ${ECS_REPO}:amazonlinux-2_gcc-7x_intel-sde_latest
+docker push ${ECS_REPO}:amazonlinux-2_gcc-7x_intel-sde_`date +%Y-%m-%d`
+
 docker tag fedora-31:clang-9x ${ECS_REPO}:fedora-31_clang-9x_`date +%Y-%m-%d`
 docker tag fedora-31:clang-9x ${ECS_REPO}:fedora-31_clang-9x_latest
 docker push ${ECS_REPO}:fedora-31_clang-9x_latest

--- a/tests/ci/run_tests_with_sde.sh
+++ b/tests/ci/run_tests_with_sde.sh
@@ -4,8 +4,8 @@
 
 source tests/ci/common_posix_setup.sh
 
-echo "Testing AWS-LC in debug mode."
+echo "Testing AWS-LC in debug mode under Intel's SDE."
 build_and_test_with_sde
 
-echo "Testing AWS-LC in release mode."
+echo "Testing AWS-LC in release mode under Intel's SDE."
 build_and_test_with_sde -DCMAKE_BUILD_TYPE=Release

--- a/tests/ci/run_tests_with_sde.sh
+++ b/tests/ci/run_tests_with_sde.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ex
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+source tests/ci/common_posix_setup.sh
+
+echo "Testing AWS-LC in debug mode."
+build_and_test_with_sde
+
+echo "Testing AWS-LC in release mode."
+build_and_test_with_sde -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
This change enables the implementation of SHA-256/512 with
SHA extension instruction set on x86 platforms.

Signed-off-by: Kostic <dkostic@amazon.com>

### Issues:
Addresses CryptoAlg-599.

### Description of changes: 
This change enables the implementation of SHA-256/512 with
SHA extension instruction set on x86 platforms.

### Call-outs:
The change should not be merged before it is ensured that the CI is running
code tests for all the possible CPU platforms. See CryptoAlg-622.

### Testing:
See call-outs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
