### PR TITLE
Scope down IAM role permissions.

### DIFF
--- a/tests/ci/cdk/app.py
+++ b/tests/ci/cdk/app.py
@@ -31,8 +31,11 @@ LinuxDockerImageBatchBuildStack(app, "aws-lc-docker-image-build-linux", env=env)
 WindowsDockerImageBuildStack(app, "aws-lc-docker-image-build-windows", env=env)
 
 # Define CodeBuild Batch job for testing code.
-AwsLcGitHubCIStack(app, "aws-lc-ci-linux-x86", "./cdk/codebuild/github_ci_linux_x86_omnibus.yaml", env=env)
-AwsLcGitHubCIStack(app, "aws-lc-ci-linux-arm", "./cdk/codebuild/github_ci_linux_arm_omnibus.yaml", env=env)
-AwsLcGitHubCIStack(app, "aws-lc-ci-windows-x86", "./cdk/codebuild/github_ci_windows_x86_omnibus.yaml", env=env)
+x86_build_spec_file = "./cdk/codebuild/github_ci_linux_x86_omnibus.yaml"
+AwsLcGitHubCIStack(app, "aws-lc-ci-linux-x86", LINUX_X86_ECR_REPO, x86_build_spec_file, env=env)
+arm_build_spec_file = "./cdk/codebuild/github_ci_linux_arm_omnibus.yaml"
+AwsLcGitHubCIStack(app, "aws-lc-ci-linux-arm", LINUX_AARCH_ECR_REPO, arm_build_spec_file, env=env)
+win_x86_build_spec_file = "./cdk/codebuild/github_ci_windows_x86_omnibus.yaml"
+AwsLcGitHubCIStack(app, "aws-lc-ci-windows-x86", WINDOWS_X86_ECR_REPO, win_x86_build_spec_file, env=env)
 
 app.synth()

--- a/tests/ci/cdk/cdk/aws_lc_github_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_ci_stack.py
@@ -43,10 +43,7 @@ class AwsLcGitHubCIStack(core.Stack):
         role = iam.Role(scope=self,
                         id="{}-role".format(id),
                         assumed_by=iam.ServicePrincipal("codebuild.amazonaws.com"),
-                        inline_policies=inline_policies,
-                        managed_policies=[
-                            iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEC2ContainerRegistryReadOnly")
-                        ])
+                        inline_policies=inline_policies)
 
         # Create build spec.
         placeholder_map = {"AWS_ACCOUNT_ID_PLACEHOLDER": AWS_ACCOUNT, "AWS_REGION_PLACEHOLDER": AWS_REGION,

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -13,7 +13,7 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:ubuntu-19.10_clang-9x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-19.10_clang-9x_latest
 
     - identifier: ubuntu2004_clang10x_aarch
       buildspec: ./tests/ci/codebuild/linux-aarch/ubuntu-20.04_clang-10x.yml
@@ -21,7 +21,7 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:ubuntu-20.04_clang-10x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_latest
 
     - identifier: ubuntu1910_clang9x_aarch_sanitizer
       buildspec: ./tests/ci/codebuild/linux-aarch/ubuntu-19.10_clang-9x_sanitizer.yml
@@ -29,7 +29,7 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:ubuntu-19.10_clang-9x_sanitizer_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-19.10_clang-9x_sanitizer_latest
 
     - identifier: amazonlinux2_gcc7x_aarch
       buildspec: ./tests/ci/codebuild/linux-aarch/amazonlinux-2_gcc-7x.yml
@@ -37,4 +37,4 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_AARCH_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_latest

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -12,7 +12,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_SMALL
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-18.04_gcc-7x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-18.04_gcc-7x_latest
 
     - identifier: ubuntu1604_gcc5x_x86
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-16.04_gcc-5x_32-bits.yml
@@ -20,7 +20,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-16.04_gcc-5x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-16.04_gcc-5x_latest
 
     - identifier: ubuntu1804_clang6x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-18.04_clang-6x.yml
@@ -28,7 +28,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-18.04_clang-6x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-18.04_clang-6x_latest
 
     - identifier: ubuntu1804_gcc7x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-18.04_gcc-7x.yml
@@ -36,7 +36,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-18.04_gcc-7x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-18.04_gcc-7x_latest
 
     - identifier: ubuntu1910_clang9x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-19.10_clang-9x.yml
@@ -44,7 +44,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-19.10_clang-9x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-19.10_clang-9x_latest
 
     - identifier: ubuntu2004_clang10x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-20.04_clang-10x.yml
@@ -52,7 +52,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-20.04_clang-10x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_latest
 
     - identifier: ubuntu1904_gcc8x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-19.04_gcc-8x.yml
@@ -60,7 +60,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-19.04_gcc-8x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-19.04_gcc-8x_latest
 
     - identifier: ubuntu1904_clang8x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-19.04_clang-8x.yml
@@ -68,7 +68,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-19.04_clang-8x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-19.04_clang-8x_latest
 
     - identifier: centos7_gcc4x_x86
       buildspec: ./tests/ci/codebuild/linux-x86/centos-7_gcc-4x-32-bits.yml
@@ -76,7 +76,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:centos-7_gcc-4x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:centos-7_gcc-4x_latest
 
     - identifier: centos7_gcc4x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/centos-7_gcc-4x.yml
@@ -84,7 +84,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:centos-7_gcc-4x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:centos-7_gcc-4x_latest
 
     - identifier: amazonlinux2_gcc7x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x.yml
@@ -92,7 +92,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
 
     - identifier: amazonlinux2_gcc7x_intel_sde_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_intel-sde.yml
@@ -100,7 +100,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:amazonlinux-2_gcc-7x_intel-sde_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_intel-sde_latest
 
     - identifier: amazonlinux2_gcc7x_x86_64_valgrind
       buildspec: ./tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_valgrind.yml
@@ -108,7 +108,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
 
     - identifier: s2n_integration
       buildspec: ./tests/ci/codebuild/linux-x86/s2n_integration.yml
@@ -116,7 +116,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:s2n_integration_clang-9x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:s2n_integration_clang-9x_latest
 
     - identifier: fedora31_clang9x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/fedora-31_clang-9x.yml
@@ -124,7 +124,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:fedora-31_clang-9x_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:fedora-31_clang-9x_latest
 
     - identifier: ubuntu1910_clang9x_x86_64_sanitizer
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-19.10_clang-9x_sanitizer.yml
@@ -132,7 +132,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-19.10_clang-9x_sanitizer_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-19.10_clang-9x_sanitizer_latest
 
     # When no SELECTCHECK env variable is undefined, formal verification is executed with a few parameters.
     # SAW does not support thread level parallelism.
@@ -145,7 +145,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-20.04_clang-10x_formal-verification_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_formal-verification_latest
 
     # When 'SHA512_384_SELECTCHECK' is defined, SHA512-384 formal verification is executed against more parameters.
     - identifier: ubuntu2004_clang10x_formal_verification_sha_selectcheck
@@ -154,7 +154,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_2XLARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-20.04_clang-10x_formal-verification_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_formal-verification_latest
         variables:
           SHA512_384_SELECTCHECK: 1
 
@@ -165,6 +165,6 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_2XLARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_X86_PLACEHOLDER:ubuntu-20.04_clang-10x_formal-verification_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_formal-verification_latest
         variables:
           HMAC_SELECTCHECK: 1

--- a/tests/ci/cdk/cdk/codebuild/github_ci_windows_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_windows_x86_omnibus.yaml
@@ -13,7 +13,7 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_WINDOWS_PLACEHOLDER:vs2015_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:vs2015_latest
 
     - identifier: windows_msvc2017_x64
       buildspec: ./tests/ci/codebuild/windows-x86/windows-msvc2017.yml
@@ -22,4 +22,4 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_WINDOWS_PLACEHOLDER:vs2017_latest
+        image: AWS_ACCOUNT_ID_PLACEHOLDER.dkr.ecr.AWS_REGION_PLACEHOLDER.amazonaws.com/ECR_REPO_PLACEHOLDER:vs2017_latest

--- a/tests/ci/cdk/cdk/linux_docker_image_batch_build_stack.py
+++ b/tests/ci/cdk/cdk/linux_docker_image_batch_build_stack.py
@@ -4,7 +4,7 @@
 from aws_cdk import core, aws_codebuild as codebuild, aws_iam as iam
 from util.metadata import AWS_ACCOUNT, GITHUB_REPO_OWNER, GITHUB_REPO_NAME, GITHUB_SOURCE_VERSION, LINUX_AARCH_ECR_REPO, \
     LINUX_X86_ECR_REPO
-from util.iam_policies import codebuild_batch_policy_in_json, ecr_power_user_policy_in_json
+from util.iam_policies import code_build_batch_policy_in_json, ecr_power_user_policy_in_json
 from util.yml_loader import YmlLoader
 
 
@@ -22,9 +22,10 @@ class LinuxDockerImageBatchBuildStack(core.Stack):
             clone_depth=1)
 
         # Define a role.
-        codebuild_batch_policy = iam.PolicyDocument.from_json(codebuild_batch_policy_in_json([id]))
-        ecr_power_user_policy = iam.PolicyDocument.from_json(ecr_power_user_policy_in_json())
-        inline_policies = {"codebuild_batch_policy": codebuild_batch_policy,
+        code_build_batch_policy = iam.PolicyDocument.from_json(code_build_batch_policy_in_json([id]))
+        ecr_repo_names = [LINUX_AARCH_ECR_REPO, LINUX_X86_ECR_REPO]
+        ecr_power_user_policy = iam.PolicyDocument.from_json(ecr_power_user_policy_in_json(ecr_repo_names))
+        inline_policies = {"code_build_batch_policy": code_build_batch_policy,
                            "ecr_power_user_policy": ecr_power_user_policy}
         role = iam.Role(scope=self,
                         id="{}-role".format(id),

--- a/tests/ci/cdk/cdk/windows_docker_image_build_stack.py
+++ b/tests/ci/cdk/cdk/windows_docker_image_build_stack.py
@@ -35,7 +35,7 @@ class WindowsDockerImageBuildStack(core.Stack):
                   block_public_access=s3.BlockPublicAccess.BLOCK_ALL)
 
         # Define a role for EC2.
-        ecr_power_user_policy = iam.PolicyDocument.from_json(ecr_power_user_policy_in_json())
+        ecr_power_user_policy = iam.PolicyDocument.from_json(ecr_power_user_policy_in_json([WINDOWS_X86_ECR_REPO]))
         s3_read_write_policy = iam.PolicyDocument.from_json(s3_read_write_policy_in_json(S3_BUCKET_NAME))
         inline_policies = {"ecr_power_user_policy": ecr_power_user_policy, "s3_read_write_policy": s3_read_write_policy}
         role = iam.Role(scope=self, id="{}-role".format(id),

--- a/tests/ci/cdk/util/iam_policies.py
+++ b/tests/ci/cdk/util/iam_policies.py
@@ -3,10 +3,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from util.metadata import AWS_REGION, AWS_ACCOUNT, LINUX_AARCH_ECR_REPO, LINUX_X86_ECR_REPO, WINDOWS_X86_ECR_REPO
+from util.metadata import AWS_REGION, AWS_ACCOUNT
 
 
-def codebuild_batch_policy_in_json(project_ids):
+def code_build_batch_policy_in_json(project_ids):
     """
     Define an IAM policy statement for CodeBuild batch operation.
     :param project_ids: a list of CodeBuild project id.
@@ -53,15 +53,25 @@ def s3_read_write_policy_in_json(s3_bucket_name):
     }
 
 
-def ecr_power_user_policy_in_json():
+def ecr_repo_arn(repo_name):
+    """
+    Create a ECR repository arn.
+    See https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonelasticcontainerregistry.html
+    :param repo_name: repository name.
+    :return: arn:aws:ecr:${Region}:${Account}:repository/${RepositoryName}
+    """
+    ecr_arn_prefix = "arn:aws:ecr:{}:{}:repository".format(AWS_REGION, AWS_ACCOUNT)
+    return "{}/{}".format(ecr_arn_prefix, repo_name)
+
+
+def ecr_power_user_policy_in_json(ecr_repo_names):
     """
     Define an AWS-LC specific IAM policy statement for AWS ECR power user used to create new docker images.
     :return: an IAM policy statement in json.
     """
-    ecr_arn_prefix = "arn:aws:ecr:{}:{}:repository".format(AWS_REGION, AWS_ACCOUNT)
-    linux_x86_ecr_arn = "{}/{}".format(ecr_arn_prefix, LINUX_X86_ECR_REPO)
-    linux_aarch_ecr_arn = "{}/{}".format(ecr_arn_prefix, LINUX_AARCH_ECR_REPO)
-    windows_ecr_arn = "{}/{}".format(ecr_arn_prefix, WINDOWS_X86_ECR_REPO)
+    ecr_arns = []
+    for ecr_repo_name in ecr_repo_names:
+        ecr_arns.append(ecr_repo_arn(ecr_repo_name))
     return {
         "Version": "2012-10-17",
         "Statement": [
@@ -91,11 +101,31 @@ def ecr_power_user_policy_in_json():
                     "ecr:CompleteLayerUpload",
                     "ecr:PutImage"
                 ],
-                "Resource": [
-                    linux_x86_ecr_arn,
-                    linux_aarch_ecr_arn,
-                    windows_ecr_arn
-                ]
+                "Resource": ecr_arns
+            }
+        ]
+    }
+
+
+def ecr_pull_only_policy_in_json(ecr_repo_name):
+    """
+    Define an AWS-LC specific IAM policy statement used to pull Docker images from ECR repo.
+    Reference:
+      https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonelasticcontainerregistry.html
+    :param ecr_repo_name: repository name.
+    :return: an IAM policy statement in json.
+    """
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ecr:BatchCheckLayerAvailability",
+                    "ecr:GetDownloadUrlForLayer",
+                    "ecr:BatchGetImage",
+                ],
+                "Resource": ecr_repo_arn(ecr_repo_name)
             }
         ]
     }


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-674

### Description of changes: 
This PR scopes down permissions of IAM role used by AWS CodeBuild. The major change is to replace [AmazonEC2ContainerRegistryReadOnly](https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html#AmazonEC2ContainerRegistryReadOnly) with below iam permission (more restricted).

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": [
                "ecr:BatchCheckLayerAvailability",
                "ecr:GetDownloadUrlForLayer",
                "ecr:BatchGetImage"
            ],
            "Resource": "arn:aws:ecr:us-west-2:xxxxxx:repository/aws-lc-docker-images-linux-x86",
            "Effect": "Allow"
        }
    ]
}
```

### Call-outs:
* No other changes (including FILE_PATH) planned. FILE_PATH may stop CI running when files under tests dir get changed.

### Testing:
* CryptoAlg-674?selectedConversation=3af70d1d-3676-4ca7-ac2a-b0a7f41773ff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
