### PR TITLE
Do not merge! This is a test for our CI

### DIFF
--- a/crypto/pkcs8/pkcs8_x509.c
+++ b/crypto/pkcs8/pkcs8_x509.c
@@ -647,7 +647,7 @@ int PKCS12_get_key_and_certs(EVP_PKEY **out_key, STACK_OF(X509) *out_certs,
   }
 
   *out_key = NULL;
-  OPENSSL_memset(&ctx, 0, sizeof(ctx));
+  OPENSSL_memset(&ctx, 0, ber_in->len);
 
   // See ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-12/pkcs-12v1.pdf, section
   // four.


### PR DESCRIPTION

### Issues:
Addresses CryptoAlg-651

### Description of changes: 
This change should pass all of our normal unit tests and fail the fuzz tests. This is just a game day to test that CI is working as expected and the runbook to check the fuzzing logs.

### Call-outs:
I had fun trying to make a bug that only fuzzing could catch and it surprisingly didn't take that too long. This particular bug might be caught in a CR but this style of bug is easy to miss: memset'ing something to 0 with the wrong size.

### Testing:
Run `ninja run_all_tests` locally and saw them pass, ran `./fuzz/pkcs12 ../fuzz/pkcs12_corpus` and saw the fuzz test quickly fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
