### PR TITLE
Install 'which' in AL2.

### DIFF
--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex && \
     ninja-build \
     perl \
     golang \
+    which \
     valgrind && \
     yum clean packages && \
     yum clean metadata && \


### PR DESCRIPTION
### Issues:
Scrutinice has some analysis script using `which` command. The command is not installed by default in AL2.

### Description of changes: 
This PR installs 'which' in AL2.

### Call-outs:
I will build this image when working on gcc10 build task. This image change is not needed by external CI.

### Testing:
Internal scrutinice build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
