### PR TITLE
CryptoAlg-629: Remove prefetch from select_w7

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -85,12 +85,6 @@ remove some code that is especially large.
 See [CMake's documentation](https://cmake.org/cmake/help/v3.4/manual/cmake-variables.7.html)
 for other variables which may be used to configure the build.
 
-### Building for ARMv8 (AArch64)
-In order to enable AArch64 optimizations for the NIST curve P-256, run `cmake`
-as follows:
-
-    cmake -DOPENSSL_AARCH64_P256=1 -DCMAKE_BUILD_TYPE=Release -GNinja ..
-
 ### Building for Android
 
 It's possible to build BoringSSL with the Android NDK using CMake. Recent

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,6 +516,8 @@ elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "i686")
   set(ARCH "x86")
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
   set(ARCH "aarch64")
+  # Enable p256_nistz on ARMv8 (AArch64) by default
+  add_definitions(-DOPENSSL_AARCH64_P256)
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm64")
   set(ARCH "aarch64")
 # Apple A12 Bionic chipset which is added in iPhone XS/XS Max/XR uses arm64e architecture.
@@ -696,7 +698,7 @@ add_custom_target(
     DEPENDS all_tests
     ${MAYBE_USES_TERMINAL})
 
-# Copy awslc-config.cmake to build artifacts. 
+# Copy awslc-config.cmake to build artifacts.
 configure_file("cmake/awslc-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/awslc-config.cmake"
     @ONLY)

--- a/crypto/fipsmodule/ec/asm/p256-armv8-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256-armv8-asm.pl
@@ -1723,10 +1723,6 @@ ecp_nistz256_select_w7:
     // Increment $M0 lanes
     add     $M0.4s, $M0.4s, $ONE.4s         ////    paddd   $ONE, $M0
 
-    // prefetch data for load into L1 cache in a streaming fashion
-    // (streaming prefetch for data that is used only once)
-    prfm    pldl1strm, [$in_t]              ////    prefetcht0	255($in_t)
-
     // [$T0a-$T0d] := [$T0a-$T0d] AND $TMP0
     // values read from the table will be 0'd if $M0 != $INDEX
     // [$Ra-$Rd] := [$Ra-$Rd] OR [$T0a-$T0d]

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -16,9 +16,6 @@ build_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release
 echo "Testing AWS-LC in no asm mode."
 build_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
 
-echo "Testing AWS-LC with AArch64 P-256 optimizations."
-build_and_test -DOPENSSL_AARCH64_P256=1 -DCMAKE_BUILD_TYPE=Release
-
 echo "Testing building shared lib."
 run_build -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
 

--- a/util/asm_dev/armv8/p256/Makefile
+++ b/util/asm_dev/armv8/p256/Makefile
@@ -12,7 +12,7 @@ BUILDDIR = ./build
 CFLAGS = -I$(SRCDIR) -std=c11 -MMD
 CFLAGS += -Wall -Wextra -Wpedantic
 CFLAGS += -Werror -Wshadow -Wconversion
-CFLAGS += -march=armv8.4-a+sve -g -O2
+CFLAGS += -g -O2 -fstack-protector -fsanitize=address
 
 SRC_C := $(wildcard $(SRCDIR)/*.c)
 SRC_ASM := $(wildcard $(SRCDIR)/*.S)

--- a/util/asm_dev/armv8/p256/src/beeu.S
+++ b/util/asm_dev/armv8/p256/src/beeu.S
@@ -16,7 +16,6 @@
 //  Chapter 14, Algorithm 14.61 and Note 14.64
 //  http://cacr.uwaterloo.ca/hac/about/chap14.pdf)
 
-    .arch armv8.4-a+crc+sve
     .text
     .align  4
     .global beeu_mod_inverse_vartime
@@ -159,7 +158,9 @@ beeu_mod_inverse_vartime:
     //    sp  <------------------- 112 bytes ----------------> old sp
     //   x29 (FP)
     //
-    paciasp
+
+    // Pointer authentication - store pointer
+    .inst   0xd503233f      // paciasp
     stp     x29,x30,[sp,#-112]!
     add	    x29,sp,#0
     stp     x19,x20,[sp,#16]
@@ -362,7 +363,9 @@ beeu_mod_inverse_vartime:
     ldp     x25,x26,[sp,#64]
     ldp     x27,x28,[sp,#80]
     ldp     x29,x30,[sp],#112
-    autiasp
+
+    // Pointer authentication - authenticate pointer before return
+    .inst   0xd50323bf      // autiasp
     ret
 
     .size beeu_mod_inverse_vartime, .-beeu_mod_inverse_vartime

--- a/util/asm_dev/armv8/p256/src/main.c
+++ b/util/asm_dev/armv8/p256/src/main.c
@@ -67,11 +67,12 @@ static void beeu_print(const int res, const uint64_t out_exp[4], const uint64_t 
 int main()
 {
 #ifdef SELECT_FN
-    uint64_t table[TABLE_LONG_SIZE];
-    uint64_t val[ENTRY_LONG_SIZE];
     uint32_t index;
     uint32_t idx_64;
     uint32_t j;
+
+    uint64_t table[TABLE_LONG_SIZE];
+    uint64_t val[ENTRY_LONG_SIZE];
 
     uint64_t table_w7[TABLE_LONG_SIZE_W7];
     uint64_t val_w7[ENTRY_LONG_SIZE_W7];
@@ -150,7 +151,6 @@ int main()
     {
         printf("select_w7 Test passed\n");
     }
-
 #endif
 
 #ifdef BEEU

--- a/util/asm_dev/armv8/p256/src/select.S
+++ b/util/asm_dev/armv8/p256/src/select.S
@@ -47,10 +47,10 @@
 select_w5:
     // Pointer authentication - store pointer
 	.inst	0xd503233f		// paciasp
-/*
+
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
-*/
+
     // [Ra - Rf] := 0
     eor     Ra.16b, Ra.16b, Ra.16b
     eor     Rb.16b, Rb.16b, Rb.16b
@@ -104,15 +104,13 @@ select_w5:
     // Write [Ra-Rf] to memory at the output pointer
     st1     {Ra.2d, Rb.2d, Rc.2d, Rd.2d}, [Val_in],#64
     st1     {Re.2d, Rf.2d}, [Val_in]
-    ret
 
     // Pointer authentication - authenticate pointer before return
-	//add	sp,x29,#0
-/*
+    add	sp,x29,#0
     ldp	x29,x30,[sp],#16
-*/
+
     .inst	0xd50323bf		// autiasp
-	ret
+    ret
 
     .size select_w5, .-select_w5
 
@@ -124,10 +122,10 @@ select_w5:
 select_w7:
     // Pointer authentication - store pointer
 	.inst	0xd503233f		// paciasp
-/*
+
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
-*/
+
     // One (vec_4*32) := | 1 | 1 | 1 | 1 |
     // Idx_in (vec_4*32) := | idx | idx | idx | idx |
     movi    One.4s, #1
@@ -176,11 +174,9 @@ select_w7:
 
     // Write [Ra-Rd] to memory at the output pointer
     st1     {Ra.2d, Rb.2d, Rc.2d, Rd.2d}, [val]
-    ret
 
     // Pointer authentication - authenticate pointer before return
     ldp	x29,x30,[sp],#16
-/*
 	.inst	0xd50323bf		// autiasp
-*/
+    ret
     .size select_w7, .-select_w7

--- a/util/asm_dev/armv8/p256/src/select.S
+++ b/util/asm_dev/armv8/p256/src/select.S
@@ -47,7 +47,6 @@
 select_w5:
     // Pointer authentication - store pointer
 	.inst	0xd503233f		// paciasp
-
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
 
@@ -108,7 +107,6 @@ select_w5:
     // Pointer authentication - authenticate pointer before return
     add	sp,x29,#0
     ldp	x29,x30,[sp],#16
-
     .inst	0xd50323bf		// autiasp
     ret
 
@@ -122,7 +120,6 @@ select_w5:
 select_w7:
     // Pointer authentication - store pointer
 	.inst	0xd503233f		// paciasp
-
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
 

--- a/util/asm_dev/armv8/p256/src/select.S
+++ b/util/asm_dev/armv8/p256/src/select.S
@@ -4,7 +4,6 @@
 //------------------------------------------------------------------------------------
 
 // void select_w5(uint64_t *val, uint64_t *in_t, int index);
-    .arch armv8.4-a+crc+sve
     .text
     .align  4
     .global select_w5
@@ -46,6 +45,12 @@
     T0f         .req v27
 
 select_w5:
+    // Pointer authentication - store pointer
+	.inst	0xd503233f		// paciasp
+/*
+	stp	x29,x30,[sp,#-16]!
+	add	x29,sp,#0
+*/
     // [Ra - Rf] := 0
     eor     Ra.16b, Ra.16b, Ra.16b
     eor     Rb.16b, Rb.16b, Rb.16b
@@ -59,7 +64,6 @@ select_w5:
     dup     Idx_in.4s, idx  // Idx_in (vec_4*32) := | idx | idx | idx | idx |
 
     mov     Val_in, val     // Val_in := val
-//    mov     In_t_in, in_t   // In_t_in := in_t
     mov     Ctr, #16        // Ctr := 16; loop counter
 
 .Lselect_w5_loop:
@@ -76,7 +80,7 @@ select_w5:
 
     // [T0a-T0f] := [T0a-T0f] AND Mask;
     // values read from the table will be 0'd if M0 != Idx_in
-    // [Ra-Rf] := [Ra-Rf] OR [T0a-T0b]
+    // [Ra-Rf] := [Ra-Rf] OR [T0a-T0f]
     // values in output registers will remain the same if M0 != Idx_in
     and     T0a.16b, T0a.16b, Mask.16b
     and     T0b.16b, T0b.16b, Mask.16b
@@ -102,6 +106,14 @@ select_w5:
     st1     {Re.2d, Rf.2d}, [Val_in]
     ret
 
+    // Pointer authentication - authenticate pointer before return
+	//add	sp,x29,#0
+/*
+    ldp	x29,x30,[sp],#16
+*/
+    .inst	0xd50323bf		// autiasp
+	ret
+
     .size select_w5, .-select_w5
 
 // void ecp_nistz256_select_w7(uint64_t *val, uint64_t *in_t, int index);
@@ -110,6 +122,12 @@ select_w5:
 .type select_w7, %function
 
 select_w7:
+    // Pointer authentication - store pointer
+	.inst	0xd503233f		// paciasp
+/*
+	stp	x29,x30,[sp,#-16]!
+	add	x29,sp,#0
+*/
     // One (vec_4*32) := | 1 | 1 | 1 | 1 |
     // Idx_in (vec_4*32) := | idx | idx | idx | idx |
     movi    One.4s, #1
@@ -138,10 +156,6 @@ select_w7:
     // Increment M0 lanes
     add     M0.4s, M0.4s, One.4s
 
-    // prefetch data for load into L1 cache in a streaming fashion
-    // (streaming prefetch for datat that is used only once)
-    prfm    pldl1strm, [in_t]
-
     // [T0a-T0d] := [T0a-T0d] AND Mask;
     // values read from the table will be 0'd if M0 != Idx_in
     // [Ra-Rd] := [Ra-Rd] OR [T0a-T0d]
@@ -164,4 +178,9 @@ select_w7:
     st1     {Ra.2d, Rb.2d, Rc.2d, Rd.2d}, [val]
     ret
 
+    // Pointer authentication - authenticate pointer before return
+    ldp	x29,x30,[sp],#16
+/*
+	.inst	0xd50323bf		// autiasp
+*/
     .size select_w7, .-select_w7


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-629

### Description of changes: 
This PR addresses the [comments](https://github.com/awslabs/aws-lc/pull/67#pullrequestreview-555043259) from @sebpop on the assembly functions developed to support ARMv8-optimized P-256 implementation.
- Removed the prefetch instruction from select_w7 to
  > let the processor figure out the memory access pattern: in this case it is linear access which is very easy to predict.
This will reduce code size for the loop and it will reduce execution time by not having to decode the instruction.

  There was a noticeable small improvement in the performance of ECDSA sign (0.6%) and ECDH (0.2%) where multiplying by the base point is employed. It's more noticeable in ECDSA sign than ECDH since multiplication by the base point dominates ECDSA sign operation, but is only the first part of ECDH which also contains multiplication by an arbitrary public point which is a slower operation.
These improvements are understandably negligible, but they only show that prefetch, which may improve performance in some cases such as tree traversal and on platforms where there isn't a good hardware-supported prefetch, in this case, affects the performance (slightly) negatively.

- Addressed other comments on the development application such as removing the `.arch` directive and the `-march` compilation option.

- Enabled P-256 optimizations by default on ARMv8
which means reverting "CryptoAlg-530: Add ci test with -DOPENSSL_AARCH64_P256=1"
commit [270f803](https://github.com/awslabs/aws-lc/commit/270f803cf2784eedbba6720f49cc2cc407ddeeaf)

### Call-outs:
N/A

### Testing:
Tested on ARMv8 EC2 instance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
