### PR TITLE
Add gcc-10x to build and test code.

### DIFF
--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -49,6 +49,8 @@ CodeBuild|gcc 7.3.1|x86-64|AL2
 CodeBuild|gcc 7.3.1|aarch64|AL2
 CodeBuild|gcc 7.4.4|x86-64|Ubuntu 18.04
 CodeBuild|gcc 8.3.0|x86-64|Ubuntu 19.04
+CodeBuild|gcc 10.2.0|x86-64|Ubuntu 20.04
+CodeBuild|gcc 10.2.0|aarch64|Ubuntu 20.04
 CodeBuild|clang 6.0.0|x86-64|Ubuntu 18.04
 CodeBuild|clang 8.0.0|x86-64|Ubuntu 19.04
 CodeBuild|clang 9.0.0|x86-64|Ubuntu 19.10

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -15,6 +15,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:ubuntu-19.10_clang-9x_latest
 
+    - identifier: ubuntu2004_gcc10x_aarch
+      buildspec: ./tests/ci/codebuild/linux-aarch/ubuntu-20.04_gcc-10x.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:ubuntu-20.04_gcc-10x_latest
+
     - identifier: ubuntu2004_clang10x_aarch
       buildspec: ./tests/ci/codebuild/linux-aarch/ubuntu-20.04_clang-10x.yml
       env:

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -46,6 +46,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-19.10_clang-9x_latest
 
+    - identifier: ubuntu2004_gcc10x_x86_64
+      buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-20.04_gcc-10x.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-20.04_gcc-10x_latest
+
     - identifier: ubuntu2004_clang10x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-20.04_clang-10x.yml
       env:

--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -154,6 +154,7 @@ function deploy() {
 
   echo "Waiting for docker images creation. Building the docker images need to take 1 hour."
   linux_aarch_img_tags=("amazonlinux-2_gcc-7x_latest"
+    "ubuntu-20.04_gcc-10x_latest"
     "ubuntu-20.04_clang-10x_latest"
     "ubuntu-19.10_clang-9x_latest"
     "ubuntu-19.10_clang-9x_sanitizer_latest")
@@ -166,6 +167,7 @@ function deploy() {
     "ubuntu-19.10_clang-9x_sanitizer_latest"
     "ubuntu-19.10_clang-9x_latest"
     "ubuntu-19.04_gcc-8x_latest"
+    "ubuntu-20.04_gcc-10x_latest"
     "ubuntu-19.04_clang-8x_latest"
     "ubuntu-20.04_clang-10x_latest"
     "ubuntu-20.04_clang-10x_formal-verification_latest"

--- a/tests/ci/codebuild/linux-aarch/ubuntu-20.04_gcc-10x.yml
+++ b/tests/ci/codebuild/linux-aarch/ubuntu-20.04_gcc-10x.yml
@@ -7,7 +7,7 @@ phases:
   pre_build:
     commands:
       - export CC=gcc-10
-      - export CXX=gcc++-10
+      - export CXX=g++-10
   build:
     commands:
       - ./tests/ci/run_posix_tests.sh

--- a/tests/ci/codebuild/linux-aarch/ubuntu-20.04_gcc-10x.yml
+++ b/tests/ci/codebuild/linux-aarch/ubuntu-20.04_gcc-10x.yml
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - export CC=gcc-10
+      - export CXX=gcc++-10
+  build:
+    commands:
+      - ./tests/ci/run_posix_tests.sh

--- a/tests/ci/codebuild/linux-x86/ubuntu-20.04_gcc-10x.yml
+++ b/tests/ci/codebuild/linux-x86/ubuntu-20.04_gcc-10x.yml
@@ -7,7 +7,7 @@ phases:
   pre_build:
     commands:
       - export CC=gcc-10
-      - export CXX=gcc++-10
+      - export CXX=g++-10
   build:
     commands:
       - ./tests/ci/run_posix_tests.sh

--- a/tests/ci/codebuild/linux-x86/ubuntu-20.04_gcc-10x.yml
+++ b/tests/ci/codebuild/linux-x86/ubuntu-20.04_gcc-10x.yml
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - export CC=gcc-10
+      - export CXX=gcc++-10
+  build:
+    commands:
+      - ./tests/ci/run_posix_tests.sh

--- a/tests/ci/docker_images/linux-aarch/build_images.sh
+++ b/tests/ci/docker_images/linux-aarch/build_images.sh
@@ -5,4 +5,5 @@
 docker build -t amazonlinux-2-aarch:gcc-7x amazonlinux-2_gcc-7x
 docker build -t ubuntu-19.10-aarch:clang-9x ubuntu-19.10_clang-9x
 docker build -t ubuntu-19.10-aarch:sanitizer ubuntu-19.10_clang-9x_sanitizer
+docker build -t ubuntu-20.04-aarch:gcc-10x ubuntu-20.04_gcc-10x
 docker build -t ubuntu-20.04-aarch:clang-10x ubuntu-20.04_clang-10x

--- a/tests/ci/docker_images/linux-aarch/push_images.sh
+++ b/tests/ci/docker_images/linux-aarch/push_images.sh
@@ -28,6 +28,11 @@ docker tag ubuntu-19.10-aarch:sanitizer ${ECS_REPO}:ubuntu-19.10_clang-9x_saniti
 docker push ${ECS_REPO}:ubuntu-19.10_clang-9x_sanitizer_latest
 docker push ${ECS_REPO}:ubuntu-19.10_clang-9x_sanitizer_`date +%Y-%m-%d`
 
+docker tag ubuntu-20.04-aarch:gcc-10x ${ECS_REPO}:ubuntu-20.04_gcc-10x_`date +%Y-%m-%d`
+docker tag ubuntu-20.04-aarch:gcc-10x ${ECS_REPO}:ubuntu-20.04_gcc-10x_latest
+docker push ${ECS_REPO}:ubuntu-20.04_gcc-10x_latest
+docker push ${ECS_REPO}:ubuntu-20.04_gcc-10x_`date +%Y-%m-%d`
+
 docker tag ubuntu-20.04-aarch:clang-10x ${ECS_REPO}:ubuntu-20.04_clang-10x_`date +%Y-%m-%d`
 docker tag ubuntu-20.04-aarch:clang-10x ${ECS_REPO}:ubuntu-20.04_clang-10x_latest
 docker push ${ECS_REPO}:ubuntu-20.04_clang-10x_latest

--- a/tests/ci/docker_images/linux-aarch/ubuntu-20.04_gcc-10x/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/ubuntu-20.04_gcc-10x/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM arm64v8/ubuntu:20.04
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -ex && \
+    apt-get update && \
+    apt-get -y --no-install-recommends upgrade && \
+    apt-get -y --no-install-recommends install \
+    gcc-10 \
+    g++-10 \
+    cmake \
+    ninja-build \
+    perl \
+    libunwind-dev \
+    pkg-config \
+    ca-certificates \
+    wget && \
+    cd /tmp && \
+    wget https://dl.google.com/go/go1.15.2.linux-arm64.tar.gz && \
+    tar -xvf go1.15.2.linux-arm64.tar.gz && \
+    mv go /usr/local && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+ENV CC=gcc-10
+ENV CXX=g++-10
+ENV GOROOT=/usr/local/go
+ENV PATH="$GOROOT/bin:$PATH"

--- a/tests/ci/docker_images/linux-x86/build_images.sh
+++ b/tests/ci/docker_images/linux-x86/build_images.sh
@@ -18,6 +18,7 @@ docker build -t amazonlinux-2:gcc-7x amazonlinux-2_gcc-7x
 docker build -t amazonlinux-2:gcc-7x-intel-sde amazonlinux-2_gcc-7x-intel-sde
 docker build -t fedora-31:clang-9x fedora-31_clang-9x
 docker build -t integration:s2n s2n_integration_clang-9x
+docker build -t ubuntu-20.04:gcc-10x ubuntu-20.04_gcc-10x
 docker build -t ubuntu-20.04:clang-10x ubuntu-20.04_clang-10x
 
 ###########################################################

--- a/tests/ci/docker_images/linux-x86/push_images.sh
+++ b/tests/ci/docker_images/linux-x86/push_images.sh
@@ -48,6 +48,11 @@ docker tag ubuntu-19.10:sanitizer ${ECS_REPO}:ubuntu-19.10_clang-9x_sanitizer_la
 docker push ${ECS_REPO}:ubuntu-19.10_clang-9x_sanitizer_latest
 docker push ${ECS_REPO}:ubuntu-19.10_clang-9x_sanitizer_`date +%Y-%m-%d`
 
+docker tag ubuntu-20.04:gcc-10x ${ECS_REPO}:ubuntu-20.04_gcc-10x_`date +%Y-%m-%d`
+docker tag ubuntu-20.04:gcc-10x ${ECS_REPO}:ubuntu-20.04_gcc-10x_latest
+docker push ${ECS_REPO}:ubuntu-20.04_gcc-10x_latest
+docker push ${ECS_REPO}:ubuntu-20.04_gcc-10x_`date +%Y-%m-%d`
+
 docker tag ubuntu-20.04:clang-10x ${ECS_REPO}:ubuntu-20.04_clang-10x_`date +%Y-%m-%d`
 docker tag ubuntu-20.04:clang-10x ${ECS_REPO}:ubuntu-20.04_clang-10x_latest
 docker push ${ECS_REPO}:ubuntu-20.04_clang-10x_latest

--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_gcc-10x/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_gcc-10x/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu:20.04
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -ex && \
+    apt-get update && \
+    apt-get -y --no-install-recommends upgrade && \
+    apt-get -y --no-install-recommends install \
+    gcc-10 \
+    g++-10 \
+    cmake \
+    ninja-build \
+    perl \
+    libunwind-dev \
+    pkg-config \
+    ca-certificates \
+    wget && \
+    cd /tmp && \
+    wget https://dl.google.com/go/go1.13.12.linux-amd64.tar.gz && \
+    tar -xvf go1.13.12.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+ENV CC=gcc-10
+ENV CXX=g++-10
+ENV GOROOT=/usr/local/go
+ENV PATH="$GOROOT/bin:$PATH"


### PR DESCRIPTION
Add gcc10 dimension.

### Issues:
Resolves CryptoAlg-631

### Description of changes: 
This PR adds new CI dimension -- ubuntu-20.04_gcc-10x.

### Call-outs:
* New CI dimension (ubuntu-20.04_gcc-10x) has been deployed.

### Testing:
* CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
