### PR TITLE
CMake: Fix linking with compiler other than MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.12)
 # Defer enabling C and CXX languages.
 project(AWSLC NONE)
 
-if(WIN32)
+if(MSVC)
   # On Windows, prefer cl over gcc if both are available. By default most of
   # the CMake generators prefer gcc, even on Windows.
   set(CMAKE_GENERATOR_CC cl)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -483,6 +483,9 @@ endif()
 
 SET_TARGET_PROPERTIES(crypto PROPERTIES LINKER_LANGUAGE C)
 
+if(WIN32)
+  target_link_libraries(crypto ws2_32)
+endif()
 if(NOT WIN32 AND NOT ANDROID)
   target_link_libraries(crypto pthread)
 endif()

--- a/crypto/bio/socket.c
+++ b/crypto/bio/socket.c
@@ -68,8 +68,6 @@
 OPENSSL_MSVC_PRAGMA(warning(push, 3))
 #include <winsock2.h>
 OPENSSL_MSVC_PRAGMA(warning(pop))
-
-OPENSSL_MSVC_PRAGMA(comment(lib, "Ws2_32.lib"))
 #endif
 
 #include "internal.h"

--- a/ssl/test/CMakeLists.txt
+++ b/ssl/test/CMakeLists.txt
@@ -16,6 +16,9 @@ add_executable(
 add_dependencies(bssl_shim global_target)
 
 target_link_libraries(bssl_shim test_support_lib ssl crypto)
+if(WIN32)
+  target_link_libraries(bssl_shim ws2_32)
+endif()
 
 if(UNIX AND NOT APPLE AND NOT ANDROID)
   add_executable(

--- a/ssl/test/bssl_shim.cc
+++ b/ssl/test/bssl_shim.cc
@@ -28,8 +28,6 @@ OPENSSL_MSVC_PRAGMA(warning(push, 3))
 #include <winsock2.h>
 #include <ws2tcpip.h>
 OPENSSL_MSVC_PRAGMA(warning(pop))
-
-OPENSSL_MSVC_PRAGMA(comment(lib, "Ws2_32.lib"))
 #endif
 
 #include <assert.h>

--- a/tool/transport_common.cc
+++ b/tool/transport_common.cc
@@ -54,8 +54,6 @@ OPENSSL_MSVC_PRAGMA(warning(push, 3))
 #include <winsock2.h>
 #include <ws2tcpip.h>
 OPENSSL_MSVC_PRAGMA(warning(pop))
-
-OPENSSL_MSVC_PRAGMA(comment(lib, "Ws2_32.lib"))
 #endif
 
 #include <openssl/err.h>


### PR DESCRIPTION
Previously, MSVC specific pragma comment are used to link with ws2_32 library.
But those does not work with MinGW gcc and clang. Hence, use CMake's own
target_link_libraries() to link with ws2_32 for Win32 platform conditionally.
