### PR TITLE
Improvement for CVE-2021-23841

### DIFF
--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -92,6 +92,8 @@ unsigned long X509_issuer_and_serial_hash(X509 *a)
 
     EVP_MD_CTX_init(&ctx);
     f = X509_NAME_oneline(a->cert_info->issuer, NULL, 0);
+    if (NULL == f)
+        goto err;
     if (!EVP_DigestInit_ex(&ctx, EVP_md5(), NULL))
         goto err;
     if (!EVP_DigestUpdate(&ctx, (unsigned char *)f, strlen(f)))


### PR DESCRIPTION
### Issues:
CryptoAlg-657

### Description of changes: 
This is a fix for CVE-2021-23841
More details in: https://www.openssl.org/news/secadv/20210216.txt

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
