### PR TITLE
Add FIPS shared builds on x86 platform.

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -164,7 +164,7 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:amazonlinux-2_clang-7x_latest
         variables:
-          # TODO(shang): change value from 0 to 1 after installing LLVM LLD on AL2.
+          # AL2 Clang-7 does not support AddressSanitizer. Related ticket is linked in CryptoAlg-694.
           # https://github.com/awslabs/aws-lc/pull/120#issuecomment-808439279
           AWSLC_NO_ASM_FIPS: 0
 

--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -179,9 +179,21 @@ function win_docker_img_build_status_check() {
   exit 1
 }
 
+function validate_github_access_token {
+  # GitHub access token is only needed when building Docker images.
+  if [[ -z "${GITHUB_ACCESS_TOKEN+x}" || -z "${GITHUB_ACCESS_TOKEN}" ]]; then
+    echo '--github-access-token is required for aws-lc ci setup.'
+    exit 1
+  fi
+}
+
 function build_docker_images() {
   # Always destroy docker build stacks (which include EC2 instance) on EXIT.
   trap destroy_docker_img_build_stack EXIT
+
+  # Check prerequisite.
+  # One prerequisite is to provide GitHub access token so AWS CodeBuild can pull Docker images from GitHub.
+  validate_github_access_token
 
   # Create/update aws-ecr repo.
   cdk deploy aws-lc-ecr-* --require-approval never
@@ -319,10 +331,6 @@ function main() {
   # Execute the action.
   case ${ACTION} in
   deploy-ci)
-    if [[ -z "${GITHUB_ACCESS_TOKEN+x}" || -z "${GITHUB_ACCESS_TOKEN}" ]]; then
-      echo '--github-access-token is required for aws-lc ci setup.'
-      exit 1
-    fi
     setup_ci
     ;;
   update-ci)

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -38,10 +38,22 @@ function build_and_test {
   run_cmake_custom_target 'run_tests'
 }
 
+function check_fips_mode {
+  # Upon completion of the build process. The module’s status can be verified by issuing:
+  # https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3678.pdf
+  module_status=$(./test_build_dir/tool/bssl isfips)
+  if [[ "${module_status}" == "1" ]]; then
+    run_cmake_custom_target 'run_tests'
+    ./test_build_dir/util/fipstools/cavp/test_fips
+  else
+    echo "Failed to validate built module status."
+    exit 1
+  fi
+}
+
 function fips_build_and_test {
   run_build "$@" -DFIPS=1
-  run_cmake_custom_target 'run_tests'
-  ./test_build_dir/util/fipstools/cavp/test_fips
+  check_fips_mode
 }
 
 function build_and_test_valgrind {

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -10,6 +10,15 @@ fips_build_and_test
 echo "Testing AWS-LC in FIPS release mode."
 fips_build_and_test -DCMAKE_BUILD_TYPE=Release
 
+echo "Testing shared AWS-LC in FIPS debug mode."
+fips_build_and_test -DBUILD_SHARED_LIBS=1
+
+# FIPS build in release mode is disabled for GCC due to some build issues relating to '-O3'.
+if [[ "${CC}" == 'clang'*  ]]; then
+  echo "Testing shared AWS-LC in FIPS release mode."
+  fips_build_and_test -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
+fi
+
 if [[  "${AWSLC_NO_ASM_FIPS}" == "1" ]]; then
   # This dimension corresponds to boringssl CI 'linux_fips_noasm_asan'.
   # https://logs.chromium.org/logs/boringssl/buildbucket/cr-buildbucket.appspot.com/8852496158370398336/+/steps/cmake/0/logs/execution_details/0


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-723

### Description of changes: 
This PR added FIPS shared builds on x86 platform.

Some minor changes of this PR include
* Add comment for AL2 Clang FIPS build.
* Validate GitHub access token when building Docker image.
* Check FIPS mode by running `tool/bssl isfips`.

### Call-outs:
* FIPS Shared release build on x86 Gcc-7x is disabled. I will make additional investigation on the build error.

### Testing:
* CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
