### PR TITLE
Wrapping all <inttypes.h> includes with __STDC_FORMAT_MACROS

### DIFF
--- a/crypto/bytestring/cbs.c
+++ b/crypto/bytestring/cbs.c
@@ -16,7 +16,12 @@
 #include <openssl/bytestring.h>
 
 #include <assert.h>
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
+
 #include <string.h>
 
 #include "internal.h"

--- a/crypto/cpu-intel.c
+++ b/crypto/cpu-intel.c
@@ -59,7 +59,11 @@
 
 #if !defined(OPENSSL_NO_ASM) && (defined(OPENSSL_X86) || defined(OPENSSL_X86_64))
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -110,7 +110,12 @@
 
 #include <assert.h>
 #include <errno.h>
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
+
 #include <string.h>
 
 #if defined(OPENSSL_WINDOWS)

--- a/crypto/fipsmodule/rand/fork_detect_test.cc
+++ b/crypto/fipsmodule/rand/fork_detect_test.cc
@@ -18,7 +18,12 @@
 // after multi-threaded fork is not supported".
 #if defined(OPENSSL_LINUX) && !defined(OPENSSL_TSAN)
 #include <errno.h>
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
+
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/crypto/obj/obj.c
+++ b/crypto/obj/obj.c
@@ -56,7 +56,11 @@
 
 #include <openssl/obj.h>
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
+
 #include <limits.h>
 #include <string.h>
 

--- a/crypto/x509/a_strex.c
+++ b/crypto/x509/a_strex.c
@@ -56,7 +56,11 @@
 
 #include <openssl/x509.h>
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
+
 #include <string.h>
 
 #include <openssl/asn1.h>

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -126,7 +126,11 @@
 #include <openssl/base.h>
 #include <openssl/thread.h>
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>  // for PRIu64 and friends
+
 #include <stdio.h>  // for FILE*
 
 #if defined(__cplusplus)

--- a/ssl/test/bssl_shim.cc
+++ b/ssl/test/bssl_shim.cc
@@ -33,7 +33,12 @@ OPENSSL_MSVC_PRAGMA(comment(lib, "Ws2_32.lib"))
 #endif
 
 #include <assert.h>
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
+
 #include <string.h>
 #include <time.h>
 

--- a/util/asm_dev/armv8/p256/src/beeu_scratch.c
+++ b/util/asm_dev/armv8/p256/src/beeu_scratch.c
@@ -10,6 +10,9 @@ The functions in this file were compiled into ARMv8 assembly code
 in order to experiment with the generated instructions and use them in beeu.S.
 */
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 
 typedef double *__attribute__((aligned(64))) aligned_double;

--- a/util/asm_dev/armv8/p256/src/main.c
+++ b/util/asm_dev/armv8/p256/src/main.c
@@ -7,6 +7,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 #include "p256.h"
 


### PR DESCRIPTION
### Issues:
Resolves: CryptoAlg-672

### Description of changes: 
On older systems supported by aws-c-cal, gcc 4.8.2, we run into compilation errors when building our test code.  It turns out that some of the defines in inttypes are only defined if you specify __STDC_FORMAT_MACROS before including inttypes.h.  

The change is very simple, add the __STDC_FORMAT_MACROS to each include to ensure it's always defined.  

```
/root/aws-c-cal/build/deps/aws-lc/ssl/test/bssl_shim.cc: In function bool CheckHandshakeProperties(SSL*, bool, const TestConfig*):
/root/aws-c-cal/build/deps/aws-lc/ssl/test/bssl_shim.cc:659:45: error: expected ) before PRId32
     fprintf(stderr, "Ticket age skew was %" PRId32 ", wanted %d\n",
                                             ^
/root/aws-c-cal/build/deps/aws-lc/ssl/test/bssl_shim.cc:660:73: error: spurious trailing % in format [-Werror=format=]
             SSL_get_ticket_age_skew(ssl), config->expect_ticket_age_skew);
```

### Call-outs:
N/A

### Testing:
This change was tested on a branch with aws-c-cal's CI.  The CI did run and successfully build with the above changes.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
