### PR TITLE
Expand ARCH check to use CMAKE_SIZEOF_VOID_P for x86 and x86_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,31 +510,19 @@ endif()
 if(OPENSSL_NO_ASM)
   add_definitions(-DOPENSSL_NO_ASM)
   set(ARCH "generic")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
-  set(ARCH "x86_64")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64")
-  set(ARCH "x86_64")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "AMD64")
-  # cmake reports AMD64 on Windows, but we might be building for 32-bit.
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|amd64|AMD64")
+  # If ARCH is originally detected as 64-bit, perform an additional check
+  # to determine whether to build as 32-bit or 64-bit. This happens in some
+  # cases such as when building in Docker, where the host-level architecture is 64-bit
+  # but the Docker image should result in building for a 32-bit architecture.
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(ARCH "x86_64")
   else()
     set(ARCH "x86")
   endif()
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86|i386|i686")
   set(ARCH "x86")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "i386")
-  set(ARCH "x86")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "i686")
-  set(ARCH "x86")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
-  set(ARCH "aarch64")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "ARM64")
-  set(ARCH "aarch64")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm64")
-  set(ARCH "aarch64")
-# Apple A12 Bionic chipset which is added in iPhone XS/XS Max/XR uses arm64e architecture.
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm64e")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64.*|ARM64|aarch64")
   set(ARCH "aarch64")
 elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm*")
   set(ARCH "arm")
@@ -545,18 +533,6 @@ elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
   set(ARCH "ppc64le")
 else()
   message(FATAL_ERROR "Unknown processor:" ${CMAKE_SYSTEM_PROCESSOR})
-endif()
-
-# If ARCH is originally set as either x86 or x86_64, perform an additional
-# check to determine whether 32-bit or 64-bit is supported. This happens in some
-# cases such as when building in Docker, where the host-level architecture is 64-bit
-# but the Docker image should result in building for a 32-bit architecture.
-if (${ARCH} STREQUAL "x86" OR ${ARCH} STREQUAL "x86_64")
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(ARCH "x86_64")
-  else()
-    set(ARCH "x86")
-  endif()
 endif()
 
 if (ARCH STREQUAL "aarch64" AND CMAKE_BUILD_TYPE_LOWER MATCHES "rel")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,6 +547,18 @@ else()
   message(FATAL_ERROR "Unknown processor:" ${CMAKE_SYSTEM_PROCESSOR})
 endif()
 
+# If ARCH is originally set as either x86 or x86_64, perform an additional
+# check to determine whether 32-bit or 64-bit is supported. This happens in some
+# cases such as when building in Docker, where the host-level architecture is 64-bit
+# but the Docker image should result in building for a 32-bit architecture.
+if (${ARCH} STREQUAL "x86" OR ${ARCH} STREQUAL "x86_64")
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(ARCH "x86_64")
+  else()
+    set(ARCH "x86")
+  endif()
+endif()
+
 if (ARCH STREQUAL "aarch64" AND CMAKE_BUILD_TYPE_LOWER MATCHES "rel")
   # Enable p256_nistz on ARMv8 (AArch64) by default
   add_definitions(-DOPENSSL_AARCH64_P256)


### PR DESCRIPTION
### Issues:
Resolves: CryptoAlg-671

### Description of changes: 
When integrating with [aws-c-cal](https://github.com/awslabs/aws-c-cal) in this [PR](https://github.com/awslabs/aws-c-cal/pull/65), `aws-lc` fails to build in a 32-bit container running on a 64-bit host. This is because `CMAKE_SYSTEM_PROCESSOR` returns the architecture of the host and, as a result, assembly files meant for 64-bit were being included. This expands to check `CMAKE_SIZEOF_VOID_P` for either `x86` or `x86_64` and update `ARCH` accordingly.

### Call-outs:
We do not currently have a dimension in our CI that tests this behavior, but this will be added in the work for CryptoAlg-663.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
