### PR TITLE
Define RSA_PSS_SALTLEN_DIGEST macro.

### DIFF
--- a/crypto/fipsmodule/rsa/padding.c
+++ b/crypto/fipsmodule/rsa/padding.c
@@ -503,9 +503,9 @@ int RSA_verify_PKCS1_PSS_mgf1(const RSA *rsa, const uint8_t *mHash,
   hLen = EVP_MD_size(Hash);
 
   // Negative sLen has special meanings:
-  //	-1	sLen == hLen
-  //	-2	salt length is autorecovered from signature
-  //	-N	reserved
+  //   RSA_PSS_SALTLEN_DIGEST  sLen == hLen
+  //   -2  salt length is autorecovered from signature
+  //   -N  reserved
   if (sLen == RSA_PSS_SALTLEN_DIGEST) {
     sLen = hLen;
   } else if (sLen == -2) {
@@ -616,7 +616,7 @@ int RSA_padding_add_PKCS1_PSS_mgf1(const RSA *rsa, unsigned char *EM,
   }
 
   // Negative sLenRequested has special meanings:
-  //   -1  sLen == hLen
+  //   RSA_PSS_SALTLEN_DIGEST  sLen == hLen
   //   -2  salt length is maximized
   //   -N  reserved
   size_t sLen;

--- a/crypto/fipsmodule/rsa/padding.c
+++ b/crypto/fipsmodule/rsa/padding.c
@@ -506,7 +506,7 @@ int RSA_verify_PKCS1_PSS_mgf1(const RSA *rsa, const uint8_t *mHash,
   //	-1	sLen == hLen
   //	-2	salt length is autorecovered from signature
   //	-N	reserved
-  if (sLen == -1) {
+  if (sLen == RSA_PSS_SALTLEN_DIGEST) {
     sLen = hLen;
   } else if (sLen == -2) {
     sLen = -2;
@@ -620,7 +620,7 @@ int RSA_padding_add_PKCS1_PSS_mgf1(const RSA *rsa, unsigned char *EM,
   //   -2  salt length is maximized
   //   -N  reserved
   size_t sLen;
-  if (sLenRequested == -1) {
+  if (sLenRequested == RSA_PSS_SALTLEN_DIGEST) {
     sLen = hLen;
   } else if (sLenRequested == -2) {
     sLen = emLen - hLen - 2;

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -437,11 +437,11 @@ OPENSSL_EXPORT int RSA_check_fips(RSA *key);
 // |mHash|, where |mHash| is a digest produced by |Hash|. |EM| must point to
 // exactly |RSA_size(rsa)| bytes of data. The |mgf1Hash| argument specifies the
 // hash function for generating the mask. If NULL, |Hash| is used. The |sLen|
-// argument specifies the expected salt length in bytes. If |sLen| is -1 then
+// argument specifies the expected salt length in bytes. If |sLen| is RSA_PSS_SALTLEN_DIGEST then
 // the salt length is the same as the hash length. If -2, then the salt length
 // is recovered and all values accepted.
 //
-// If unsure, use -1.
+// If unsure, use RSA_PSS_SALTLEN_DIGEST.
 //
 // It returns one on success or zero on error.
 //
@@ -457,9 +457,9 @@ OPENSSL_EXPORT int RSA_verify_PKCS1_PSS_mgf1(const RSA *rsa,
 // where |mHash| is a digest produced by |Hash|. |RSA_size(rsa)| bytes of
 // output will be written to |EM|. The |mgf1Hash| argument specifies the hash
 // function for generating the mask. If NULL, |Hash| is used. The |sLen|
-// argument specifies the expected salt length in bytes. If |sLen| is -1 then
-// the salt length is the same as the hash length. If -2, then the salt length
-// is maximal given the space in |EM|.
+// argument specifies the expected salt length in bytes.
+// If |sLen| is RSA_PSS_SALTLEN_DIGEST then the salt length is the same as 
+// the hash length. If -2, then the salt length is maximal given the space in |EM|.
 //
 // It returns one on success or zero on error.
 //

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -278,6 +278,9 @@ OPENSSL_EXPORT int RSA_private_decrypt(size_t flen, const uint8_t *from,
                                        uint8_t *to, RSA *rsa, int padding);
 
 
+// Salt length matches digest
+#define RSA_PSS_SALTLEN_DIGEST -1
+
 // Signing / Verification
 //
 // These functions are considered non-mutating for thread-safety purposes and


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-614

### Description of changes: 
This PR imports `RSA_PSS_SALTLEN_DIGEST` from [OpenSSL 1.1.1](https://github.com/openssl/openssl/commit/137096a7ead3738a0035b9e760b7c3f74b7555a3) to support s2n usage.
The macro means the salt length must equal the length of hash function output. This macro is the most common usage mentioned in standards. 

### Call-outs:
* Other RSA_PSS_SALTLEN macros (`RSA_PSS_SALTLEN_AUTO` and `RSA_PSS_SALTLEN_MAX`) are not imported currently because these may need additional investigation on this [OpenSSL commit](https://github.com/openssl/openssl/commit/137096a7ead3738a0035b9e760b7c3f74b7555a3) . Besides, BoringSSL has one [TODO](https://github.com/awslabs/aws-lc/blob/main/crypto/x509/rsa_pss.c#L201-L203) to forbid the auto mode.
* I will keep all CryptoAlg-614 code in  `rsa-pss` branch and then create a final PR before merging to `main` branch.

### Testing:
No new tests are added because this PR simply defines macro for existing value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
