### PR TITLE
Add support for BUILD_TESTING and BUILD_LIBSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ include(sources.cmake)
 enable_language(C)
 enable_language(CXX)
 
+option(BUILD_TESTING "Build all test targets for AWS-LC" ON)
+
 # Fail CMake build when some vulnerable gcc versions are used.
 set(VUL_GCC_VERSIONS "")
 # These versions are disabled due to a bug reported in memcmp, which means we can't trust them.
@@ -620,9 +622,11 @@ target_include_directories(boringssl_gtest PRIVATE third_party/googletest)
 
 include_directories(third_party/googletest/include)
 
-# Declare a dummy target to build all unit tests. Test targets should inject
-# themselves as dependencies next to the target definition.
-add_custom_target(all_tests)
+if(BUILD_TESTING)
+  # Declare a dummy target to build all unit tests. Test targets should inject
+  # themselves as dependencies next to the target definition.
+  add_custom_target(all_tests)
+endif()
 
 # On Windows, CRYPTO_TEST_DATA is too long to fit in command-line limits.
 # TODO(davidben): CMake 3.12 has a list(JOIN) command. Use that when we've
@@ -649,7 +653,6 @@ add_library(crypto_test_data OBJECT crypto_test_data.cc)
 
 add_subdirectory(crypto)
 add_subdirectory(ssl)
-add_subdirectory(ssl/test)
 add_subdirectory(tool)
 add_subdirectory(util/fipstools/cavp)
 add_subdirectory(util/fipstools/acvp/modulewrapper)
@@ -685,67 +688,69 @@ if (NOT ${CMAKE_VERSION} VERSION_LESS "3.2")
   set(MAYBE_USES_TERMINAL USES_TERMINAL)
 endif()
 
-if(GO_EXECUTABLE)
-  if(FIPS)
-    add_custom_target(
-      acvp_tests
-      COMMAND ${GO_EXECUTABLE} build -o ${CMAKE_BINARY_DIR}/acvptool
-              boringssl.googlesource.com/boringssl/util/fipstools/acvp/acvptool
-      COMMAND ${GO_EXECUTABLE} build -o ${CMAKE_BINARY_DIR}/testmodulewrapper
-              boringssl.googlesource.com/boringssl/util/fipstools/acvp/acvptool/testmodulewrapper
-      COMMAND cd util/fipstools/acvp/acvptool/test &&
-              ${GO_EXECUTABLE} run check_expected.go
-              -tool ${CMAKE_BINARY_DIR}/acvptool
-              -module-wrappers modulewrapper:$<TARGET_FILE:modulewrapper>,testmodulewrapper:${CMAKE_BINARY_DIR}/testmodulewrapper
-              -tests tests.json
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-      DEPENDS modulewrapper
-      USES_TERMINAL)
+if(BUILD_TESTING)
+  if(GO_EXECUTABLE)
+    if(FIPS)
+      add_custom_target(
+        acvp_tests
+        COMMAND ${GO_EXECUTABLE} build -o ${CMAKE_BINARY_DIR}/acvptool
+                boringssl.googlesource.com/boringssl/util/fipstools/acvp/acvptool
+        COMMAND ${GO_EXECUTABLE} build -o ${CMAKE_BINARY_DIR}/testmodulewrapper
+                boringssl.googlesource.com/boringssl/util/fipstools/acvp/acvptool/testmodulewrapper
+        COMMAND cd util/fipstools/acvp/acvptool/test &&
+                ${GO_EXECUTABLE} run check_expected.go
+                -tool ${CMAKE_BINARY_DIR}/acvptool
+                -module-wrappers modulewrapper:$<TARGET_FILE:modulewrapper>,testmodulewrapper:${CMAKE_BINARY_DIR}/testmodulewrapper
+                -tests tests.json
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DEPENDS modulewrapper
+        USES_TERMINAL)
+
+      add_custom_target(
+        fips_specific_tests_if_any
+        DEPENDS acvp_tests
+      )
+    else()
+      add_custom_target(fips_specific_tests_if_any)
+    endif()
 
     add_custom_target(
-      fips_specific_tests_if_any
-      DEPENDS acvp_tests
-    )
+        run_tests
+        COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
+                ${CMAKE_BINARY_DIR}
+        COMMAND cd ssl/test/runner &&
+                ${GO_EXECUTABLE} test -timeout ${GO_TEST_TIMEOUT} -shim-path $<TARGET_FILE:bssl_shim>
+                  ${HANDSHAKER_ARGS} ${RUNNER_ARGS}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DEPENDS all_tests bssl_shim handshaker fips_specific_tests_if_any
+        ${MAYBE_USES_TERMINAL})
+
+    add_custom_target(
+        run_tests_valgrind
+        COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
+                ${CMAKE_BINARY_DIR} -valgrind=true -valgrind-supp-dir "tests/ci"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DEPENDS all_tests
+        ${MAYBE_USES_TERMINAL})
+
+    add_custom_target(
+        run_tests_with_sde
+        COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
+                ${CMAKE_BINARY_DIR} -sde true -sde-path "$ENV{SDEROOT}/sde"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DEPENDS all_tests
+        ${MAYBE_USES_TERMINAL})
   else()
-    add_custom_target(fips_specific_tests_if_any)
+    add_custom_target(
+            run_minimal_tests
+            COMMAND crypto_test
+            COMMAND urandom_test
+            COMMAND ssl_test
+            COMMAND decrepit_test
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            DEPENDS all_tests
+            ${MAYBE_USES_TERMINAL})
   endif()
-
-  add_custom_target(
-      run_tests
-      COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
-              ${CMAKE_BINARY_DIR}
-      COMMAND cd ssl/test/runner &&
-              ${GO_EXECUTABLE} test -timeout ${GO_TEST_TIMEOUT} -shim-path $<TARGET_FILE:bssl_shim>
-                ${HANDSHAKER_ARGS} ${RUNNER_ARGS}
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-      DEPENDS all_tests bssl_shim handshaker fips_specific_tests_if_any
-      ${MAYBE_USES_TERMINAL})
-
-  add_custom_target(
-      run_tests_valgrind
-      COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
-              ${CMAKE_BINARY_DIR} -valgrind=true -valgrind-supp-dir "tests/ci"
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-      DEPENDS all_tests
-      ${MAYBE_USES_TERMINAL})
-
-  add_custom_target(
-      run_tests_with_sde
-      COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
-              ${CMAKE_BINARY_DIR} -sde true -sde-path "$ENV{SDEROOT}/sde"
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-      DEPENDS all_tests
-      ${MAYBE_USES_TERMINAL})
-else()
-  add_custom_target(
-          run_minimal_tests
-          COMMAND crypto_test
-          COMMAND urandom_test
-          COMMAND ssl_test
-          COMMAND decrepit_test
-          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-          DEPENDS all_tests
-          ${MAYBE_USES_TERMINAL})
 endif()
 
 # Copy awslc-config.cmake to build artifacts.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,7 +737,7 @@ if(BUILD_TESTING)
       add_custom_target(
           run_tests
           COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
-                  ${CMAKE_BINARY_DIR}
+                  ${CMAKE_BINARY_DIR} -ssl-tests=false
           WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
           DEPENDS all_tests fips_specific_tests_if_any
           ${MAYBE_USES_TERMINAL}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,16 @@ endif()
 
 include(sources.cmake)
 
-enable_language(C)
-enable_language(CXX)
-
 option(BUILD_TESTING "Build all test targets for AWS-LC" ON)
+option(BUILD_LIBSSL "" ON)
+
+enable_language(C)
+
+# Tests and libssl both require the CXX language to be enabled. If a consumer
+# chooses to disable building the tests and libssl, do not enable CXX
+if(BUILD_TESTING OR BUILD_LIBSSL)
+  enable_language(CXX)
+endif()
 
 # Fail CMake build when some vulnerable gcc versions are used.
 set(VUL_GCC_VERSIONS "")
@@ -615,45 +621,47 @@ if(USE_CUSTOM_LIBCXX)
   target_link_libraries(libcxx libcxxabi)
 endif()
 
-# Add minimal googletest targets. The provided one has many side-effects, and
-# googletest has a very straightforward build.
-add_library(boringssl_gtest third_party/googletest/src/gtest-all.cc)
-target_include_directories(boringssl_gtest PRIVATE third_party/googletest)
-
-include_directories(third_party/googletest/include)
-
 if(BUILD_TESTING)
+  # Add minimal googletest targets. The provided one has many side-effects, and
+  # googletest has a very straightforward build.
+  add_library(boringssl_gtest third_party/googletest/src/gtest-all.cc)
+  target_include_directories(boringssl_gtest PRIVATE third_party/googletest)
+
+  include_directories(third_party/googletest/include)
+
   # Declare a dummy target to build all unit tests. Test targets should inject
   # themselves as dependencies next to the target definition.
   add_custom_target(all_tests)
-endif()
 
-# On Windows, CRYPTO_TEST_DATA is too long to fit in command-line limits.
-# TODO(davidben): CMake 3.12 has a list(JOIN) command. Use that when we've
-# updated the minimum version.
-set(EMBED_TEST_DATA_ARGS "")
-foreach(arg ${CRYPTO_TEST_DATA})
-  set(EMBED_TEST_DATA_ARGS "${EMBED_TEST_DATA_ARGS}${arg}\n")
-endforeach()
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/embed_test_data_args.txt"
-     "${EMBED_TEST_DATA_ARGS}")
+  # On Windows, CRYPTO_TEST_DATA is too long to fit in command-line limits.
+  # TODO(davidben): CMake 3.12 has a list(JOIN) command. Use that when we've
+  # updated the minimum version.
+  set(EMBED_TEST_DATA_ARGS "")
+  foreach(arg ${CRYPTO_TEST_DATA})
+    set(EMBED_TEST_DATA_ARGS "${EMBED_TEST_DATA_ARGS}${arg}\n")
+  endforeach()
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/embed_test_data_args.txt"
+      "${EMBED_TEST_DATA_ARGS}")
 
-if(GO_EXECUTABLE)
-  add_custom_command(
-    OUTPUT crypto_test_data.cc
-    COMMAND ${GO_EXECUTABLE} run util/embed_test_data.go -file-list
-            "${CMAKE_CURRENT_BINARY_DIR}/embed_test_data_args.txt" >
-            "${CMAKE_CURRENT_BINARY_DIR}/crypto_test_data.cc"
-    DEPENDS util/embed_test_data.go ${CRYPTO_TEST_DATA}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-else()
-  file(COPY ${GENERATE_CODE_ROOT}/crypto_test_data.cc DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+  if(GO_EXECUTABLE)
+    add_custom_command(
+        OUTPUT crypto_test_data.cc
+        COMMAND ${GO_EXECUTABLE} run util/embed_test_data.go -file-list
+        "${CMAKE_CURRENT_BINARY_DIR}/embed_test_data_args.txt" >
+        "${CMAKE_CURRENT_BINARY_DIR}/crypto_test_data.cc"
+        DEPENDS util/embed_test_data.go ${CRYPTO_TEST_DATA}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  else()
+    file(COPY ${GENERATE_CODE_ROOT}/crypto_test_data.cc DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+  endif()
+  add_library(crypto_test_data OBJECT crypto_test_data.cc)
 endif()
-add_library(crypto_test_data OBJECT crypto_test_data.cc)
 
 add_subdirectory(crypto)
-add_subdirectory(ssl)
-add_subdirectory(tool)
+if(BUILD_LIBSSL)
+  add_subdirectory(ssl)
+  add_subdirectory(tool)
+endif()
 add_subdirectory(util/fipstools/cavp)
 add_subdirectory(util/fipstools/acvp/modulewrapper)
 add_subdirectory(decrepit)
@@ -714,16 +722,27 @@ if(BUILD_TESTING)
       add_custom_target(fips_specific_tests_if_any)
     endif()
 
-    add_custom_target(
-        run_tests
-        COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
-                ${CMAKE_BINARY_DIR}
-        COMMAND cd ssl/test/runner &&
-                ${GO_EXECUTABLE} test -timeout ${GO_TEST_TIMEOUT} -shim-path $<TARGET_FILE:bssl_shim>
-                  ${HANDSHAKER_ARGS} ${RUNNER_ARGS}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        DEPENDS all_tests bssl_shim handshaker fips_specific_tests_if_any
-        ${MAYBE_USES_TERMINAL})
+    if(BUILD_LIBSSL)
+      add_custom_target(
+          run_tests
+          COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
+                  ${CMAKE_BINARY_DIR}
+          COMMAND cd ssl/test/runner &&
+                  ${GO_EXECUTABLE} test -timeout ${GO_TEST_TIMEOUT} -shim-path $<TARGET_FILE:bssl_shim>
+                    ${HANDSHAKER_ARGS} ${RUNNER_ARGS}
+          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          DEPENDS all_tests bssl_shim handshaker fips_specific_tests_if_any
+          ${MAYBE_USES_TERMINAL})
+    else()
+      add_custom_target(
+          run_tests
+          COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
+                  ${CMAKE_BINARY_DIR}
+          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          DEPENDS all_tests fips_specific_tests_if_any
+          ${MAYBE_USES_TERMINAL}
+      )
+    endif()
 
     add_custom_target(
         run_tests_valgrind
@@ -741,15 +760,27 @@ if(BUILD_TESTING)
         DEPENDS all_tests
         ${MAYBE_USES_TERMINAL})
   else()
-    add_custom_target(
-            run_minimal_tests
-            COMMAND crypto_test
-            COMMAND urandom_test
-            COMMAND ssl_test
-            COMMAND decrepit_test
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-            DEPENDS all_tests
-            ${MAYBE_USES_TERMINAL})
+    if(BUILD_LIBSSL)
+      add_custom_target(
+          run_minimal_tests
+          COMMAND crypto_test
+          COMMAND urandom_test
+          COMMAND ssl_test
+          COMMAND decrepit_test
+          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          DEPENDS all_tests
+          ${MAYBE_USES_TERMINAL})
+    else()
+      add_custom_command(
+          run_minimal_tests
+          COMMAND crypto_test
+          COMMAND urandom_test
+          COMMAND decrepit_test
+          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          DEPENDS all_tests
+          ${MAYBE_USES_TERMINAL}
+      )
+    endif()
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 include(sources.cmake)
 
 option(BUILD_TESTING "Build all test targets for AWS-LC" ON)
-option(BUILD_LIBSSL "" ON)
+option(BUILD_LIBSSL "Build libssl for AWS-LC" ON)
 
 enable_language(C)
 

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -120,10 +120,6 @@ else()
 endif()
 add_subdirectory(fipsmodule)
 
-if(BUILD_TESTING)
-  add_subdirectory(test)
-endif()
-
 if(FIPS_DELOCATE OR FIPS_SHARED)
   SET_SOURCE_FILES_PROPERTIES(fipsmodule/bcm.o PROPERTIES EXTERNAL_OBJECT true)
   SET_SOURCE_FILES_PROPERTIES(fipsmodule/bcm.o PROPERTIES GENERATED true)
@@ -497,6 +493,8 @@ if(USE_CUSTOM_LIBCXX)
 endif()
 
 if(BUILD_TESTING)
+  add_subdirectory(test)
+
   # urandom_test is a separate binary because it needs to be able to observe the
   # PRNG initialisation, which means that it can't have other tests running before
   # it does.

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -119,7 +119,10 @@ else()
 
 endif()
 add_subdirectory(fipsmodule)
-add_subdirectory(test)
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 if(FIPS_DELOCATE OR FIPS_SHARED)
   SET_SOURCE_FILES_PROPERTIES(fipsmodule/bcm.o PROPERTIES EXTERNAL_OBJECT true)
@@ -493,98 +496,100 @@ if(USE_CUSTOM_LIBCXX)
   target_link_libraries(crypto libcxx)
 endif()
 
-# urandom_test is a separate binary because it needs to be able to observe the
-# PRNG initialisation, which means that it can't have other tests running before
-# it does.
-add_executable(
-  urandom_test
+if(BUILD_TESTING)
+  # urandom_test is a separate binary because it needs to be able to observe the
+  # PRNG initialisation, which means that it can't have other tests running before
+  # it does.
+  add_executable(
+    urandom_test
 
-  fipsmodule/rand/urandom_test.cc
-)
+    fipsmodule/rand/urandom_test.cc
+  )
 
-target_link_libraries(urandom_test test_support_lib boringssl_gtest crypto)
+  target_link_libraries(urandom_test test_support_lib boringssl_gtest crypto)
 
-add_dependencies(urandom_test global_target)
-add_dependencies(all_tests urandom_test)
+  add_dependencies(urandom_test global_target)
+  add_dependencies(all_tests urandom_test)
 
-add_executable(
-  crypto_test
+  add_executable(
+    crypto_test
 
-  abi_self_test.cc
-  asn1/asn1_test.cc
-  base64/base64_test.cc
-  bio/bio_test.cc
-  blake2/blake2_test.cc
-  buf/buf_test.cc
-  bytestring/bytestring_test.cc
-  chacha/chacha_test.cc
-  cipher_extra/aead_test.cc
-  cipher_extra/cipher_test.cc
-  cmac/cmac_test.cc
-  compiler_test.cc
-  constant_time_test.cc
-  cpu-arm-linux_test.cc
-  crypto_test.cc
-  curve25519/ed25519_test.cc
-  curve25519/spake25519_test.cc
-  curve25519/x25519_test.cc
-  ecdh_extra/ecdh_test.cc
-  dh_extra/dh_test.cc
-  digest_extra/digest_test.cc
-  dsa/dsa_test.cc
-  err/err_test.cc
-  evp/evp_extra_test.cc
-  evp/evp_test.cc
-  evp/pbkdf_test.cc
-  evp/scrypt_test.cc
-  fipsmodule/aes/aes_test.cc
-  fipsmodule/bn/bn_test.cc
-  fipsmodule/ec/ec_test.cc
-  fipsmodule/ec/p256-nistz_test.cc
-  fipsmodule/ecdsa/ecdsa_test.cc
-  fipsmodule/md5/md5_test.cc
-  fipsmodule/modes/gcm_test.cc
-  fipsmodule/rand/ctrdrbg_test.cc
-  fipsmodule/rand/fork_detect_test.cc
-  fipsmodule/sha/sha_test.cc
-  hkdf/hkdf_test.cc
-  hpke/hpke_test.cc
-  hmac_extra/hmac_test.cc
-  hrss/hrss_test.cc
-  impl_dispatch_test.cc
-  lhash/lhash_test.cc
-  obj/obj_test.cc
-  pem/pem_test.cc
-  pkcs7/pkcs7_test.cc
-  pkcs8/pkcs8_test.cc
-  pkcs8/pkcs12_test.cc
-  poly1305/poly1305_test.cc
-  pool/pool_test.cc
-  rand_extra/rand_test.cc
-  refcount_test.cc
-  rsa_extra/rsa_test.cc
-  self_test.cc
-  stack/stack_test.cc
-  siphash/siphash_test.cc
-  test/file_test_gtest.cc
-  thread_test.cc
-  trust_token/trust_token_test.cc
-  x509/x509_test.cc
-  x509/x509_time_test.cc
-  x509v3/tab_test.cc
-  x509v3/v3name_test.cc
+    abi_self_test.cc
+    asn1/asn1_test.cc
+    base64/base64_test.cc
+    bio/bio_test.cc
+    blake2/blake2_test.cc
+    buf/buf_test.cc
+    bytestring/bytestring_test.cc
+    chacha/chacha_test.cc
+    cipher_extra/aead_test.cc
+    cipher_extra/cipher_test.cc
+    cmac/cmac_test.cc
+    compiler_test.cc
+    constant_time_test.cc
+    cpu-arm-linux_test.cc
+    crypto_test.cc
+    curve25519/ed25519_test.cc
+    curve25519/spake25519_test.cc
+    curve25519/x25519_test.cc
+    ecdh_extra/ecdh_test.cc
+    dh_extra/dh_test.cc
+    digest_extra/digest_test.cc
+    dsa/dsa_test.cc
+    err/err_test.cc
+    evp/evp_extra_test.cc
+    evp/evp_test.cc
+    evp/pbkdf_test.cc
+    evp/scrypt_test.cc
+    fipsmodule/aes/aes_test.cc
+    fipsmodule/bn/bn_test.cc
+    fipsmodule/ec/ec_test.cc
+    fipsmodule/ec/p256-nistz_test.cc
+    fipsmodule/ecdsa/ecdsa_test.cc
+    fipsmodule/md5/md5_test.cc
+    fipsmodule/modes/gcm_test.cc
+    fipsmodule/rand/ctrdrbg_test.cc
+    fipsmodule/rand/fork_detect_test.cc
+    fipsmodule/sha/sha_test.cc
+    hkdf/hkdf_test.cc
+    hpke/hpke_test.cc
+    hmac_extra/hmac_test.cc
+    hrss/hrss_test.cc
+    impl_dispatch_test.cc
+    lhash/lhash_test.cc
+    obj/obj_test.cc
+    pem/pem_test.cc
+    pkcs7/pkcs7_test.cc
+    pkcs8/pkcs8_test.cc
+    pkcs8/pkcs12_test.cc
+    poly1305/poly1305_test.cc
+    pool/pool_test.cc
+    rand_extra/rand_test.cc
+    refcount_test.cc
+    rsa_extra/rsa_test.cc
+    self_test.cc
+    stack/stack_test.cc
+    siphash/siphash_test.cc
+    test/file_test_gtest.cc
+    thread_test.cc
+    trust_token/trust_token_test.cc
+    x509/x509_test.cc
+    x509/x509_time_test.cc
+    x509v3/tab_test.cc
+    x509v3/v3name_test.cc
 
-  $<TARGET_OBJECTS:crypto_test_data>
-  $<TARGET_OBJECTS:boringssl_gtest_main>
-)
+    $<TARGET_OBJECTS:crypto_test_data>
+    $<TARGET_OBJECTS:boringssl_gtest_main>
+  )
 
-add_dependencies(crypto_test global_target)
+  add_dependencies(crypto_test global_target)
 
-target_link_libraries(crypto_test test_support_lib boringssl_gtest crypto)
-if(WIN32)
-  target_link_libraries(crypto_test ws2_32)
+  target_link_libraries(crypto_test test_support_lib boringssl_gtest crypto)
+  if(WIN32)
+    target_link_libraries(crypto_test ws2_32)
+  endif()
+  add_dependencies(all_tests crypto_test)
 endif()
-add_dependencies(all_tests crypto_test)
 
 install(TARGETS crypto
         EXPORT crypto-targets

--- a/decrepit/CMakeLists.txt
+++ b/decrepit/CMakeLists.txt
@@ -26,23 +26,25 @@ add_dependencies(decrepit global_target)
 
 target_link_libraries(decrepit crypto ssl)
 
-add_executable(
-  decrepit_test
+if(BUILD_TESTING)
+  add_executable(
+    decrepit_test
 
-  blowfish/blowfish_test.cc
-  cast/cast_test.cc
-  cfb/cfb_test.cc
-  ripemd/ripemd_test.cc
-  xts/xts_test.cc
+    blowfish/blowfish_test.cc
+    cast/cast_test.cc
+    cfb/cfb_test.cc
+    ripemd/ripemd_test.cc
+    xts/xts_test.cc
 
-  $<TARGET_OBJECTS:boringssl_gtest_main>
-)
+    $<TARGET_OBJECTS:boringssl_gtest_main>
+  )
 
-add_dependencies(decrepit_test global_target)
+  add_dependencies(decrepit_test global_target)
 
-target_link_libraries(decrepit_test test_support_lib boringssl_gtest decrepit
-                      crypto)
-if(WIN32)
-  target_link_libraries(decrepit_test ws2_32)
+  target_link_libraries(decrepit_test test_support_lib boringssl_gtest decrepit
+                        crypto)
+  if(WIN32)
+    target_link_libraries(decrepit_test ws2_32)
+  endif()
+  add_dependencies(all_tests decrepit_test)
 endif()
-add_dependencies(all_tests decrepit_test)

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -45,23 +45,26 @@ add_dependencies(ssl global_target)
 
 target_link_libraries(ssl crypto)
 
-add_executable(
-  ssl_test
+if(BUILD_TESTING)
+  add_executable(
+    ssl_test
 
-  span_test.cc
-  ssl_test.cc
-  ssl_c_test.c
+    span_test.cc
+    ssl_test.cc
+    ssl_c_test.c
 
-  $<TARGET_OBJECTS:boringssl_gtest_main>
-)
+    $<TARGET_OBJECTS:boringssl_gtest_main>
+  )
 
-add_dependencies(ssl_test global_target)
+  add_dependencies(ssl_test global_target)
 
-target_link_libraries(ssl_test test_support_lib boringssl_gtest ssl crypto)
-if(WIN32)
-  target_link_libraries(ssl_test ws2_32)
+  target_link_libraries(ssl_test test_support_lib boringssl_gtest ssl crypto)
+  if(WIN32)
+    target_link_libraries(ssl_test ws2_32)
+  endif()
+  add_dependencies(all_tests ssl_test)
+  add_subdirectory(test)
 endif()
-add_dependencies(all_tests ssl_test)
 
 install(TARGETS ssl
         EXPORT ssl-targets

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -42,7 +42,7 @@ var (
 	useCallgrind    = flag.Bool("callgrind", false, "If true, run code under valgrind to generate callgrind traces.")
 	useGDB          = flag.Bool("gdb", false, "If true, run BoringSSL code under gdb")
 	useSDE          = flag.Bool("sde", false, "If true, run BoringSSL code under Intel's SDE for each supported chip")
-	sslTests		= flag.Bool("ssl-tests", true, "If true, run BoringSSL tests against libssl")
+	sslTests        = flag.Bool("ssl-tests", true, "If true, run BoringSSL tests against libssl")
 	sdePath         = flag.String("sde-path", "sde", "The path to find the sde binary.")
 	buildDir        = flag.String("build-dir", "build", "The build directory to run the tests from.")
 	numWorkers      = flag.Int("num-workers", runtime.NumCPU(), "Runs the given number of workers when testing.")
@@ -110,7 +110,7 @@ var armCPUs = []string{
 func valgrindOf(dbAttach bool, supps []string, path string, args ...string) *exec.Cmd {
 	valgrindArgs := []string{"--error-exitcode=99", "--track-origins=yes", "--leak-check=full", "--trace-children=yes", "--quiet"}
 	for _, supp := range supps {
-		valgrindArgs = append(valgrindArgs, "--suppressions=" + *valgrindSuppDir + "/" + supp)
+		valgrindArgs = append(valgrindArgs, "--suppressions="+*valgrindSuppDir+"/"+supp)
 	}
 	if dbAttach {
 		valgrindArgs = append(valgrindArgs, "--db-attach=yes", "--db-command=xterm -e gdb -nw %f %p")
@@ -420,7 +420,7 @@ func main() {
 				}
 			}
 
-			if *sslTests {
+			if !(*sslTests) {
 				if strings.Contains(fmt.Sprint(test.Cmd), "ssl_test") {
 					continue
 				}

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -42,6 +42,7 @@ var (
 	useCallgrind    = flag.Bool("callgrind", false, "If true, run code under valgrind to generate callgrind traces.")
 	useGDB          = flag.Bool("gdb", false, "If true, run BoringSSL code under gdb")
 	useSDE          = flag.Bool("sde", false, "If true, run BoringSSL code under Intel's SDE for each supported chip")
+	sslTests		= flag.Bool("ssl-tests", true, "If true, run BoringSSL tests against libssl")
 	sdePath         = flag.String("sde-path", "sde", "The path to find the sde binary.")
 	buildDir        = flag.String("build-dir", "build", "The build directory to run the tests from.")
 	numWorkers      = flag.Int("num-workers", runtime.NumCPU(), "Runs the given number of workers when testing.")
@@ -418,6 +419,13 @@ func main() {
 					continue
 				}
 			}
+
+			if *sslTests {
+				if strings.Contains(fmt.Sprint(test.Cmd), "ssl_test") {
+					continue
+				}
+			}
+
 			if *useSDE {
 				if test.SkipSDE {
 					continue


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
With this change AWS-LC will no longer build test targets or libssl if `-DBUILD_TESTING=OFF` and `-DBUILD_LIBSSL=OFF` are specified. By default, all tests and libssl will still be built.

Setting both of these options to `OFF` also disables the CXX language when building.

### Testing:
Build succeeds when `BUILD_TESTING=OFF` is specified, and all tests pass when this flag is not provided. When `BUILD_LIBSSL=OFF` and `BUILD_TESTING` is not specified, all tests pass and `ssl_test` is excluded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
