### PR TITLE
Add FIPS aarch POC build to CI.

### DIFF
--- a/generated-src/ios-aarch64/crypto/fipsmodule/p256-armv8-asm.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/p256-armv8-asm.S
@@ -133,31 +133,6 @@ _ecp_nistz256_sqr_mont:
 	ret
 
 
-// void	ecp_nistz256_add(BN_ULONG x0[4],const BN_ULONG x1[4],
-//					const BN_ULONG x2[4]);
-.globl	_ecp_nistz256_add
-.private_extern	_ecp_nistz256_add
-
-.align	4
-_ecp_nistz256_add:
-.long	0xd503233f		// paciasp
-	stp	x29,x30,[sp,#-16]!
-	add	x29,sp,#0
-
-	ldp	x14,x15,[x1]
-	ldp	x8,x9,[x2]
-	ldp	x16,x17,[x1,#16]
-	ldp	x10,x11,[x2,#16]
-	ldr	x12,Lpoly+8
-	ldr	x13,Lpoly+24
-
-	bl	__ecp_nistz256_add
-
-	ldp	x29,x30,[sp],#16
-.long	0xd50323bf		// autiasp
-	ret
-
-
 // void	ecp_nistz256_div_by_2(BN_ULONG x0[4],const BN_ULONG x1[4]);
 .globl	_ecp_nistz256_div_by_2
 .private_extern	_ecp_nistz256_div_by_2
@@ -199,7 +174,7 @@ _ecp_nistz256_mul_by_2:
 	mov	x10,x16
 	mov	x11,x17
 
-	bl	__ecp_nistz256_add	// ret = a+a	// 2*a
+	bl	__ecp_nistz256_add_to	// ret = a+a	// 2*a
 
 	ldp	x29,x30,[sp],#16
 .long	0xd50323bf		// autiasp
@@ -229,14 +204,14 @@ _ecp_nistz256_mul_by_3:
 	mov	x6,x16
 	mov	x7,x17
 
-	bl	__ecp_nistz256_add	// ret = a+a	// 2*a
+	bl	__ecp_nistz256_add_to	// ret = a+a	// 2*a
 
 	mov	x8,x4
 	mov	x9,x5
 	mov	x10,x6
 	mov	x11,x7
 
-	bl	__ecp_nistz256_add	// ret += a	// 2*a+a=3*a
+	bl	__ecp_nistz256_add_to	// ret += a	// 2*a+a=3*a
 
 	ldp	x29,x30,[sp],#16
 .long	0xd50323bf		// autiasp
@@ -550,12 +525,12 @@ __ecp_nistz256_sqr_mont:
 	ret
 
 
-// Note that __ecp_nistz256_add expects both input vectors pre-loaded to
+// Note that __ecp_nistz256_add_to expects both input vectors pre-loaded to
 // x4-x7 and x8-x11. This is done because it's used in multiple
 // contexts, e.g. in multiplication by 2 and 3...
 
 .align	4
-__ecp_nistz256_add:
+__ecp_nistz256_add_to:
 	adds	x14,x14,x8		// ret = a+b
 	adcs	x15,x15,x9
 	adcs	x16,x16,x10
@@ -687,7 +662,7 @@ Ldouble_shortcut:
 	mov	x11,x17
 	ldp	x6,x7,[x22,#64+16]
 	add	x0,sp,#0
-	bl	__ecp_nistz256_add	// p256_mul_by_2(S, in_y);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(S, in_y);
 
 	add	x0,sp,#64
 	bl	__ecp_nistz256_sqr_mont	// p256_sqr_mont(Zsqr, in_z);
@@ -699,7 +674,7 @@ Ldouble_shortcut:
 	mov	x6,x16
 	mov	x7,x17
 	add	x0,sp,#32
-	bl	__ecp_nistz256_add	// p256_add(M, Zsqr, in_x);
+	bl	__ecp_nistz256_add_to	// p256_add(M, Zsqr, in_x);
 
 	add	x2,x22,#0
 	mov	x14,x4		// restore Zsqr
@@ -728,7 +703,7 @@ Ldouble_shortcut:
 	mov	x11,x17
 	ldp	x6,x7,[sp,#0+16]
 	add	x0,x21,#64
-	bl	__ecp_nistz256_add	// p256_mul_by_2(res_z, tmp0);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(res_z, tmp0);
 
 	add	x0,sp,#96
 	bl	__ecp_nistz256_sqr_mont	// p256_sqr_mont(tmp0, S);
@@ -752,7 +727,7 @@ Ldouble_shortcut:
 	mov	x6,x16
 	mov	x7,x17
 	add	x0,sp,#32
-	bl	__ecp_nistz256_add
+	bl	__ecp_nistz256_add_to
 	mov	x8,x4			// restore M
 	mov	x9,x5
 	ldr	x3,[x22]		// forward load for p256_mul_mont
@@ -760,7 +735,7 @@ Ldouble_shortcut:
 	ldp	x4,x5,[sp,#0]
 	mov	x11,x7
 	ldp	x6,x7,[sp,#0+16]
-	bl	__ecp_nistz256_add	// p256_mul_by_3(M, M);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_3(M, M);
 
 	add	x2,x22,#0
 	add	x0,sp,#0
@@ -773,7 +748,7 @@ Ldouble_shortcut:
 	mov	x11,x17
 	ldp	x6,x7,[sp,#32+16]
 	add	x0,sp,#96
-	bl	__ecp_nistz256_add	// p256_mul_by_2(tmp0, S);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(tmp0, S);
 
 	add	x0,x21,#0
 	bl	__ecp_nistz256_sqr_mont	// p256_sqr_mont(res_x, M);
@@ -917,7 +892,7 @@ Ladd_double:
 	ldp	x23,x24,[x29,#48]
 	ldp	x25,x26,[x29,#64]
 	ldp	x27,x28,[x29,#80]
-	add	sp,sp,#32*(12-4)	// difference in stack frames
+	add	sp,sp,#256	// #256 is from #32*(12-4). difference in stack frames
 	b	Ldouble_shortcut
 
 .align	4
@@ -963,7 +938,7 @@ Ladd_proceed:
 	mov	x10,x16
 	mov	x11,x17
 	add	x0,sp,#128
-	bl	__ecp_nistz256_add	// p256_mul_by_2(Hsqr, U2);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(Hsqr, U2);
 
 	add	x2,sp,#192
 	add	x0,sp,#0
@@ -1171,7 +1146,7 @@ _ecp_nistz256_point_add_affine:
 	mov	x10,x16
 	mov	x11,x17
 	add	x0,sp,#224
-	bl	__ecp_nistz256_add	// p256_mul_by_2(Hsqr, U2);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(Hsqr, U2);
 
 	add	x2,sp,#288
 	add	x0,sp,#0

--- a/generated-src/linux-aarch64/crypto/fipsmodule/p256-armv8-asm.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/p256-armv8-asm.S
@@ -134,31 +134,6 @@ ecp_nistz256_sqr_mont:
 	ret
 .size	ecp_nistz256_sqr_mont,.-ecp_nistz256_sqr_mont
 
-// void	ecp_nistz256_add(BN_ULONG x0[4],const BN_ULONG x1[4],
-//					const BN_ULONG x2[4]);
-.globl	ecp_nistz256_add
-.hidden	ecp_nistz256_add
-.type	ecp_nistz256_add,%function
-.align	4
-ecp_nistz256_add:
-.inst	0xd503233f		// paciasp
-	stp	x29,x30,[sp,#-16]!
-	add	x29,sp,#0
-
-	ldp	x14,x15,[x1]
-	ldp	x8,x9,[x2]
-	ldp	x16,x17,[x1,#16]
-	ldp	x10,x11,[x2,#16]
-	ldr	x12,.Lpoly+8
-	ldr	x13,.Lpoly+24
-
-	bl	__ecp_nistz256_add
-
-	ldp	x29,x30,[sp],#16
-.inst	0xd50323bf		// autiasp
-	ret
-.size	ecp_nistz256_add,.-ecp_nistz256_add
-
 // void	ecp_nistz256_div_by_2(BN_ULONG x0[4],const BN_ULONG x1[4]);
 .globl	ecp_nistz256_div_by_2
 .hidden	ecp_nistz256_div_by_2
@@ -200,7 +175,7 @@ ecp_nistz256_mul_by_2:
 	mov	x10,x16
 	mov	x11,x17
 
-	bl	__ecp_nistz256_add	// ret = a+a	// 2*a
+	bl	__ecp_nistz256_add_to	// ret = a+a	// 2*a
 
 	ldp	x29,x30,[sp],#16
 .inst	0xd50323bf		// autiasp
@@ -230,14 +205,14 @@ ecp_nistz256_mul_by_3:
 	mov	x6,x16
 	mov	x7,x17
 
-	bl	__ecp_nistz256_add	// ret = a+a	// 2*a
+	bl	__ecp_nistz256_add_to	// ret = a+a	// 2*a
 
 	mov	x8,x4
 	mov	x9,x5
 	mov	x10,x6
 	mov	x11,x7
 
-	bl	__ecp_nistz256_add	// ret += a	// 2*a+a=3*a
+	bl	__ecp_nistz256_add_to	// ret += a	// 2*a+a=3*a
 
 	ldp	x29,x30,[sp],#16
 .inst	0xd50323bf		// autiasp
@@ -551,12 +526,12 @@ __ecp_nistz256_sqr_mont:
 	ret
 .size	__ecp_nistz256_sqr_mont,.-__ecp_nistz256_sqr_mont
 
-// Note that __ecp_nistz256_add expects both input vectors pre-loaded to
+// Note that __ecp_nistz256_add_to expects both input vectors pre-loaded to
 // x4-x7 and x8-x11. This is done because it's used in multiple
 // contexts, e.g. in multiplication by 2 and 3...
-.type	__ecp_nistz256_add,%function
+.type	__ecp_nistz256_add_to,%function
 .align	4
-__ecp_nistz256_add:
+__ecp_nistz256_add_to:
 	adds	x14,x14,x8		// ret = a+b
 	adcs	x15,x15,x9
 	adcs	x16,x16,x10
@@ -577,7 +552,7 @@ __ecp_nistz256_add:
 	stp	x16,x17,[x0,#16]
 
 	ret
-.size	__ecp_nistz256_add,.-__ecp_nistz256_add
+.size	__ecp_nistz256_add_to,.-__ecp_nistz256_add_to
 
 .type	__ecp_nistz256_sub_from,%function
 .align	4
@@ -688,7 +663,7 @@ ecp_nistz256_point_double:
 	mov	x11,x17
 	ldp	x6,x7,[x22,#64+16]
 	add	x0,sp,#0
-	bl	__ecp_nistz256_add	// p256_mul_by_2(S, in_y);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(S, in_y);
 
 	add	x0,sp,#64
 	bl	__ecp_nistz256_sqr_mont	// p256_sqr_mont(Zsqr, in_z);
@@ -700,7 +675,7 @@ ecp_nistz256_point_double:
 	mov	x6,x16
 	mov	x7,x17
 	add	x0,sp,#32
-	bl	__ecp_nistz256_add	// p256_add(M, Zsqr, in_x);
+	bl	__ecp_nistz256_add_to	// p256_add(M, Zsqr, in_x);
 
 	add	x2,x22,#0
 	mov	x14,x4		// restore Zsqr
@@ -729,7 +704,7 @@ ecp_nistz256_point_double:
 	mov	x11,x17
 	ldp	x6,x7,[sp,#0+16]
 	add	x0,x21,#64
-	bl	__ecp_nistz256_add	// p256_mul_by_2(res_z, tmp0);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(res_z, tmp0);
 
 	add	x0,sp,#96
 	bl	__ecp_nistz256_sqr_mont	// p256_sqr_mont(tmp0, S);
@@ -753,7 +728,7 @@ ecp_nistz256_point_double:
 	mov	x6,x16
 	mov	x7,x17
 	add	x0,sp,#32
-	bl	__ecp_nistz256_add
+	bl	__ecp_nistz256_add_to
 	mov	x8,x4			// restore M
 	mov	x9,x5
 	ldr	x3,[x22]		// forward load for p256_mul_mont
@@ -761,7 +736,7 @@ ecp_nistz256_point_double:
 	ldp	x4,x5,[sp,#0]
 	mov	x11,x7
 	ldp	x6,x7,[sp,#0+16]
-	bl	__ecp_nistz256_add	// p256_mul_by_3(M, M);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_3(M, M);
 
 	add	x2,x22,#0
 	add	x0,sp,#0
@@ -774,7 +749,7 @@ ecp_nistz256_point_double:
 	mov	x11,x17
 	ldp	x6,x7,[sp,#32+16]
 	add	x0,sp,#96
-	bl	__ecp_nistz256_add	// p256_mul_by_2(tmp0, S);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(tmp0, S);
 
 	add	x0,x21,#0
 	bl	__ecp_nistz256_sqr_mont	// p256_sqr_mont(res_x, M);
@@ -918,7 +893,7 @@ ecp_nistz256_point_add:
 	ldp	x23,x24,[x29,#48]
 	ldp	x25,x26,[x29,#64]
 	ldp	x27,x28,[x29,#80]
-	add	sp,sp,#32*(12-4)	// difference in stack frames
+	add	sp,sp,#256	// #256 is from #32*(12-4). difference in stack frames
 	b	.Ldouble_shortcut
 
 .align	4
@@ -964,7 +939,7 @@ ecp_nistz256_point_add:
 	mov	x10,x16
 	mov	x11,x17
 	add	x0,sp,#128
-	bl	__ecp_nistz256_add	// p256_mul_by_2(Hsqr, U2);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(Hsqr, U2);
 
 	add	x2,sp,#192
 	add	x0,sp,#0
@@ -1172,7 +1147,7 @@ ecp_nistz256_point_add_affine:
 	mov	x10,x16
 	mov	x11,x17
 	add	x0,sp,#224
-	bl	__ecp_nistz256_add	// p256_mul_by_2(Hsqr, U2);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(Hsqr, U2);
 
 	add	x2,sp,#288
 	add	x0,sp,#0

--- a/generated-src/win-aarch64/crypto/fipsmodule/p256-armv8-asm.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/p256-armv8-asm.S
@@ -142,33 +142,6 @@ ecp_nistz256_sqr_mont:
 	ret
 
 
-// void	ecp_nistz256_add(BN_ULONG x0[4],const BN_ULONG x1[4],
-//					const BN_ULONG x2[4]);
-.globl	ecp_nistz256_add
-
-.def ecp_nistz256_add
-   .type 32
-.endef
-.align	4
-ecp_nistz256_add:
-.long	0xd503233f		// paciasp
-	stp	x29,x30,[sp,#-16]!
-	add	x29,sp,#0
-
-	ldp	x14,x15,[x1]
-	ldp	x8,x9,[x2]
-	ldp	x16,x17,[x1,#16]
-	ldp	x10,x11,[x2,#16]
-	ldr	x12,Lpoly+8
-	ldr	x13,Lpoly+24
-
-	bl	__ecp_nistz256_add
-
-	ldp	x29,x30,[sp],#16
-.long	0xd50323bf		// autiasp
-	ret
-
-
 // void	ecp_nistz256_div_by_2(BN_ULONG x0[4],const BN_ULONG x1[4]);
 .globl	ecp_nistz256_div_by_2
 
@@ -214,7 +187,7 @@ ecp_nistz256_mul_by_2:
 	mov	x10,x16
 	mov	x11,x17
 
-	bl	__ecp_nistz256_add	// ret = a+a	// 2*a
+	bl	__ecp_nistz256_add_to	// ret = a+a	// 2*a
 
 	ldp	x29,x30,[sp],#16
 .long	0xd50323bf		// autiasp
@@ -246,14 +219,14 @@ ecp_nistz256_mul_by_3:
 	mov	x6,x16
 	mov	x7,x17
 
-	bl	__ecp_nistz256_add	// ret = a+a	// 2*a
+	bl	__ecp_nistz256_add_to	// ret = a+a	// 2*a
 
 	mov	x8,x4
 	mov	x9,x5
 	mov	x10,x6
 	mov	x11,x7
 
-	bl	__ecp_nistz256_add	// ret += a	// 2*a+a=3*a
+	bl	__ecp_nistz256_add_to	// ret += a	// 2*a+a=3*a
 
 	ldp	x29,x30,[sp],#16
 .long	0xd50323bf		// autiasp
@@ -575,14 +548,14 @@ __ecp_nistz256_sqr_mont:
 	ret
 
 
-// Note that __ecp_nistz256_add expects both input vectors pre-loaded to
+// Note that __ecp_nistz256_add_to expects both input vectors pre-loaded to
 // x4-x7 and x8-x11. This is done because it's used in multiple
 // contexts, e.g. in multiplication by 2 and 3...
-.def __ecp_nistz256_add
+.def __ecp_nistz256_add_to
    .type 32
 .endef
 .align	4
-__ecp_nistz256_add:
+__ecp_nistz256_add_to:
 	adds	x14,x14,x8		// ret = a+b
 	adcs	x15,x15,x9
 	adcs	x16,x16,x10
@@ -722,7 +695,7 @@ Ldouble_shortcut:
 	mov	x11,x17
 	ldp	x6,x7,[x22,#64+16]
 	add	x0,sp,#0
-	bl	__ecp_nistz256_add	// p256_mul_by_2(S, in_y);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(S, in_y);
 
 	add	x0,sp,#64
 	bl	__ecp_nistz256_sqr_mont	// p256_sqr_mont(Zsqr, in_z);
@@ -734,7 +707,7 @@ Ldouble_shortcut:
 	mov	x6,x16
 	mov	x7,x17
 	add	x0,sp,#32
-	bl	__ecp_nistz256_add	// p256_add(M, Zsqr, in_x);
+	bl	__ecp_nistz256_add_to	// p256_add(M, Zsqr, in_x);
 
 	add	x2,x22,#0
 	mov	x14,x4		// restore Zsqr
@@ -763,7 +736,7 @@ Ldouble_shortcut:
 	mov	x11,x17
 	ldp	x6,x7,[sp,#0+16]
 	add	x0,x21,#64
-	bl	__ecp_nistz256_add	// p256_mul_by_2(res_z, tmp0);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(res_z, tmp0);
 
 	add	x0,sp,#96
 	bl	__ecp_nistz256_sqr_mont	// p256_sqr_mont(tmp0, S);
@@ -787,7 +760,7 @@ Ldouble_shortcut:
 	mov	x6,x16
 	mov	x7,x17
 	add	x0,sp,#32
-	bl	__ecp_nistz256_add
+	bl	__ecp_nistz256_add_to
 	mov	x8,x4			// restore M
 	mov	x9,x5
 	ldr	x3,[x22]		// forward load for p256_mul_mont
@@ -795,7 +768,7 @@ Ldouble_shortcut:
 	ldp	x4,x5,[sp,#0]
 	mov	x11,x7
 	ldp	x6,x7,[sp,#0+16]
-	bl	__ecp_nistz256_add	// p256_mul_by_3(M, M);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_3(M, M);
 
 	add	x2,x22,#0
 	add	x0,sp,#0
@@ -808,7 +781,7 @@ Ldouble_shortcut:
 	mov	x11,x17
 	ldp	x6,x7,[sp,#32+16]
 	add	x0,sp,#96
-	bl	__ecp_nistz256_add	// p256_mul_by_2(tmp0, S);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(tmp0, S);
 
 	add	x0,x21,#0
 	bl	__ecp_nistz256_sqr_mont	// p256_sqr_mont(res_x, M);
@@ -954,7 +927,7 @@ Ladd_double:
 	ldp	x23,x24,[x29,#48]
 	ldp	x25,x26,[x29,#64]
 	ldp	x27,x28,[x29,#80]
-	add	sp,sp,#32*(12-4)	// difference in stack frames
+	add	sp,sp,#256	// #256 is from #32*(12-4). difference in stack frames
 	b	Ldouble_shortcut
 
 .align	4
@@ -1000,7 +973,7 @@ Ladd_proceed:
 	mov	x10,x16
 	mov	x11,x17
 	add	x0,sp,#128
-	bl	__ecp_nistz256_add	// p256_mul_by_2(Hsqr, U2);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(Hsqr, U2);
 
 	add	x2,sp,#192
 	add	x0,sp,#0
@@ -1210,7 +1183,7 @@ ecp_nistz256_point_add_affine:
 	mov	x10,x16
 	mov	x11,x17
 	add	x0,sp,#224
-	bl	__ecp_nistz256_add	// p256_mul_by_2(Hsqr, U2);
+	bl	__ecp_nistz256_add_to	// p256_mul_by_2(Hsqr, U2);
 
 	add	x2,sp,#288
 	add	x0,sp,#0

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -97,7 +97,6 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:amazonlinux-2_clang-7x_latest
         variables:
-          AWS_LC_GO_TEST_TIMEOUT: 60m
           # AL2 Clang-7 does not support AddressSanitizer. Related ticket is linked in CryptoAlg-694.
           # https://github.com/awslabs/aws-lc/pull/120#issuecomment-808439279
           AWSLC_NO_ASM_FIPS: 0

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -38,6 +38,7 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-7x_latest
         variables:
+          AWS_LC_GO_TEST_TIMEOUT: 60m
           AWSLC_NO_ASM_FIPS: 1
 
     - identifier: ubuntu2004_clang8x_aarch

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -38,6 +38,7 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-7x_latest
         variables:
+          # AWS_LC_GO_TEST_TIMEOUT is needed on aarch when ASAN is enabled because the ASAN is very slow.
           AWS_LC_GO_TEST_TIMEOUT: 120m
           AWSLC_NO_ASM_FIPS: 1
 

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -38,7 +38,7 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-7x_latest
         variables:
-          AWS_LC_GO_TEST_TIMEOUT: 60m
+          AWS_LC_GO_TEST_TIMEOUT: 120m
           AWSLC_NO_ASM_FIPS: 1
 
     - identifier: ubuntu2004_clang8x_aarch

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -30,6 +30,16 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-7x_latest
 
+    - identifier: ubuntu2004_clang7x_aarch_fips
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_fips_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-7x_latest
+        variables:
+          AWSLC_NO_ASM_FIPS: 1
+
     - identifier: ubuntu2004_clang8x_aarch
       buildspec: ./tests/ci/codebuild/linux-aarch/run_posix_tests.yml
       env:
@@ -77,3 +87,16 @@ batch:
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:amazonlinux-2_clang-7x_latest
+
+    - identifier: amazonlinux2_clang7x_aarch_fips
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_fips_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_clang-7x_latest
+        variables:
+          AWS_LC_GO_TEST_TIMEOUT: 60m
+          # AL2 Clang-7 does not support AddressSanitizer. Related ticket is linked in CryptoAlg-694.
+          # https://github.com/awslabs/aws-lc/pull/120#issuecomment-808439279
+          AWSLC_NO_ASM_FIPS: 0

--- a/util/fipstools/delocate/README.md
+++ b/util/fipstools/delocate/README.md
@@ -1,0 +1,22 @@
+### Convert delocate.peg to delocate.peg.go
+
+Below shell script should be execute under the directory having `delocate.peg`.
+```shell script
+# Clone peg.
+git clone https://github.com/pointlander/peg
+cd peg
+
+# Building.
+go run build.go
+
+# After build, 'peg' executable is available under current dir.
+# Below command can tell the https://github.com/pointlander/peg#usage
+./peg --help
+
+# Generate delocate.peg.go by running below command.
+cd ..
+./peg/peg delocate.peg
+
+# Clean up.
+rm -rf peg
+```           

--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -509,7 +509,7 @@ func (d *delocation) processAarch64Instruction(statement, instruction *node32) (
 				// This is a branch. Either the target needs to be written to a local
 				// version of the symbol to ensure that no relocations are emitted, or
 				// it needs to jump to a redirector function.
-				symbol, _, _, didChange, symbolIsLocal, _ := d.parseMemRef(arg.up)
+				symbol, offset, _, didChange, symbolIsLocal, _ := d.parseMemRef(arg.up)
 				changed = didChange
 
 				if _, knownSymbol := d.symbols[symbol]; knownSymbol {
@@ -520,6 +520,13 @@ func (d *delocation) processAarch64Instruction(statement, instruction *node32) (
 					d.redirectors[symbol] = redirector
 					symbol = redirector
 					changed = true
+				} else if didChange && symbolIsLocal && len(offset) > 0 {
+					// didChange is set when the inputFile index is not 0; which is the index of the
+					// first file copied to the output, which is the generated assembly of bcm.c.
+					// In subsequently copied assembly files, local symbols are changed by appending (BCM_ + index)
+					// in order to ensure they don't collide. `index` gets incremented per file.
+					// If there is offset after the symbol, append the `offset`.
+					symbol = symbol + offset
 				}
 
 				args = append(args, symbol)

--- a/util/fipstools/delocate/delocate.peg
+++ b/util/fipstools/delocate/delocate.peg
@@ -89,7 +89,7 @@ MemoryRef <- (SymbolRef BaseIndexScale /
               BaseIndexScale)
 SymbolRef <- (Offset* '+')? (LocalSymbol / SymbolName) Offset* ('@' Section Offset*)?
 Low12BitsSymbolRef <- ":lo12:" (LocalSymbol / SymbolName) Offset?
-ARMBaseIndexScale <- '[' ARMRegister (',' WS? (('#' Offset ('*' [0-9]+)? ) / ARMGOTLow12 / Low12BitsSymbolRef / ARMRegister) (',' WS? ARMConstantTweak)?)? ']' ARMPostincrement?
+ARMBaseIndexScale <- '[' ARMRegister (',' WS? (('#' Offset (('*' [0-9]+) / ('*' '(' [0-9]+ Operator [0-9]+ ')') / (('+' [0-9]+)*))? ) / ARMGOTLow12 / Low12BitsSymbolRef / ARMRegister) (',' WS? ARMConstantTweak)?)? ']' ARMPostincrement?
 ARMGOTLow12 <- ":got_lo12:" SymbolName
 ARMPostincrement <- '!'
 BaseIndexScale <- '(' RegisterOrConstant? WS? (',' WS? RegisterOrConstant WS? (',' [0-9]+)? )? ')'

--- a/util/fipstools/delocate/delocate.peg.go
+++ b/util/fipstools/delocate/delocate.peg.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
-	"math"
+	"io"
+	"os"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 const endSymbol rune = 1114112
@@ -136,19 +138,19 @@ type node32 struct {
 	up, next *node32
 }
 
-func (node *node32) print(pretty bool, buffer string) {
+func (node *node32) print(w io.Writer, pretty bool, buffer string) {
 	var print func(node *node32, depth int)
 	print = func(node *node32, depth int) {
 		for node != nil {
 			for c := 0; c < depth; c++ {
-				fmt.Printf(" ")
+				fmt.Fprintf(w, " ")
 			}
 			rule := rul3s[node.pegRule]
 			quote := strconv.Quote(string(([]rune(buffer)[node.begin:node.end])))
 			if !pretty {
-				fmt.Printf("%v %v\n", rule, quote)
+				fmt.Fprintf(w, "%v %v\n", rule, quote)
 			} else {
-				fmt.Printf("\x1B[34m%v\x1B[m %v\n", rule, quote)
+				fmt.Fprintf(w, "\x1B[36m%v\x1B[m %v\n", rule, quote)
 			}
 			if node.up != nil {
 				print(node.up, depth+1)
@@ -159,12 +161,12 @@ func (node *node32) print(pretty bool, buffer string) {
 	print(node, 0)
 }
 
-func (node *node32) Print(buffer string) {
-	node.print(false, buffer)
+func (node *node32) Print(w io.Writer, buffer string) {
+	node.print(w, false, buffer)
 }
 
-func (node *node32) PrettyPrint(buffer string) {
-	node.print(true, buffer)
+func (node *node32) PrettyPrint(w io.Writer, buffer string) {
+	node.print(w, true, buffer)
 }
 
 type tokens32 struct {
@@ -207,24 +209,24 @@ func (t *tokens32) AST() *node32 {
 }
 
 func (t *tokens32) PrintSyntaxTree(buffer string) {
-	t.AST().Print(buffer)
+	t.AST().Print(os.Stdout, buffer)
+}
+
+func (t *tokens32) WriteSyntaxTree(w io.Writer, buffer string) {
+	t.AST().Print(w, buffer)
 }
 
 func (t *tokens32) PrettyPrintSyntaxTree(buffer string) {
-	t.AST().PrettyPrint(buffer)
+	t.AST().PrettyPrint(os.Stdout, buffer)
 }
 
 func (t *tokens32) Add(rule pegRule, begin, end, index uint32) {
-	if tree := t.tree; int(index) >= len(tree) {
-		expanded := make([]token32, 2*len(tree))
-		copy(expanded, tree)
-		t.tree = expanded
+	tree, i := t.tree, int(index)
+	if i >= len(tree) {
+		t.tree = append(tree, token32{pegRule: rule, begin: begin, end: end})
+		return
 	}
-	t.tree[index] = token32{
-		pegRule: rule,
-		begin:   begin,
-		end:     end,
-	}
+	tree[i] = token32{pegRule: rule, begin: begin, end: end}
 }
 
 func (t *tokens32) Tokens() []token32 {
@@ -286,7 +288,7 @@ type parseError struct {
 }
 
 func (e *parseError) Error() string {
-	tokens, error := []token32{e.max}, "\n"
+	tokens, err := []token32{e.max}, "\n"
 	positions, p := make([]int, 2*len(tokens)), 0
 	for _, token := range tokens {
 		positions[p], p = int(token.begin), p+1
@@ -299,14 +301,14 @@ func (e *parseError) Error() string {
 	}
 	for _, token := range tokens {
 		begin, end := int(token.begin), int(token.end)
-		error += fmt.Sprintf(format,
+		err += fmt.Sprintf(format,
 			rul3s[token.pegRule],
 			translations[begin].line, translations[begin].symbol,
 			translations[end].line, translations[end].symbol,
 			strconv.Quote(string(e.p.buffer[begin:end])))
 	}
 
-	return error
+	return err
 }
 
 func (p *Asm) PrintSyntaxTree() {
@@ -317,12 +319,41 @@ func (p *Asm) PrintSyntaxTree() {
 	}
 }
 
-func (p *Asm) Init() {
+func (p *Asm) WriteSyntaxTree(w io.Writer) {
+	p.tokens32.WriteSyntaxTree(w, p.Buffer)
+}
+
+func (p *Asm) SprintSyntaxTree() string {
+	var bldr strings.Builder
+	p.WriteSyntaxTree(&bldr)
+	return bldr.String()
+}
+
+func Pretty(pretty bool) func(*Asm) error {
+	return func(p *Asm) error {
+		p.Pretty = pretty
+		return nil
+	}
+}
+
+func Size(size int) func(*Asm) error {
+	return func(p *Asm) error {
+		p.tokens32 = tokens32{tree: make([]token32, 0, size)}
+		return nil
+	}
+}
+func (p *Asm) Init(options ...func(*Asm) error) error {
 	var (
 		max                  token32
 		position, tokenIndex uint32
 		buffer               []rune
 	)
+	for _, option := range options {
+		err := option(p)
+		if err != nil {
+			return err
+		}
+	}
 	p.reset = func() {
 		max = token32{}
 		position, tokenIndex = 0, 0
@@ -336,7 +367,7 @@ func (p *Asm) Init() {
 	p.reset()
 
 	_rules := p.rules
-	tree := tokens32{tree: make([]token32, math.MaxInt16)}
+	tree := p.tokens32
 	p.parse = func(rule ...int) error {
 		r := 1
 		if len(rule) > 0 {
@@ -5402,7 +5433,7 @@ func (p *Asm) Init() {
 			position, tokenIndex = position681, tokenIndex681
 			return false
 		},
-		/* 43 ARMBaseIndexScale <- <('[' ARMRegister (',' WS? (('#' Offset ('*' [0-9]+)?) / ARMGOTLow12 / Low12BitsSymbolRef / ARMRegister) (',' WS? ARMConstantTweak)?)? ']' ARMPostincrement?)> */
+		/* 43 ARMBaseIndexScale <- <('[' ARMRegister (',' WS? (('#' Offset (('*' [0-9]+) / ('*' '(' [0-9]+ Operator [0-9]+ ')') / ('+' [0-9]+)*)?) / ARMGOTLow12 / Low12BitsSymbolRef / ARMRegister) (',' WS? ARMConstantTweak)?)? ']' ARMPostincrement?)> */
 		func() bool {
 			position691, tokenIndex691 := position, tokenIndex
 			{
@@ -5441,27 +5472,108 @@ func (p *Asm) Init() {
 						}
 						{
 							position699, tokenIndex699 := position, tokenIndex
-							if buffer[position] != rune('*') {
-								goto l699
-							}
-							position++
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l699
-							}
-							position++
-						l701:
 							{
-								position702, tokenIndex702 := position, tokenIndex
+								position701, tokenIndex701 := position, tokenIndex
+								if buffer[position] != rune('*') {
+									goto l702
+								}
+								position++
 								if c := buffer[position]; c < rune('0') || c > rune('9') {
 									goto l702
 								}
 								position++
+							l703:
+								{
+									position704, tokenIndex704 := position, tokenIndex
+									if c := buffer[position]; c < rune('0') || c > rune('9') {
+										goto l704
+									}
+									position++
+									goto l703
+								l704:
+									position, tokenIndex = position704, tokenIndex704
+								}
 								goto l701
 							l702:
-								position, tokenIndex = position702, tokenIndex702
+								position, tokenIndex = position701, tokenIndex701
+								if buffer[position] != rune('*') {
+									goto l705
+								}
+								position++
+								if buffer[position] != rune('(') {
+									goto l705
+								}
+								position++
+								if c := buffer[position]; c < rune('0') || c > rune('9') {
+									goto l705
+								}
+								position++
+							l706:
+								{
+									position707, tokenIndex707 := position, tokenIndex
+									if c := buffer[position]; c < rune('0') || c > rune('9') {
+										goto l707
+									}
+									position++
+									goto l706
+								l707:
+									position, tokenIndex = position707, tokenIndex707
+								}
+								if !_rules[ruleOperator]() {
+									goto l705
+								}
+								if c := buffer[position]; c < rune('0') || c > rune('9') {
+									goto l705
+								}
+								position++
+							l708:
+								{
+									position709, tokenIndex709 := position, tokenIndex
+									if c := buffer[position]; c < rune('0') || c > rune('9') {
+										goto l709
+									}
+									position++
+									goto l708
+								l709:
+									position, tokenIndex = position709, tokenIndex709
+								}
+								if buffer[position] != rune(')') {
+									goto l705
+								}
+								position++
+								goto l701
+							l705:
+								position, tokenIndex = position701, tokenIndex701
+							l710:
+								{
+									position711, tokenIndex711 := position, tokenIndex
+									if buffer[position] != rune('+') {
+										goto l711
+									}
+									position++
+									if c := buffer[position]; c < rune('0') || c > rune('9') {
+										goto l711
+									}
+									position++
+								l712:
+									{
+										position713, tokenIndex713 := position, tokenIndex
+										if c := buffer[position]; c < rune('0') || c > rune('9') {
+											goto l713
+										}
+										position++
+										goto l712
+									l713:
+										position, tokenIndex = position713, tokenIndex713
+									}
+									goto l710
+								l711:
+									position, tokenIndex = position711, tokenIndex711
+								}
 							}
+						l701:
 							goto l700
-						l699:
+
 							position, tokenIndex = position699, tokenIndex699
 						}
 					l700:
@@ -5469,16 +5581,16 @@ func (p *Asm) Init() {
 					l698:
 						position, tokenIndex = position697, tokenIndex697
 						if !_rules[ruleARMGOTLow12]() {
-							goto l703
+							goto l714
 						}
 						goto l697
-					l703:
+					l714:
 						position, tokenIndex = position697, tokenIndex697
 						if !_rules[ruleLow12BitsSymbolRef]() {
-							goto l704
+							goto l715
 						}
 						goto l697
-					l704:
+					l715:
 						position, tokenIndex = position697, tokenIndex697
 						if !_rules[ruleARMRegister]() {
 							goto l693
@@ -5486,29 +5598,29 @@ func (p *Asm) Init() {
 					}
 				l697:
 					{
-						position705, tokenIndex705 := position, tokenIndex
+						position716, tokenIndex716 := position, tokenIndex
 						if buffer[position] != rune(',') {
-							goto l705
+							goto l716
 						}
 						position++
 						{
-							position707, tokenIndex707 := position, tokenIndex
+							position718, tokenIndex718 := position, tokenIndex
 							if !_rules[ruleWS]() {
-								goto l707
+								goto l718
 							}
-							goto l708
-						l707:
-							position, tokenIndex = position707, tokenIndex707
+							goto l719
+						l718:
+							position, tokenIndex = position718, tokenIndex718
 						}
-					l708:
+					l719:
 						if !_rules[ruleARMConstantTweak]() {
-							goto l705
+							goto l716
 						}
-						goto l706
-					l705:
-						position, tokenIndex = position705, tokenIndex705
+						goto l717
+					l716:
+						position, tokenIndex = position716, tokenIndex716
 					}
-				l706:
+				l717:
 					goto l694
 				l693:
 					position, tokenIndex = position693, tokenIndex693
@@ -5519,15 +5631,15 @@ func (p *Asm) Init() {
 				}
 				position++
 				{
-					position709, tokenIndex709 := position, tokenIndex
+					position720, tokenIndex720 := position, tokenIndex
 					if !_rules[ruleARMPostincrement]() {
-						goto l709
+						goto l720
 					}
-					goto l710
-				l709:
-					position, tokenIndex = position709, tokenIndex709
+					goto l721
+				l720:
+					position, tokenIndex = position720, tokenIndex720
 				}
-			l710:
+			l721:
 				add(ruleARMBaseIndexScale, position692)
 			}
 			return true
@@ -5537,566 +5649,567 @@ func (p *Asm) Init() {
 		},
 		/* 44 ARMGOTLow12 <- <(':' ('g' / 'G') ('o' / 'O') ('t' / 'T') '_' ('l' / 'L') ('o' / 'O') '1' '2' ':' SymbolName)> */
 		func() bool {
-			position711, tokenIndex711 := position, tokenIndex
+			position722, tokenIndex722 := position, tokenIndex
 			{
-				position712 := position
+				position723 := position
 				if buffer[position] != rune(':') {
-					goto l711
+					goto l722
 				}
 				position++
 				{
-					position713, tokenIndex713 := position, tokenIndex
+					position724, tokenIndex724 := position, tokenIndex
 					if buffer[position] != rune('g') {
-						goto l714
+						goto l725
 					}
 					position++
-					goto l713
-				l714:
-					position, tokenIndex = position713, tokenIndex713
+					goto l724
+				l725:
+					position, tokenIndex = position724, tokenIndex724
 					if buffer[position] != rune('G') {
-						goto l711
-					}
-					position++
-				}
-			l713:
-				{
-					position715, tokenIndex715 := position, tokenIndex
-					if buffer[position] != rune('o') {
-						goto l716
-					}
-					position++
-					goto l715
-				l716:
-					position, tokenIndex = position715, tokenIndex715
-					if buffer[position] != rune('O') {
-						goto l711
-					}
-					position++
-				}
-			l715:
-				{
-					position717, tokenIndex717 := position, tokenIndex
-					if buffer[position] != rune('t') {
-						goto l718
-					}
-					position++
-					goto l717
-				l718:
-					position, tokenIndex = position717, tokenIndex717
-					if buffer[position] != rune('T') {
-						goto l711
-					}
-					position++
-				}
-			l717:
-				if buffer[position] != rune('_') {
-					goto l711
-				}
-				position++
-				{
-					position719, tokenIndex719 := position, tokenIndex
-					if buffer[position] != rune('l') {
-						goto l720
-					}
-					position++
-					goto l719
-				l720:
-					position, tokenIndex = position719, tokenIndex719
-					if buffer[position] != rune('L') {
-						goto l711
-					}
-					position++
-				}
-			l719:
-				{
-					position721, tokenIndex721 := position, tokenIndex
-					if buffer[position] != rune('o') {
 						goto l722
 					}
 					position++
-					goto l721
-				l722:
-					position, tokenIndex = position721, tokenIndex721
+				}
+			l724:
+				{
+					position726, tokenIndex726 := position, tokenIndex
+					if buffer[position] != rune('o') {
+						goto l727
+					}
+					position++
+					goto l726
+				l727:
+					position, tokenIndex = position726, tokenIndex726
 					if buffer[position] != rune('O') {
-						goto l711
+						goto l722
 					}
 					position++
 				}
-			l721:
+			l726:
+				{
+					position728, tokenIndex728 := position, tokenIndex
+					if buffer[position] != rune('t') {
+						goto l729
+					}
+					position++
+					goto l728
+				l729:
+					position, tokenIndex = position728, tokenIndex728
+					if buffer[position] != rune('T') {
+						goto l722
+					}
+					position++
+				}
+			l728:
+				if buffer[position] != rune('_') {
+					goto l722
+				}
+				position++
+				{
+					position730, tokenIndex730 := position, tokenIndex
+					if buffer[position] != rune('l') {
+						goto l731
+					}
+					position++
+					goto l730
+				l731:
+					position, tokenIndex = position730, tokenIndex730
+					if buffer[position] != rune('L') {
+						goto l722
+					}
+					position++
+				}
+			l730:
+				{
+					position732, tokenIndex732 := position, tokenIndex
+					if buffer[position] != rune('o') {
+						goto l733
+					}
+					position++
+					goto l732
+				l733:
+					position, tokenIndex = position732, tokenIndex732
+					if buffer[position] != rune('O') {
+						goto l722
+					}
+					position++
+				}
+			l732:
 				if buffer[position] != rune('1') {
-					goto l711
+					goto l722
 				}
 				position++
 				if buffer[position] != rune('2') {
-					goto l711
+					goto l722
 				}
 				position++
 				if buffer[position] != rune(':') {
-					goto l711
+					goto l722
 				}
 				position++
 				if !_rules[ruleSymbolName]() {
-					goto l711
+					goto l722
 				}
-				add(ruleARMGOTLow12, position712)
+				add(ruleARMGOTLow12, position723)
 			}
 			return true
-		l711:
-			position, tokenIndex = position711, tokenIndex711
+		l722:
+			position, tokenIndex = position722, tokenIndex722
 			return false
 		},
 		/* 45 ARMPostincrement <- <'!'> */
 		func() bool {
-			position723, tokenIndex723 := position, tokenIndex
+			position734, tokenIndex734 := position, tokenIndex
 			{
-				position724 := position
+				position735 := position
 				if buffer[position] != rune('!') {
-					goto l723
+					goto l734
 				}
 				position++
-				add(ruleARMPostincrement, position724)
+				add(ruleARMPostincrement, position735)
 			}
 			return true
-		l723:
-			position, tokenIndex = position723, tokenIndex723
+		l734:
+			position, tokenIndex = position734, tokenIndex734
 			return false
 		},
 		/* 46 BaseIndexScale <- <('(' RegisterOrConstant? WS? (',' WS? RegisterOrConstant WS? (',' [0-9]+)?)? ')')> */
 		func() bool {
-			position725, tokenIndex725 := position, tokenIndex
+			position736, tokenIndex736 := position, tokenIndex
 			{
-				position726 := position
+				position737 := position
 				if buffer[position] != rune('(') {
-					goto l725
+					goto l736
 				}
 				position++
 				{
-					position727, tokenIndex727 := position, tokenIndex
+					position738, tokenIndex738 := position, tokenIndex
 					if !_rules[ruleRegisterOrConstant]() {
-						goto l727
+						goto l738
 					}
-					goto l728
-				l727:
-					position, tokenIndex = position727, tokenIndex727
+					goto l739
+				l738:
+					position, tokenIndex = position738, tokenIndex738
 				}
-			l728:
+			l739:
 				{
-					position729, tokenIndex729 := position, tokenIndex
+					position740, tokenIndex740 := position, tokenIndex
 					if !_rules[ruleWS]() {
-						goto l729
+						goto l740
 					}
-					goto l730
-				l729:
-					position, tokenIndex = position729, tokenIndex729
+					goto l741
+				l740:
+					position, tokenIndex = position740, tokenIndex740
 				}
-			l730:
+			l741:
 				{
-					position731, tokenIndex731 := position, tokenIndex
+					position742, tokenIndex742 := position, tokenIndex
 					if buffer[position] != rune(',') {
-						goto l731
+						goto l742
 					}
 					position++
 					{
-						position733, tokenIndex733 := position, tokenIndex
+						position744, tokenIndex744 := position, tokenIndex
 						if !_rules[ruleWS]() {
-							goto l733
+							goto l744
 						}
-						goto l734
-					l733:
-						position, tokenIndex = position733, tokenIndex733
+						goto l745
+					l744:
+						position, tokenIndex = position744, tokenIndex744
 					}
-				l734:
+				l745:
 					if !_rules[ruleRegisterOrConstant]() {
-						goto l731
+						goto l742
 					}
 					{
-						position735, tokenIndex735 := position, tokenIndex
+						position746, tokenIndex746 := position, tokenIndex
 						if !_rules[ruleWS]() {
-							goto l735
+							goto l746
 						}
-						goto l736
-					l735:
-						position, tokenIndex = position735, tokenIndex735
+						goto l747
+					l746:
+						position, tokenIndex = position746, tokenIndex746
 					}
-				l736:
+				l747:
 					{
-						position737, tokenIndex737 := position, tokenIndex
+						position748, tokenIndex748 := position, tokenIndex
 						if buffer[position] != rune(',') {
-							goto l737
+							goto l748
 						}
 						position++
 						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l737
+							goto l748
 						}
 						position++
-					l739:
+					l750:
 						{
-							position740, tokenIndex740 := position, tokenIndex
+							position751, tokenIndex751 := position, tokenIndex
 							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l740
+								goto l751
 							}
 							position++
-							goto l739
-						l740:
-							position, tokenIndex = position740, tokenIndex740
+							goto l750
+						l751:
+							position, tokenIndex = position751, tokenIndex751
 						}
-						goto l738
-					l737:
-						position, tokenIndex = position737, tokenIndex737
+						goto l749
+					l748:
+						position, tokenIndex = position748, tokenIndex748
 					}
-				l738:
-					goto l732
-				l731:
-					position, tokenIndex = position731, tokenIndex731
+				l749:
+					goto l743
+				l742:
+					position, tokenIndex = position742, tokenIndex742
 				}
-			l732:
+			l743:
 				if buffer[position] != rune(')') {
-					goto l725
+					goto l736
 				}
 				position++
-				add(ruleBaseIndexScale, position726)
+				add(ruleBaseIndexScale, position737)
 			}
 			return true
-		l725:
-			position, tokenIndex = position725, tokenIndex725
+		l736:
+			position, tokenIndex = position736, tokenIndex736
 			return false
 		},
 		/* 47 Operator <- <('+' / '-')> */
 		func() bool {
-			position741, tokenIndex741 := position, tokenIndex
+			position752, tokenIndex752 := position, tokenIndex
 			{
-				position742 := position
+				position753 := position
 				{
-					position743, tokenIndex743 := position, tokenIndex
+					position754, tokenIndex754 := position, tokenIndex
 					if buffer[position] != rune('+') {
-						goto l744
+						goto l755
 					}
 					position++
-					goto l743
-				l744:
-					position, tokenIndex = position743, tokenIndex743
+					goto l754
+				l755:
+					position, tokenIndex = position754, tokenIndex754
 					if buffer[position] != rune('-') {
-						goto l741
+						goto l752
 					}
 					position++
 				}
-			l743:
-				add(ruleOperator, position742)
+			l754:
+				add(ruleOperator, position753)
 			}
 			return true
-		l741:
-			position, tokenIndex = position741, tokenIndex741
+		l752:
+			position, tokenIndex = position752, tokenIndex752
 			return false
 		},
 		/* 48 Offset <- <('+'? '-'? (('0' ('b' / 'B') ('0' / '1')+) / ('0' ('x' / 'X') ([0-9] / [0-9] / ([a-f] / [A-F]))+) / [0-9]+))> */
 		func() bool {
-			position745, tokenIndex745 := position, tokenIndex
+			position756, tokenIndex756 := position, tokenIndex
 			{
-				position746 := position
+				position757 := position
 				{
-					position747, tokenIndex747 := position, tokenIndex
+					position758, tokenIndex758 := position, tokenIndex
 					if buffer[position] != rune('+') {
-						goto l747
+						goto l758
 					}
 					position++
-					goto l748
-				l747:
-					position, tokenIndex = position747, tokenIndex747
+					goto l759
+				l758:
+					position, tokenIndex = position758, tokenIndex758
 				}
-			l748:
+			l759:
 				{
-					position749, tokenIndex749 := position, tokenIndex
+					position760, tokenIndex760 := position, tokenIndex
 					if buffer[position] != rune('-') {
-						goto l749
+						goto l760
 					}
 					position++
-					goto l750
-				l749:
-					position, tokenIndex = position749, tokenIndex749
+					goto l761
+				l760:
+					position, tokenIndex = position760, tokenIndex760
 				}
-			l750:
+			l761:
 				{
-					position751, tokenIndex751 := position, tokenIndex
+					position762, tokenIndex762 := position, tokenIndex
 					if buffer[position] != rune('0') {
-						goto l752
+						goto l763
 					}
 					position++
 					{
-						position753, tokenIndex753 := position, tokenIndex
+						position764, tokenIndex764 := position, tokenIndex
 						if buffer[position] != rune('b') {
-							goto l754
+							goto l765
 						}
 						position++
-						goto l753
-					l754:
-						position, tokenIndex = position753, tokenIndex753
+						goto l764
+					l765:
+						position, tokenIndex = position764, tokenIndex764
 						if buffer[position] != rune('B') {
-							goto l752
-						}
-						position++
-					}
-				l753:
-					{
-						position757, tokenIndex757 := position, tokenIndex
-						if buffer[position] != rune('0') {
-							goto l758
-						}
-						position++
-						goto l757
-					l758:
-						position, tokenIndex = position757, tokenIndex757
-						if buffer[position] != rune('1') {
-							goto l752
-						}
-						position++
-					}
-				l757:
-				l755:
-					{
-						position756, tokenIndex756 := position, tokenIndex
-						{
-							position759, tokenIndex759 := position, tokenIndex
-							if buffer[position] != rune('0') {
-								goto l760
-							}
-							position++
-							goto l759
-						l760:
-							position, tokenIndex = position759, tokenIndex759
-							if buffer[position] != rune('1') {
-								goto l756
-							}
-							position++
-						}
-					l759:
-						goto l755
-					l756:
-						position, tokenIndex = position756, tokenIndex756
-					}
-					goto l751
-				l752:
-					position, tokenIndex = position751, tokenIndex751
-					if buffer[position] != rune('0') {
-						goto l761
-					}
-					position++
-					{
-						position762, tokenIndex762 := position, tokenIndex
-						if buffer[position] != rune('x') {
 							goto l763
 						}
 						position++
-						goto l762
-					l763:
-						position, tokenIndex = position762, tokenIndex762
-						if buffer[position] != rune('X') {
-							goto l761
-						}
-						position++
 					}
-				l762:
-					{
-						position766, tokenIndex766 := position, tokenIndex
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l767
-						}
-						position++
-						goto l766
-					l767:
-						position, tokenIndex = position766, tokenIndex766
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l768
-						}
-						position++
-						goto l766
-					l768:
-						position, tokenIndex = position766, tokenIndex766
-						{
-							position769, tokenIndex769 := position, tokenIndex
-							if c := buffer[position]; c < rune('a') || c > rune('f') {
-								goto l770
-							}
-							position++
-							goto l769
-						l770:
-							position, tokenIndex = position769, tokenIndex769
-							if c := buffer[position]; c < rune('A') || c > rune('F') {
-								goto l761
-							}
-							position++
-						}
-					l769:
-					}
-				l766:
 				l764:
 					{
-						position765, tokenIndex765 := position, tokenIndex
-						{
-							position771, tokenIndex771 := position, tokenIndex
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l772
-							}
-							position++
-							goto l771
-						l772:
-							position, tokenIndex = position771, tokenIndex771
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l773
-							}
-							position++
-							goto l771
-						l773:
-							position, tokenIndex = position771, tokenIndex771
-							{
-								position774, tokenIndex774 := position, tokenIndex
-								if c := buffer[position]; c < rune('a') || c > rune('f') {
-									goto l775
-								}
-								position++
-								goto l774
-							l775:
-								position, tokenIndex = position774, tokenIndex774
-								if c := buffer[position]; c < rune('A') || c > rune('F') {
-									goto l765
-								}
-								position++
-							}
-						l774:
+						position768, tokenIndex768 := position, tokenIndex
+						if buffer[position] != rune('0') {
+							goto l769
 						}
-					l771:
-						goto l764
-					l765:
-						position, tokenIndex = position765, tokenIndex765
+						position++
+						goto l768
+					l769:
+						position, tokenIndex = position768, tokenIndex768
+						if buffer[position] != rune('1') {
+							goto l763
+						}
+						position++
 					}
-					goto l751
-				l761:
-					position, tokenIndex = position751, tokenIndex751
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l745
+				l768:
+				l766:
+					{
+						position767, tokenIndex767 := position, tokenIndex
+						{
+							position770, tokenIndex770 := position, tokenIndex
+							if buffer[position] != rune('0') {
+								goto l771
+							}
+							position++
+							goto l770
+						l771:
+							position, tokenIndex = position770, tokenIndex770
+							if buffer[position] != rune('1') {
+								goto l767
+							}
+							position++
+						}
+					l770:
+						goto l766
+					l767:
+						position, tokenIndex = position767, tokenIndex767
+					}
+					goto l762
+				l763:
+					position, tokenIndex = position762, tokenIndex762
+					if buffer[position] != rune('0') {
+						goto l772
 					}
 					position++
-				l776:
+					{
+						position773, tokenIndex773 := position, tokenIndex
+						if buffer[position] != rune('x') {
+							goto l774
+						}
+						position++
+						goto l773
+					l774:
+						position, tokenIndex = position773, tokenIndex773
+						if buffer[position] != rune('X') {
+							goto l772
+						}
+						position++
+					}
+				l773:
 					{
 						position777, tokenIndex777 := position, tokenIndex
 						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l777
+							goto l778
 						}
 						position++
-						goto l776
-					l777:
+						goto l777
+					l778:
 						position, tokenIndex = position777, tokenIndex777
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l779
+						}
+						position++
+						goto l777
+					l779:
+						position, tokenIndex = position777, tokenIndex777
+						{
+							position780, tokenIndex780 := position, tokenIndex
+							if c := buffer[position]; c < rune('a') || c > rune('f') {
+								goto l781
+							}
+							position++
+							goto l780
+						l781:
+							position, tokenIndex = position780, tokenIndex780
+							if c := buffer[position]; c < rune('A') || c > rune('F') {
+								goto l772
+							}
+							position++
+						}
+					l780:
+					}
+				l777:
+				l775:
+					{
+						position776, tokenIndex776 := position, tokenIndex
+						{
+							position782, tokenIndex782 := position, tokenIndex
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l783
+							}
+							position++
+							goto l782
+						l783:
+							position, tokenIndex = position782, tokenIndex782
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l784
+							}
+							position++
+							goto l782
+						l784:
+							position, tokenIndex = position782, tokenIndex782
+							{
+								position785, tokenIndex785 := position, tokenIndex
+								if c := buffer[position]; c < rune('a') || c > rune('f') {
+									goto l786
+								}
+								position++
+								goto l785
+							l786:
+								position, tokenIndex = position785, tokenIndex785
+								if c := buffer[position]; c < rune('A') || c > rune('F') {
+									goto l776
+								}
+								position++
+							}
+						l785:
+						}
+					l782:
+						goto l775
+					l776:
+						position, tokenIndex = position776, tokenIndex776
+					}
+					goto l762
+				l772:
+					position, tokenIndex = position762, tokenIndex762
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
+						goto l756
+					}
+					position++
+				l787:
+					{
+						position788, tokenIndex788 := position, tokenIndex
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l788
+						}
+						position++
+						goto l787
+					l788:
+						position, tokenIndex = position788, tokenIndex788
 					}
 				}
-			l751:
-				add(ruleOffset, position746)
+			l762:
+				add(ruleOffset, position757)
 			}
 			return true
-		l745:
-			position, tokenIndex = position745, tokenIndex745
+		l756:
+			position, tokenIndex = position756, tokenIndex756
 			return false
 		},
 		/* 49 Section <- <([a-z] / [A-Z] / '@')+> */
 		func() bool {
-			position778, tokenIndex778 := position, tokenIndex
+			position789, tokenIndex789 := position, tokenIndex
 			{
-				position779 := position
+				position790 := position
 				{
-					position782, tokenIndex782 := position, tokenIndex
+					position793, tokenIndex793 := position, tokenIndex
 					if c := buffer[position]; c < rune('a') || c > rune('z') {
-						goto l783
+						goto l794
 					}
 					position++
-					goto l782
-				l783:
-					position, tokenIndex = position782, tokenIndex782
+					goto l793
+				l794:
+					position, tokenIndex = position793, tokenIndex793
 					if c := buffer[position]; c < rune('A') || c > rune('Z') {
-						goto l784
+						goto l795
 					}
 					position++
-					goto l782
-				l784:
-					position, tokenIndex = position782, tokenIndex782
+					goto l793
+				l795:
+					position, tokenIndex = position793, tokenIndex793
 					if buffer[position] != rune('@') {
-						goto l778
+						goto l789
 					}
 					position++
 				}
-			l782:
-			l780:
+			l793:
+			l791:
 				{
-					position781, tokenIndex781 := position, tokenIndex
+					position792, tokenIndex792 := position, tokenIndex
 					{
-						position785, tokenIndex785 := position, tokenIndex
+						position796, tokenIndex796 := position, tokenIndex
 						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l786
+							goto l797
 						}
 						position++
-						goto l785
-					l786:
-						position, tokenIndex = position785, tokenIndex785
+						goto l796
+					l797:
+						position, tokenIndex = position796, tokenIndex796
 						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l787
+							goto l798
 						}
 						position++
-						goto l785
-					l787:
-						position, tokenIndex = position785, tokenIndex785
+						goto l796
+					l798:
+						position, tokenIndex = position796, tokenIndex796
 						if buffer[position] != rune('@') {
-							goto l781
+							goto l792
 						}
 						position++
 					}
-				l785:
-					goto l780
-				l781:
-					position, tokenIndex = position781, tokenIndex781
+				l796:
+					goto l791
+				l792:
+					position, tokenIndex = position792, tokenIndex792
 				}
-				add(ruleSection, position779)
+				add(ruleSection, position790)
 			}
 			return true
-		l778:
-			position, tokenIndex = position778, tokenIndex778
+		l789:
+			position, tokenIndex = position789, tokenIndex789
 			return false
 		},
 		/* 50 SegmentRegister <- <('%' ([c-g] / 's') ('s' ':'))> */
 		func() bool {
-			position788, tokenIndex788 := position, tokenIndex
+			position799, tokenIndex799 := position, tokenIndex
 			{
-				position789 := position
+				position800 := position
 				if buffer[position] != rune('%') {
-					goto l788
+					goto l799
 				}
 				position++
 				{
-					position790, tokenIndex790 := position, tokenIndex
+					position801, tokenIndex801 := position, tokenIndex
 					if c := buffer[position]; c < rune('c') || c > rune('g') {
-						goto l791
+						goto l802
 					}
 					position++
-					goto l790
-				l791:
-					position, tokenIndex = position790, tokenIndex790
+					goto l801
+				l802:
+					position, tokenIndex = position801, tokenIndex801
 					if buffer[position] != rune('s') {
-						goto l788
+						goto l799
 					}
 					position++
 				}
-			l790:
+			l801:
 				if buffer[position] != rune('s') {
-					goto l788
+					goto l799
 				}
 				position++
 				if buffer[position] != rune(':') {
-					goto l788
+					goto l799
 				}
 				position++
-				add(ruleSegmentRegister, position789)
+				add(ruleSegmentRegister, position800)
 			}
 			return true
-		l788:
-			position, tokenIndex = position788, tokenIndex788
+		l799:
+			position, tokenIndex = position799, tokenIndex799
 			return false
 		},
 	}
 	p.rules = _rules
+	return nil
 }


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-725

### Description of changes: 
This PR added FIPS aarch build dimensions to awslc CI.

### Call-outs:
* Unlike x86 FIPS build, gcc7x is not planned to be in FIPS POC scope.
  * Related reference -- `CryptoAlg-723?selectedConversation=e0c5b7c9-60f5-4d30-a496-f5f8dbc711cd` 
* The first two code commits were reviewed.

### Testing:
* CI set up in personal account
   * ~~CodeBuild request - `aws-lc-ci-linux-arm:db6724d9-5b22-4f6f-a429-c0b552eec1f9`~~
      * This build failed because the test used default `go test` timeout, which is 10m.
   * CodeBuild request - `aws-lc-ci-linux-arm:8f624494-6ea8-46e2-b337-1f924dc40d03`
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
