### PR TITLE
Change s2n GitHub repo.

### DIFF
--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -8,7 +8,7 @@ AWS_LC_DIR=${PWD##*/}
 cd ../
 ROOT=$(pwd)
 mkdir -p aws-lc-build aws-lc-install s2n-build
-git clone https://github.com/awslabs/s2n.git
+git clone https://github.com/aws/s2n-tls.git
 ls
 
 # s2n's FindLibCrypto.cmake expects to find both the archieve (.a) and shared object (.so) libcrypto

--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -7,19 +7,19 @@ source tests/ci/common_posix_setup.sh
 AWS_LC_DIR=${PWD##*/}
 cd ../
 ROOT=$(pwd)
-mkdir -p aws-lc-build aws-lc-install s2n-build
+mkdir -p aws-lc-build aws-lc-install s2n-tls-build
 git clone https://github.com/aws/s2n-tls.git
 ls
 
-# s2n's FindLibCrypto.cmake expects to find both the archieve (.a) and shared object (.so) libcrypto
+# s2n-tls's FindLibCrypto.cmake expects to find both the archieve (.a) and shared object (.so) libcrypto
 cmake ${AWS_LC_DIR} -GNinja "-B${ROOT}/aws-lc-build" "-DCMAKE_INSTALL_PREFIX=${ROOT}/aws-lc-install"
 ninja -C aws-lc-build install
 rm -rf aws-lc-build/*
 cmake ${AWS_LC_DIR} -GNinja "-B${ROOT}/aws-lc-build" "-DCMAKE_INSTALL_PREFIX=${ROOT}/aws-lc-install" -DBUILD_SHARED_LIBS=1
 ninja -C aws-lc-build install
 
-cmake s2n -GNinja "-B${ROOT}/s2n-build" "-DCMAKE_PREFIX_PATH=${ROOT}/aws-lc-install"
-ninja -C s2n-build
+cmake s2n-tls -GNinja "-B${ROOT}/s2n-tls-build" "-DCMAKE_PREFIX_PATH=${ROOT}/aws-lc-install"
+ninja -C s2n-tls-build
 
-cd "${ROOT}/s2n-build"
+cd "${ROOT}/s2n-tls-build"
 ctest -j 8 --output-on-failure


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
This PR changes s2n repo from https://github.com/awslabs/s2n.git to https://github.com/aws/s2n-tls

### Call-outs:
N/A

### Testing:
Tested in personal account. See CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
