### PR TITLE
CryptoAlg-740: Adding the doubling case analysis in p384.c

### DIFF
--- a/crypto/fipsmodule/ec/simple_mul.c
+++ b/crypto/fipsmodule/ec/simple_mul.c
@@ -33,10 +33,8 @@ void ec_GFp_mont_mul(const EC_GROUP *group, EC_RAW_POINT *r,
   ec_GFp_simple_point_copy(&precomp[1], p);
   for (size_t j = 2; j < OPENSSL_ARRAY_SIZE(precomp); j++) {
     if (j & 1) {
-//      ec_GFp_mont_add(group, &precomp[j], &precomp[1], &precomp[j - 1]); //TBD
         group->meth->add(group, &precomp[j], &precomp[1], &precomp[j - 1]);
     } else {
-//      ec_GFp_mont_dbl(group, &precomp[j], &precomp[j / 2]); //TBD
         group->meth->dbl(group, &precomp[j], &precomp[j / 2]);
     }
   }
@@ -46,7 +44,6 @@ void ec_GFp_mont_mul(const EC_GROUP *group, EC_RAW_POINT *r,
   int r_is_at_infinity = 1;
   for (unsigned i = bits - 1; i < bits; i--) {
     if (!r_is_at_infinity) {
-//      ec_GFp_mont_dbl(group, r, r);  //TBD
         group->meth->dbl(group, r, r);
     }
     if (i % 5 == 0) {
@@ -70,7 +67,6 @@ void ec_GFp_mont_mul(const EC_GROUP *group, EC_RAW_POINT *r,
         ec_GFp_simple_point_copy(r, &tmp);
         r_is_at_infinity = 0;
       } else {
-//        ec_GFp_mont_add(group, r, r, &tmp); //TBD
           group->meth->add(group, r, r, &tmp);
       }
     }

--- a/crypto/fipsmodule/ec/wnaf.c
+++ b/crypto/fipsmodule/ec/wnaf.c
@@ -231,7 +231,6 @@ int ec_GFp_mont_mul_public_batch(const EC_GROUP *group, EC_RAW_POINT *r,
   int r_is_at_infinity = 1;
   for (size_t k = wNAF_len - 1; k < wNAF_len; k--) {
     if (!r_is_at_infinity) {
-//      ec_GFp_mont_dbl(group, r, r); // TBD
       group->meth->dbl(group, r, r);
     }
 
@@ -241,7 +240,6 @@ int ec_GFp_mont_mul_public_batch(const EC_GROUP *group, EC_RAW_POINT *r,
         ec_GFp_simple_point_copy(r, &tmp);
         r_is_at_infinity = 0;
       } else {
-//        ec_GFp_mont_add(group, r, r, &tmp); // TBD
         group->meth->add(group, r, r, &tmp);
       }
     }
@@ -253,7 +251,6 @@ int ec_GFp_mont_mul_public_batch(const EC_GROUP *group, EC_RAW_POINT *r,
           ec_GFp_simple_point_copy(r, &tmp);
           r_is_at_infinity = 0;
         } else {
-//        ec_GFp_mont_add(group, r, r, &tmp); // TBD
         group->meth->add(group, r, r, &tmp);
         }
       }


### PR DESCRIPTION
### Issues:
CryptoAlg-740

### Description of changes: 
- This change appends the analysis of non-trivial doubling case when using the Joye_Tunstall recoding (AFRICACRYPT `09).
- Also Removed the commented lines with TBD in wnaf.c and simple_mul.c
  so they continue to call the underlying algorithms from EC_METHOD and not from ec_montgomery.c
- Fixed few typos.

### Call-outs:
- This analysis can be moved to util.c if the recoding is used
  with other curves than P-384 and is made generic in the size of w.

### Testing:
The attached python script tests the values mentioned in this analysis.
[JTrecoding.py.txt](https://github.com/awslabs/aws-lc/files/6352488/JTrecoding.py.txt)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
