### PR TITLE
Add configuration to build and run existing Fuzz tests in our CI

### DIFF
--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -92,7 +92,7 @@ CI Tool|Compiler|CPU platform|OS| memcheck
 CodeBuild|gcc 7.3.1|x86-64|AL2 | X
 
 ### Fuzz tests
-All Fuzz tests under /fuzz is run in CodeBuild for an hour total.
+All Fuzz tests under /fuzz are run in CodeBuild for an hour total.
 
 CI Tool|Compiler|CPU platform|OS|Flags
 ------------|-------------|-------------|-------------|-------------

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -90,3 +90,15 @@ The following Valgrind tests are run for a subset of targets in `utils/all_tests
 CI Tool|Compiler|CPU platform|OS| memcheck 
 ------------ | -------------| -------------|-------------|-------------
 CodeBuild|gcc 7.3.1|x86-64|AL2 | X
+
+### Fuzz tests
+All Fuzz tests under /fuzz is run in CodeBuild for an hour total.
+
+CI Tool|Compiler|CPU platform|OS|Flags
+------------|-------------|-------------|-------------|-------------
+CodeBuild|clang 10.0.0|x86-64|Ubuntu 20.04|ASAN=1
+CodeBuild|clang 10.0.0|aarch64|ubuntu 20.04|ASAN=1
+
+To add a new fuzz test create a new executable follow [libFuzzer's](https://llvm.org/docs/LibFuzzer.html) documentation
+and existing tests. Generate a seed corpus and check it into a folder with the same name as the executable. The CI will
+pull in any files from the seed folder and merge it into the growing corpus in EFS.

--- a/tests/ci/cdk/README.md
+++ b/tests/ci/cdk/README.md
@@ -63,6 +63,11 @@ export GITHUB_ACCESS_TOKEN='xxxxx'
 ./run-cdk.sh --action deploy-ci --github-access-token ${GITHUB_ACCESS_TOKEN}
 ```
 
+To update AWS-LC CI, run command:
+```
+./run-cdk.sh --action update-ci
+```
+
 To create/udpate Docker images, run command:
 ```
 export GITHUB_ACCESS_TOKEN='xxxxx'

--- a/tests/ci/cdk/app.py
+++ b/tests/ci/cdk/app.py
@@ -6,6 +6,7 @@
 from aws_cdk import core
 
 from cdk.aws_lc_github_ci_stack import AwsLcGitHubCIStack
+from cdk.aws_lc_github_fuzz_ci_stack import  AwsLcGitHubFuzzCIStack
 from cdk.linux_docker_image_batch_build_stack import LinuxDockerImageBatchBuildStack
 from cdk.windows_docker_image_build_stack import WindowsDockerImageBuildStack
 from cdk.ecr_stack import EcrStack
@@ -37,5 +38,7 @@ arm_build_spec_file = "./cdk/codebuild/github_ci_linux_arm_omnibus.yaml"
 AwsLcGitHubCIStack(app, "aws-lc-ci-linux-arm", LINUX_AARCH_ECR_REPO, arm_build_spec_file, env=env)
 win_x86_build_spec_file = "./cdk/codebuild/github_ci_windows_x86_omnibus.yaml"
 AwsLcGitHubCIStack(app, "aws-lc-ci-windows-x86", WINDOWS_X86_ECR_REPO, win_x86_build_spec_file, env=env)
+fuzz_build_spec_file = "cdk/codebuild/github_ci_fuzzing_omnibus.yaml"
+AwsLcGitHubFuzzCIStack(app, "aws-lc-ci-fuzzing", LINUX_X86_ECR_REPO, LINUX_AARCH_ECR_REPO, fuzz_build_spec_file, env=env)
 
 app.synth()

--- a/tests/ci/cdk/cdk/aws_lc_github_fuzz_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_fuzz_ci_stack.py
@@ -1,0 +1,134 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from aws_cdk import core, aws_codebuild as codebuild, aws_iam as iam, aws_ec2 as ec2, aws_efs as efs
+
+from util.ecr_util import ecr_arn
+from util.iam_policies import code_build_batch_policy_in_json, \
+    code_build_fuzz_policy_in_json
+from util.metadata import AWS_ACCOUNT, AWS_REGION, GITHUB_REPO_OWNER, GITHUB_REPO_NAME
+from util.yml_loader import YmlLoader
+
+
+class AwsLcGitHubFuzzCIStack(core.Stack):
+    """Define a stack used to batch execute AWS-LC tests in GitHub."""
+
+    def __init__(self,
+                 scope: core.Construct,
+                 id: str,
+                 x86_ecr_repo_name: str,
+                 arm_ecr_repo_name: str,
+                 spec_file_path: str,
+                 **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        # Define CodeBuild resource.
+        git_hub_source = codebuild.Source.git_hub(
+            owner=GITHUB_REPO_OWNER,
+            repo=GITHUB_REPO_NAME,
+            webhook=True,
+            webhook_filters=[
+                codebuild.FilterGroup.in_event_of(
+                    codebuild.EventAction.PULL_REQUEST_CREATED,
+                    codebuild.EventAction.PULL_REQUEST_UPDATED,
+                    codebuild.EventAction.PULL_REQUEST_REOPENED)
+            ],
+            clone_depth=1)
+
+        # Define a IAM role for this stack.
+        code_build_batch_policy = iam.PolicyDocument.from_json(
+            code_build_batch_policy_in_json([id])
+        )
+        fuzz_policy = iam.PolicyDocument.from_json(code_build_fuzz_policy_in_json())
+        inline_policies = {"code_build_batch_policy": code_build_batch_policy,
+                           "fuzz_policy": fuzz_policy}
+        role = iam.Role(scope=self,
+                        id="{}-role".format(id),
+                        assumed_by=iam.ServicePrincipal("codebuild.amazonaws.com"),
+                        inline_policies=inline_policies)
+
+        # Create the VPC for EFS and CodeBuild
+        public_subnet = ec2.SubnetConfiguration(name="PublicFuzzingSubnet", subnet_type=ec2.SubnetType.PUBLIC)
+        private_subnet = ec2.SubnetConfiguration(name="PrivateFuzzingSubnet", subnet_type=ec2.SubnetType.PRIVATE)
+
+        # Create a VPC with a single public and private subnet in a single AZ. This is to avoid the elastic IP limit
+        # being used up by a bunch of idle NAT gateways
+        fuzz_vpc = ec2.Vpc(
+            scope=self,
+            id="FuzzingVPC",
+            subnet_configuration=[public_subnet, private_subnet],
+            max_azs=1
+        )
+        build_security_group = ec2.SecurityGroup(
+            scope=self,
+            id="FuzzingSecurityGroup",
+            vpc=fuzz_vpc
+        )
+
+        build_security_group.add_ingress_rule(
+            peer=build_security_group,
+            connection=ec2.Port.all_traffic(),
+            description="Allow all traffic inside security group"
+        )
+
+        efs_subnet_selection = ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE)
+
+        # Create the EFS to store the corpus and logs
+        fuzz_filesystem = efs.FileSystem(
+            scope=self,
+            id="FuzzingEFS",
+            file_system_name="AWS-LC-Fuzz-Corpus",
+            enable_automatic_backups=True,
+            encrypted=True,
+            security_group=build_security_group,
+            vpc=fuzz_vpc,
+            vpc_subnets=efs_subnet_selection
+        )
+
+        # Create build spec.
+        placeholder_map = {"AWS_ACCOUNT_ID_PLACEHOLDER": AWS_ACCOUNT, "AWS_REGION_PLACEHOLDER": AWS_REGION,
+                           "X86_ECR_REPO_PLACEHOLDER": ecr_arn(x86_ecr_repo_name),
+                           "ARM_ECR_REPO_PLACEHOLDER": ecr_arn(arm_ecr_repo_name)}
+        build_spec_content = YmlLoader.load(spec_file_path, placeholder_map)
+
+        print(placeholder_map)
+        print(spec_file_path)
+        print(build_spec_content)
+
+        # Define CodeBuild.
+        fuzz_codebuild = codebuild.Project(
+            scope=self,
+            id="FuzzingCodeBuild",
+            project_name=id,
+            source=git_hub_source,
+            role=role,
+            timeout=core.Duration.minutes(120),
+            environment=codebuild.BuildEnvironment(compute_type=codebuild.ComputeType.LARGE,
+                                                   privileged=True,
+                                                   build_image=codebuild.LinuxBuildImage.STANDARD_4_0),
+            build_spec=codebuild.BuildSpec.from_object(build_spec_content),
+            vpc=fuzz_vpc,
+            security_groups=[build_security_group])
+
+        # TODO: add build type BUILD_BATCH when CFN finishes the feature release. See CryptoAlg-575.
+
+        # Add 'BuildBatchConfig' property, which is not supported in CDK.
+        # CDK raw overrides: https://docs.aws.amazon.com/cdk/latest/guide/cfn_layer.html#cfn_layer_raw
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html#aws-resource-codebuild-project-properties
+        cfn_codebuild = fuzz_codebuild.node.default_child
+        cfn_codebuild.add_override("Properties.BuildBatchConfig", {
+            "ServiceRole": role.role_arn,
+            "TimeoutInMins": 120
+        })
+
+        # The EFS identifier needs to match tests/ci/common_fuzz.sh, CodeBuild defines an environment variable named
+        # codebuild_$identifier.
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectfilesystemlocation.html
+        #
+        # TODO: add this to the CDK project above when it supports EfsFileSystemLocation
+        cfn_codebuild.add_override("Properties.FileSystemLocations", [{
+          "Identifier": "fuzzing_root",
+          "Location": "%s.efs.%s.amazonaws.com:/" % (fuzz_filesystem.file_system_id, AWS_REGION),
+          "MountPoint": "/efs_fuzzing_root",
+          "Type": "EFS"
+        }])

--- a/tests/ci/cdk/cdk/aws_lc_github_fuzz_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_fuzz_ci_stack.py
@@ -55,13 +55,13 @@ class AwsLcGitHubFuzzCIStack(core.Stack):
         # being used up by a bunch of idle NAT gateways
         fuzz_vpc = ec2.Vpc(
             scope=self,
-            id="FuzzingVPC",
+            id="{}-FuzzingVPC".format(id),
             subnet_configuration=[public_subnet, private_subnet],
             max_azs=1
         )
         build_security_group = ec2.SecurityGroup(
             scope=self,
-            id="FuzzingSecurityGroup",
+            id="{}-FuzzingSecurityGroup".format(id),
             vpc=fuzz_vpc
         )
 
@@ -76,7 +76,7 @@ class AwsLcGitHubFuzzCIStack(core.Stack):
         # Create the EFS to store the corpus and logs
         fuzz_filesystem = efs.FileSystem(
             scope=self,
-            id="FuzzingEFS",
+            id="{}-FuzzingEFS".format(id),
             file_system_name="AWS-LC-Fuzz-Corpus",
             enable_automatic_backups=True,
             encrypted=True,
@@ -86,14 +86,9 @@ class AwsLcGitHubFuzzCIStack(core.Stack):
         )
 
         # Create build spec.
-        placeholder_map = {"AWS_ACCOUNT_ID_PLACEHOLDER": AWS_ACCOUNT, "AWS_REGION_PLACEHOLDER": AWS_REGION,
-                           "X86_ECR_REPO_PLACEHOLDER": ecr_arn(x86_ecr_repo_name),
+        placeholder_map = {"X86_ECR_REPO_PLACEHOLDER": ecr_arn(x86_ecr_repo_name),
                            "ARM_ECR_REPO_PLACEHOLDER": ecr_arn(arm_ecr_repo_name)}
         build_spec_content = YmlLoader.load(spec_file_path, placeholder_map)
-
-        print(placeholder_map)
-        print(spec_file_path)
-        print(build_spec_content)
 
         # Define CodeBuild.
         fuzz_codebuild = codebuild.Project(

--- a/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+# Doc for batch https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html#build-spec.batch.build-list
+batch:
+  build-list:
+
+    - identifier: ubuntu2004_clang10_x86_64_fuzz
+      buildspec: ./tests/ci/codebuild/linux-x86/run_fuzz_tests.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: X86_ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_latest
+
+    - identifier: ubuntu2004_clang10_arm_fuzz
+      buildspec: ./tests/ci/codebuild/linux-x86/run_fuzz_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ARM_ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_latest

--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -94,6 +94,7 @@ function create_github_ci_stack() {
   aws codebuild update-webhook --project-name aws-lc-ci-linux-x86 --build-type BUILD_BATCH
   aws codebuild update-webhook --project-name aws-lc-ci-linux-arm --build-type BUILD_BATCH
   aws codebuild update-webhook --project-name aws-lc-ci-windows-x86 --build-type BUILD_BATCH
+  aws codebuild update-webhook --project-name aws-lc-ci-fuzzing --build-type BUILD_BATCH
 }
 
 function build_linux_img() {

--- a/tests/ci/cdk/util/ecr_util.py
+++ b/tests/ci/cdk/util/ecr_util.py
@@ -1,0 +1,5 @@
+from util.metadata import AWS_ACCOUNT, AWS_REGION
+
+
+def ecr_arn(ecr_repo_name):
+    return "{}.dkr.ecr.{}.amazonaws.com/{}".format(AWS_ACCOUNT, AWS_REGION, ecr_repo_name)

--- a/tests/ci/cdk/util/iam_policies.py
+++ b/tests/ci/cdk/util/iam_policies.py
@@ -30,6 +30,33 @@ def code_build_batch_policy_in_json(project_ids):
         ]
     }
 
+def code_build_fuzz_policy_in_json():
+    """
+    Define an IAM policy that only grants access to publish CloudWatch metrics to the current region in the same
+    namespace used in the calls to PutMetricData in tests/ci/common_fuzz.sh.
+    """
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "cloudwatch:PutMetricData",
+                "Resource": "*",
+                "Condition": {
+                    "StringEquals": {
+                        "aws:RequestedRegion": [
+                            AWS_REGION
+                        ],
+                        "cloudwatch:namespace": [
+                            "AWS-LC-Fuzz"
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+
+
 
 def s3_read_write_policy_in_json(s3_bucket_name):
     """
@@ -102,30 +129,6 @@ def ecr_power_user_policy_in_json(ecr_repo_names):
                     "ecr:PutImage"
                 ],
                 "Resource": ecr_arns
-            }
-        ]
-    }
-
-
-def ecr_pull_only_policy_in_json(ecr_repo_name):
-    """
-    Define an AWS-LC specific IAM policy statement used to pull Docker images from ECR repo.
-    Reference:
-      https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonelasticcontainerregistry.html
-    :param ecr_repo_name: repository name.
-    :return: an IAM policy statement in json.
-    """
-    return {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "ecr:BatchCheckLayerAvailability",
-                    "ecr:GetDownloadUrlForLayer",
-                    "ecr:BatchGetImage",
-                ],
-                "Resource": ecr_repo_arn(ecr_repo_name)
             }
         ]
     }

--- a/tests/ci/codebuild/linux-x86/run_fuzz_tests.yml
+++ b/tests/ci/codebuild/linux-x86/run_fuzz_tests.yml
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      # To use this build spec file, CMake environment variable CC and CXX compiler should be defined before build.
+      - if [[ -z "${CC+x}" || -z "${CC}" ]]; then echo "CC is not defined." && exit 1; else ${CC} --version && echo "Found correct CC."; fi
+      - if [[ -z "${CXX+x}" || -z "${CXX}" ]]; then echo "CXX is not defined." && exit 1; else ${CXX} --version && echo "Found correct CXX."; fi
+  build:
+    commands:
+      - ./tests/ci/run_fuzz_tests.sh

--- a/tests/ci/common_fuzz.sh
+++ b/tests/ci/common_fuzz.sh
@@ -23,7 +23,11 @@ function put_metric_count {
 }
 
 function put_metric {
-  aws --region us-west-2 cloudwatch put-metric-data \
+  # This call to publish the metric could fail but we don't want to fail the build +e turns off exit on error
+  set +e
+  aws cloudwatch put-metric-data \
     --namespace AWS-LC-Fuzz \
-    "$@"
+    "$@" || echo "Publishing metric failed, continuing with the rest of the build"
+  # Turn it back on for the rest of the build
+  set -e
 }

--- a/tests/ci/common_fuzz.sh
+++ b/tests/ci/common_fuzz.sh
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+source tests/ci/common_posix_setup.sh
+
+if [ -v CODEBUILD_FUZZING_ROOT ]; then
+  CORPUS_ROOT="${CODEBUILD_FUZZING_ROOT}/fuzzing"
+else
+  CORPUS_ROOT="${BUILD_ROOT}/mock_efs/fuzzing"
+fi
+echo "$CORPUS_ROOT"
+
+if [ -v CODEBUILD_BUILD_ID ]; then
+  BUILD_ID=$CODEBUILD_BUILD_ID
+else
+  # Generate a random string in bash https://unix.stackexchange.com/questions/230673/how-to-generate-a-random-string
+  BUILD_ID=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')
+fi
+echo "$BUILD_ID"
+
+function put_metric_count {
+  put_metric --unit Count "$@"
+}
+
+function put_metric {
+  aws --region us-west-2 cloudwatch put-metric-data \
+    --namespace AWS-LC-Fuzz \
+    "$@"
+}

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -20,7 +20,7 @@ function run_build {
   mkdir -p "$BUILD_ROOT"
   cd "$BUILD_ROOT" || exit 1
 
-  if [[ -v AWSLC_32BIT ]] && [[ "${AWSLC_32BIT}" == "1" ]]; then
+  if [[ "${AWSLC_32BIT}" == "1" ]]; then
     cflags+=("-DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake")
   fi
 

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -12,7 +12,7 @@ echo "$SRC_ROOT"
 BUILD_ROOT="${SRC_ROOT}/test_build_dir"
 echo "$BUILD_ROOT"
 
-NUM_CPU_THREADS=$(nproc)
+NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 
 function run_build {
   local cflags=("$@")

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -1,13 +1,26 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+
+if [ -v CODEBUILD_SRC_DIR ]; then
+  SRC_ROOT="$CODEBUILD_SRC_DIR"
+else
+  SRC_ROOT=$(pwd)
+fi
+echo "$SRC_ROOT"
+
+BUILD_ROOT="${SRC_ROOT}/test_build_dir"
+echo "$BUILD_ROOT"
+
+NUM_CPU_THREADS=$(nproc)
+
 function run_build {
   local cflags=("$@")
-  rm -rf test_build_dir
-  mkdir -p test_build_dir
-  cd test_build_dir || exit 1
+  rm -rf "$BUILD_ROOT"
+  mkdir -p "$BUILD_ROOT"
+  cd "$BUILD_ROOT" || exit 1
 
-  if [[ "${AWSLC_32BIT}" == "1" ]]; then
+  if [[ -v AWSLC_32BIT && "${AWSLC_32BIT}" == "1" ]]; then
     cflags+=("-DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake")
   fi
 
@@ -21,7 +34,7 @@ function run_build {
     cflags+=(-GNinja)
   else
     echo "Using Make."
-    BUILD_COMMAND="make"
+    BUILD_COMMAND="make -j${NUM_CPU_THREADS}"
   fi
 
   cmake "${cflags[@]}" ../
@@ -30,7 +43,7 @@ function run_build {
 }
 
 function run_cmake_custom_target {
-  $BUILD_COMMAND -C test_build_dir "$@"
+  $BUILD_COMMAND -C "$BUILD_ROOT" "$@"
 }
 
 function build_and_test {

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -20,7 +20,7 @@ function run_build {
   mkdir -p "$BUILD_ROOT"
   cd "$BUILD_ROOT" || exit 1
 
-  if [[ -v AWSLC_32BIT && "${AWSLC_32BIT}" == "1" ]]; then
+  if [[ -v AWSLC_32BIT ]] && [[ "${AWSLC_32BIT}" == "1" ]]; then
     cflags+=("-DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake")
   fi
 

--- a/tests/ci/docker_images/linux-aarch/ubuntu-20.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/ubuntu-20.04_base/Dockerfile
@@ -13,8 +13,6 @@ ENV LLVM_PROJECT_HOME=${DEPENDENCIES_DIR}/llvm-project
 # llvm, llvm-dev, libcxx, and libcxxabi are needed for the sanitizer tests.
 # 11.1.0 is the latest stable release as of 2021-02-16.
 # See https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
-
-# The awscli is used to publish data to CloudWatch Metrics in some jobs. This requires additional IAM permission
 RUN set -ex && \
     apt-get update && \
     apt-get -y --no-install-recommends upgrade && \
@@ -31,7 +29,15 @@ RUN set -ex && \
     lld \
     llvm \
     llvm-dev \
-    awscli && \
+    curl \
+    unzip && \
+    # Based on https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
+    # The awscli is used to publish data to CloudWatch Metrics in some jobs. This requires additional IAM permission
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install --bin-dir /usr/bin && \
+    rm -rf awscliv2.zip aws/ && \
+    # Download a copy of LLVM's libcxx which is required for building and running with Memory Sanitizer
     mkdir -p ${DEPENDENCIES_DIR} && \
     cd ${DEPENDENCIES_DIR} && \
     git clone https://github.com/llvm/llvm-project.git --branch llvmorg-11.1.0  --depth 1 && \

--- a/tests/ci/docker_images/linux-aarch/ubuntu-20.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/ubuntu-20.04_base/Dockerfile
@@ -13,6 +13,8 @@ ENV LLVM_PROJECT_HOME=${DEPENDENCIES_DIR}/llvm-project
 # llvm, llvm-dev, libcxx, and libcxxabi are needed for the sanitizer tests.
 # 11.1.0 is the latest stable release as of 2021-02-16.
 # See https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
+
+# The awscli is used to publish data to CloudWatch Metrics in some jobs. This requires additional IAM permission
 RUN set -ex && \
     apt-get update && \
     apt-get -y --no-install-recommends upgrade && \
@@ -28,7 +30,8 @@ RUN set -ex && \
     wget \
     lld \
     llvm \
-    llvm-dev && \
+    llvm-dev \
+    awscli && \
     mkdir -p ${DEPENDENCIES_DIR} && \
     cd ${DEPENDENCIES_DIR} && \
     git clone https://github.com/llvm/llvm-project.git --branch llvmorg-11.1.0  --depth 1 && \

--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_base/Dockerfile
@@ -13,6 +13,8 @@ ENV LLVM_PROJECT_HOME=${DEPENDENCIES_DIR}/llvm-project
 # llvm, llvm-dev, libcxx, and libcxxabi are needed for the sanitizer tests.
 # 11.1.0 is the latest stable release as of 2021-02-16.
 # See https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
+
+# The awscli is used to publish data to CloudWatch Metrics in some jobs. This requires additional IAM permission
 RUN set -ex && \
     apt-get update && \
     apt-get -y --no-install-recommends upgrade && \
@@ -28,7 +30,8 @@ RUN set -ex && \
     wget \
     lld \
     llvm \
-    llvm-dev && \
+    llvm-dev \
+    awscli && \
     mkdir -p ${DEPENDENCIES_DIR} && \
     cd ${DEPENDENCIES_DIR} && \
     git clone https://github.com/llvm/llvm-project.git --branch llvmorg-11.1.0  --depth 1 && \

--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_base/Dockerfile
@@ -13,8 +13,6 @@ ENV LLVM_PROJECT_HOME=${DEPENDENCIES_DIR}/llvm-project
 # llvm, llvm-dev, libcxx, and libcxxabi are needed for the sanitizer tests.
 # 11.1.0 is the latest stable release as of 2021-02-16.
 # See https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
-
-# The awscli is used to publish data to CloudWatch Metrics in some jobs. This requires additional IAM permission
 RUN set -ex && \
     apt-get update && \
     apt-get -y --no-install-recommends upgrade && \
@@ -31,7 +29,15 @@ RUN set -ex && \
     lld \
     llvm \
     llvm-dev \
-    awscli && \
+    curl \
+    unzip && \
+    # Based on https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
+    # The awscli is used to publish data to CloudWatch Metrics in some jobs. This requires additional IAM permission
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install --bin-dir /usr/bin && \
+    rm -rf awscliv2.zip aws/ && \
+    # Download a copy of LLVM's libcxx which is required for building and running with Memory Sanitizer
     mkdir -p ${DEPENDENCIES_DIR} && \
     cd ${DEPENDENCIES_DIR} && \
     git clone https://github.com/llvm/llvm-project.git --branch llvmorg-11.1.0  --depth 1 && \
@@ -39,6 +45,7 @@ RUN set -ex && \
     wget https://dl.google.com/go/go1.13.12.linux-amd64.tar.gz && \
     tar -xvf go1.13.12.linux-amd64.tar.gz && \
     mv go /usr/local && \
+    apt-get --purge remove -y curl unzip && \
     apt-get autoremove --purge -y && \
     apt-get clean && \
     apt-get autoclean && \

--- a/tests/ci/run_fuzz_tests.sh
+++ b/tests/ci/run_fuzz_tests.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -exuo pipefail
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+source tests/ci/common_fuzz.sh
+
+echo "Building fuzz tests."
+run_build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DFUZZ=1 -DASAN=1
+
+OVERALL_FUZZ_FAILURE=0
+PLATFORM=$(uname -m)
+DATE_NOW="$(date +%Y-%m-%d)"
+FAILURE_ROOT="${CORPUS_ROOT}/runs/${DATE_NOW}/${BUILD_ID}"
+ALL_RUN_ROOT="${BUILD_ROOT}/fuzz_run_root"
+rm -rf "$ALL_RUN_ROOT"
+
+# We want our CI to take about an hour:
+# ~2 minutes to build AWS-LC
+# ~50 minutes (3000 seconds) for all fuzzing
+# ~2 minutes for merging files
+# ~3 minutes for cleanup
+TOTAL_FUZZ_TEST_TIME=3000
+FUZZ_TESTS=$(find test_build_dir/fuzz -type f -executable)
+NUM_FUZZ_TESTS=$(echo "$FUZZ_TESTS" | wc -l)
+TIME_FOR_EACH_FUZZ=$((TOTAL_FUZZ_TEST_TIME/NUM_FUZZ_TESTS))
+
+for FUZZ_TEST in $FUZZ_TESTS;do
+  FUZZ_RUN_FAILURE=0
+  FUZZ_NAME=$(basename "$FUZZ_TEST")
+
+  SRC_CORPUS="${SRC_ROOT}/fuzz/${FUZZ_NAME}_corpus"
+  SHARED_CORPUS="${CORPUS_ROOT}/shared_corpus/${FUZZ_NAME}/shared_corpus"
+
+  FUZZ_TEST_ROOT="${ALL_RUN_ROOT}/${FUZZ_NAME}"
+  FUZZ_TEST_CORPUS="${FUZZ_TEST_ROOT}/run_corpus"
+  ARTIFACTS_FOLDER="${FUZZ_TEST_ROOT}/artifacts"
+  FUZZ_RUN_LOGS="${FUZZ_TEST_ROOT}/logs"
+  SUMMARY_LOG="${FUZZ_RUN_LOGS}/summary.log"
+  mkdir -p "$SHARED_CORPUS" "$FUZZ_TEST_ROOT" "$FUZZ_TEST_CORPUS" "$ARTIFACTS_FOLDER" "$FUZZ_RUN_LOGS"
+
+  # Calculate starting metrics and post to CloudWatch
+  ORIGINAL_SHARED_CORPUS_FILE_COUNT=$(find "$SHARED_CORPUS" -type f | wc -l)
+  put_metric_count --metric-name SharedCorpusFileCount --value "$ORIGINAL_SHARED_CORPUS_FILE_COUNT" --dimensions "FuzzTest=$FUZZ_NAME"
+
+  # Perform the actual fuzzing!
+  # Step 1 run each fuzz test for the determined time. This will use the existing shared corpus and any files checked
+  # into the GitHub corpus. It will write new files to the temporary run corpus.
+  # https://llvm.org/docs/LibFuzzer.html#options
+  #
+  # Run with NUM_CPU_THREADS which will be physical cores on ARM and virtualized cores on x86 with hyper threading.
+  # Looking at the overall system fuzz rate running 1:1 with virtualized cores provides a noticeable speed up. This
+  # is slightly different than libfuzzer's recommendation of #cores/2.
+  # This could fail and we want to capture that (+e)
+  set +e
+  time ${FUZZ_TEST} -print_final_stats=1 -timeout=5 -max_total_time="$TIME_FOR_EACH_FUZZ" \
+    -jobs="$NUM_CPU_THREADS" -workers="$NUM_CPU_THREADS" \
+    -artifact_prefix="$ARTIFACTS_FOLDER/" \
+    "$FUZZ_TEST_CORPUS" "$SHARED_CORPUS" "$SRC_CORPUS" 2>&1 | tee "$SUMMARY_LOG"
+  # This gets the status of the fuzz run which determines if we want to fail the build or not, otherwise we'd get the results of tee
+  if [ "${PIPESTATUS[0]}" == 1 ]; then
+    OVERALL_FUZZ_FAILURE=1
+    FUZZ_RUN_FAILURE=1
+  fi
+  set -e
+
+  # The libfuzzer logs are written to the current working directory and need to be moved after the test is done
+  mv ./*.log  "${FUZZ_RUN_LOGS}/."
+
+  if [ "$FUZZ_RUN_FAILURE" == 1 ]; then
+    FUZZ_TEST_FAILURE_ROOT="${FAILURE_ROOT}/${FUZZ_NAME}"
+    mkdir -p "$FUZZ_TEST_FAILURE_ROOT"
+
+    cp -r "$FUZZ_TEST_ROOT" "$FAILURE_ROOT"
+  else
+    echo "Fuzz test ${FUZZ_NAME} finished successfully, not copying run logs and run corpus"
+  fi
+  # Step 2 merge any new coverage from the run corpus and GitHub src corpus into the shared corpus
+  time ${FUZZ_TEST} -merge=1 "$SHARED_CORPUS" "$FUZZ_TEST_CORPUS" "$SRC_CORPUS"
+
+  # Calculate interesting metrics and post results to CloudWatch
+  FINAL_SHARED_CORPUS_FILE_COUNT=$(find "$SHARED_CORPUS" -type f | wc -l)
+  put_metric_count --metric-name SharedCorpusFileCount --value "$FINAL_SHARED_CORPUS_FILE_COUNT" --dimensions "FuzzTest=$FUZZ_NAME"
+
+  NEW_FUZZ_FILES=$(find "$FUZZ_TEST_CORPUS" -type f | wc -l)
+  put_metric_count --metric-name RunCorpusFileCount --value "$NEW_FUZZ_FILES" --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
+
+  TEST_COUNT=$(grep -o "stat::number_of_executed_units: [0-9]*" "$SUMMARY_LOG" | awk '{test_count += $2} END {print test_count}')
+  put_metric_count --metric-name TestCount --value "$TEST_COUNT" --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
+
+  TESTS_PER_SECOND=$((TEST_COUNT/TOTAL_FUZZ_TEST_TIME))
+  put_metric --metric-name TestRate --value "$TESTS_PER_SECOND" --unit Count/Second --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
+
+  FEATURE_COVERAGE=$(grep -o "ft: [0-9]*" "$SUMMARY_LOG" | awk '{print $2}' | sort | tail -1)
+  put_metric_count --metric-name FeatureCoverage --value "$FEATURE_COVERAGE" --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
+
+  BLOCK_COVERAGE=$(grep -o "cov: [0-9]*" "$SUMMARY_LOG" | awk '{print $2}' | sort | tail -1)
+  put_metric_count --metric-name BlockCoverage --value "$BLOCK_COVERAGE" --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
+
+  echo "${FUZZ_NAME} starting shared ${ORIGINAL_SHARED_CORPUS_FILE_COUNT} final shared ${FINAL_SHARED_CORPUS_FILE_COUNT} new files ${NEW_FUZZ_FILES} total test count ${TEST_COUNT} test rate ${TESTS_PER_SECOND} code coverage ${BLOCK_COVERAGE} feature coverage ${FEATURE_COVERAGE}"
+done
+
+exit "$OVERALL_FUZZ_FAILURE"

--- a/tests/ci/run_fuzz_tests.sh
+++ b/tests/ci/run_fuzz_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -exo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ci/run_posix_sanitizers.sh
+++ b/tests/ci/run_posix_sanitizers.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -exo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ci/run_posix_sanitizers.sh
+++ b/tests/ci/run_posix_sanitizers.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -ex
+#!/bin/bash
+set -exuo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +17,7 @@ if [ $(dpkg --print-architecture) == "arm64" ]; then
   # TODO: Open a GitHub issue on https://github.com/google/sanitizers/issues, and then link the issue here.
   echo "Building AWS-LC in ${build_type} mode with address sanitizer, and running only non ssl test."
   run_build -DASAN=1 -DUSE_CUSTOM_LIBCXX=1 "${cflags[@]}"
-  go run util/all_tests.go -build-dir test_build_dir
+  go run util/all_tests.go -build-dir "$BUILD_ROOT"
 else
   echo "Testing AWS-LC in ${build_type} mode with address sanitizer."
   build_and_test -DASAN=1 -DUSE_CUSTOM_LIBCXX=1 "${cflags[@]}"

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -exo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -20,23 +20,23 @@ build_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
 echo "Testing building shared lib."
 run_build -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
 
-if [[ -v AWSLC_FIPS && "${AWSLC_FIPS}" == "1" ]]; then
+if [[ "${AWSLC_FIPS}" == "1" ]]; then
   echo "Testing AWS-LC in FIPS release mode."
   build_and_test -DFIPS=1 -DCMAKE_BUILD_TYPE=Release
   ./${BUILD_ROOT}/util/fipstools/cavp/test_fips
 fi
 
-if [[ -v AWSLC_C99_TEST && "${AWSLC_C99_TEST}" == "1" ]]; then
+if [[ "${AWSLC_C99_TEST}" == "1" ]]; then
     echo "Testing the C99 compatability of AWS-LC headers."
     ./tests/coding_guidelines/c99_gcc_test.sh
 fi
 
-if [[ -v AWSLC_CODING_GUIDELINES_TEST && "${AWSLC_CODING_GUIDELINES_TEST}" == "1" ]]; then
+if [[ "${AWSLC_CODING_GUIDELINES_TEST}" == "1" ]]; then
   echo "Testing that AWS-LC is compliant with the coding guidelines."
   source ./tests/coding_guidelines/coding_guidelines_test.sh
 fi
 
-if [[ -v AWSLC_FUZZ && "${AWSLC_FUZZ}" == "1" ]]; then
+if [[ "${AWSLC_FUZZ}" == "1" ]]; then
   echo "Testing building fuzz tests."
   run_build -DFUZZ=1
 fi

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -23,7 +23,7 @@ run_build -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
 if [[ "${AWSLC_FIPS}" == "1" ]]; then
   echo "Testing AWS-LC in FIPS release mode."
   build_and_test -DFIPS=1 -DCMAKE_BUILD_TYPE=Release
-  ./${BUILD_ROOT}/util/fipstools/cavp/test_fips
+  "${BUILD_ROOT}/util/fipstools/cavp/test_fips"
 fi
 
 if [[ "${AWSLC_C99_TEST}" == "1" ]]; then

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -ex
+#!/bin/bash
+set -exuo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -19,23 +20,23 @@ build_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
 echo "Testing building shared lib."
 run_build -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
 
-if [[  "${AWSLC_FIPS}" == "1" ]]; then
+if [[ -v AWSLC_FIPS && "${AWSLC_FIPS}" == "1" ]]; then
   echo "Testing AWS-LC in FIPS release mode."
   build_and_test -DFIPS=1 -DCMAKE_BUILD_TYPE=Release
-  ./test_build_dir/util/fipstools/cavp/test_fips
+  ./${BUILD_ROOT}/util/fipstools/cavp/test_fips
 fi
 
-if [[ "${AWSLC_C99_TEST}" == "1" ]]; then
+if [[ -v AWSLC_C99_TEST && "${AWSLC_C99_TEST}" == "1" ]]; then
     echo "Testing the C99 compatability of AWS-LC headers."
     ./tests/coding_guidelines/c99_gcc_test.sh
 fi
 
-if [[  "${AWSLC_CODING_GUIDELINES_TEST}" == "1" ]]; then
+if [[ -v AWSLC_CODING_GUIDELINES_TEST && "${AWSLC_CODING_GUIDELINES_TEST}" == "1" ]]; then
   echo "Testing that AWS-LC is compliant with the coding guidelines."
   source ./tests/coding_guidelines/coding_guidelines_test.sh
 fi
 
-if [[ "${AWSLC_FUZZ}" == "1" ]]; then
+if [[ -v AWSLC_FUZZ && "${AWSLC_FUZZ}" == "1" ]]; then
   echo "Testing building fuzz tests."
   run_build -DFUZZ=1
 fi


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-651

### Description of changes: 
This adds 2 new CI targets: running the existing fuzz tests on ARM and x86. This uses EFS to store the shared and minimized corpus. 

Other changes:
* Cleanup common test directories and set common bash flags
    * Add -u to check for unset variables, also update existing checks for variables to handle this
* Remove the pull image permission from the CodeBuild roles, we grant permission to the CodeBuild service principal already

### Testing:
I have not deployed this change to the CI account. I can walk you through the changes in my account.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
