### PR TITLE
Fuzzing and Windows CI updates

### DIFF
--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -102,3 +102,16 @@ CodeBuild|clang 10.0.0|aarch64|ubuntu 20.04|ASAN=1
 To add a new fuzz test create a new executable follow [libFuzzer's](https://llvm.org/docs/LibFuzzer.html) documentation
 and existing tests. Generate a seed corpus and check it into a folder with the same name as the executable. The CI will
 pull in any files from the seed folder and merge it into the growing corpus in EFS.
+
+
+### Cryptofuzz
+Each change is built and tested with [Cryptofuzz](https://github.com/guidovranken/cryptofuzz) for an hour. A seed corpus
+is included in tests/docker_images/cryptofuzz_data.zip. As new inputs are found they are saved in a shared corpus across
+runs in AWS EFS. Cryptofuzz is built with 3 modules:
+* AWS-LC
+* Botan
+* Crypto++
+
+CI Tool|Compiler|CPU platform|OS|Flags
+------------|-------------|-------------|-------------|-------------
+CodeBuild|clang 10.0.0|x86-64|Ubuntu 20.04|ASAN=1

--- a/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
@@ -31,10 +31,10 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: X86_ECR_REPO_PLACEHOLDER:ubuntu-20.04_cryptofuzz_latest
 
-    - identifier: ubuntu2004_clang10_arm_cryptofuzz
-      buildspec: ./tests/ci/codebuild/linux-x86/run_cryptofuzz.yml
-      env:
-        type: ARM_CONTAINER
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        image: ARM_ECR_REPO_PLACEHOLDER:ubuntu-20.04_cryptofuzz_latest
+#    - identifier: ubuntu2004_clang10_arm_cryptofuzz
+#      buildspec: ./tests/ci/codebuild/linux-x86/run_cryptofuzz.yml
+#      env:
+#        type: ARM_CONTAINER
+#        privileged-mode: true
+#        compute-type: BUILD_GENERAL1_LARGE
+#        image: ARM_ECR_REPO_PLACEHOLDER:ubuntu-20.04_cryptofuzz_latest

--- a/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
@@ -31,6 +31,7 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: X86_ECR_REPO_PLACEHOLDER:ubuntu-20.04_cryptofuzz_latest
 
+# Turn off the ARM Cryptofuzz, fix is tracked in CryptoAlg-742
 #    - identifier: ubuntu2004_clang10_arm_cryptofuzz
 #      buildspec: ./tests/ci/codebuild/linux-x86/run_cryptofuzz.yml
 #      env:

--- a/tests/ci/cdk/cdk/codebuild/github_ci_windows_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_windows_x86_omnibus.yaml
@@ -22,4 +22,5 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: ECR_REPO_PLACEHOLDER:vs2017_latest
+        # Build failure on Docker image `vs2015_latest`, tracked in CryptoAlg-741.
+        image: ECR_REPO_PLACEHOLDER:vs2015-2020-12-08-01

--- a/tests/ci/cdk/cdk/codebuild/github_ci_windows_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_windows_x86_omnibus.yaml
@@ -13,7 +13,8 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: ECR_REPO_PLACEHOLDER:vs2015_latest
+        # Build failure on Docker image `vs2015_latest`, tracked in CryptoAlg-741.
+        image: ECR_REPO_PLACEHOLDER:vs2015-2020-12-08-01
 
     - identifier: windows_msvc2017_x64
       buildspec: ./tests/ci/codebuild/windows-x86/windows-msvc2017.yml
@@ -22,5 +23,4 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        # Build failure on Docker image `vs2015_latest`, tracked in CryptoAlg-741.
-        image: ECR_REPO_PLACEHOLDER:vs2015-2020-12-08-01
+        image: ECR_REPO_PLACEHOLDER:vs2017_latest

--- a/tests/ci/docker_images/build_cryptofuzz_modules.sh
+++ b/tests/ci/docker_images/build_cryptofuzz_modules.sh
@@ -36,11 +36,8 @@ make -j$(nproc)
 
 # Crypto++ https://github.com/guidovranken/cryptofuzz/blob/master/docs/cryptopp.md
 cd "$MODULES_ROOT"
-# Crypto++ broke arm compatibility with this change https://github.com/weidai11/cryptopp/commit/d1cea852f06008541966de7af433b57c4e9e2504
-#git clone --depth 1 https://github.com/weidai11/cryptopp.git
-git clone https://github.com/weidai11/cryptopp.git
+git clone --depth 1 https://github.com/weidai11/cryptopp.git
 cd cryptopp/
-git checkout fee14910eaabfa098b1a7e1b05326a8831ee5e41
 git rev-parse HEAD
 make libcryptopp.a -j$(nproc)
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_CRYPTOPP"
@@ -60,3 +57,6 @@ env CRYPTOFUZZ_DICT `realpath cryptofuzz-dict.txt`
 env CFLAGS "$CFLAGS"
 env CXXFLAGS "$CXXFLAGS"
 env CRYPTOFUZZ_SRC "$CRYPTOFUZZ_SRC"
+
+# Cryptofuzz builds it's modules into $CRYPTOFUZZ_SRC/modules that includes everything it needs, this saves a substantial amount of space
+rm -rf "$MODULES_ROOT"

--- a/tests/ci/docker_images/build_cryptofuzz_modules.sh
+++ b/tests/ci/docker_images/build_cryptofuzz_modules.sh
@@ -12,10 +12,8 @@ export CXXFLAGS="-fsanitize=address,undefined,fuzzer-no-link -D_GLIBCXX_DEBUG -O
 # Setup base of Cryptofuzz
 cd "$FUZZ_ROOT"
 MODULES_ROOT="${FUZZ_ROOT}/modules"
-#git clone --depth 1 https://github.com/guidovranken/cryptofuzz.git
-git clone https://github.com/guidovranken/cryptofuzz.git
+git clone --depth 1 https://github.com/guidovranken/cryptofuzz.git
 cd cryptofuzz
-git checkout 76ffeff944403cdd840f06b8fc42e131e6258f36
 git rev-parse HEAD
 CRYPTOFUZZ_SRC=$(pwd)
 python3 gen_repository.py
@@ -38,8 +36,11 @@ make -j$(nproc)
 
 # Crypto++ https://github.com/guidovranken/cryptofuzz/blob/master/docs/cryptopp.md
 cd "$MODULES_ROOT"
-git clone --depth 1 https://github.com/weidai11/cryptopp.git
+# Crypto++ broke arm compatibility with this change https://github.com/weidai11/cryptopp/commit/d1cea852f06008541966de7af433b57c4e9e2504
+#git clone --depth 1 https://github.com/weidai11/cryptopp.git
+git clone https://github.com/weidai11/cryptopp.git
 cd cryptopp/
+git checkout fee14910eaabfa098b1a7e1b05326a8831ee5e41
 git rev-parse HEAD
 make libcryptopp.a -j$(nproc)
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_CRYPTOPP"

--- a/tests/ci/docker_images/build_cryptofuzz_modules.sh
+++ b/tests/ci/docker_images/build_cryptofuzz_modules.sh
@@ -58,5 +58,6 @@ env CFLAGS "$CFLAGS"
 env CXXFLAGS "$CXXFLAGS"
 env CRYPTOFUZZ_SRC "$CRYPTOFUZZ_SRC"
 
-# Cryptofuzz builds it's modules into $CRYPTOFUZZ_SRC/modules that includes everything it needs, this saves a substantial amount of space
+# Cryptofuzz builds its modules into $CRYPTOFUZZ_SRC/modules that includes everything it needs, deleting the module source
+# code saves a substantial amount of space in the docker image
 rm -rf "$MODULES_ROOT"


### PR DESCRIPTION
### Issues:
Resolves Cryptofuzz ARM failures due to this issue and latest Windows Docker container issue.

### Description of changes: 
Cryptofuzz previously required changes from BoringSSL not yet merged into AWS-LC. With the recent merge we can use the latest version again.

This change also uses the older tag of our Windows Docker image while we investigate why the latest built one is failing.

### Testing:
Built image into my personal account for testing and the main AWS-LC one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
