### PR TITLE
Implements an additional fork detection mechanism: pthread_atfork

### DIFF
--- a/crypto/fipsmodule/rand/fork_detect.c
+++ b/crypto/fipsmodule/rand/fork_detect.c
@@ -64,6 +64,12 @@ static void pthread_atfork_on_fork(void) {
 
   struct CRYPTO_STATIC_MUTEX *const lock = g_fork_detect_lock_bss_get();
 
+  // This zeroises the first byte of the memory page pointed to by
+  // |*g_fork_detect_addr_bss_get|. This is the same byte used as fork
+  // detection sentinel in |CRYPTO_get_fork_generation|. The same memory page,
+  // and in turn, the byte, is also the memory zeroised by the |MADV_WIPEONFORK|
+  // fork detection mechanism.
+  //
   // Aquire locks to be on the safe side. We want to avoid the checks in
   // |CRYPTO_get_fork_generation| getting executed before setting the sentinel
   // flag. The write lock prevents any other thread from owning any other type

--- a/crypto/fipsmodule/rand/fork_detect.h
+++ b/crypto/fipsmodule/rand/fork_detect.h
@@ -42,6 +42,10 @@ OPENSSL_EXPORT uint64_t CRYPTO_get_fork_generation(void);
 // used for testing purposes.
 OPENSSL_EXPORT void CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing(void);
 
+// CRYPTO_fork_detect_ignore_pthread_atfork_for_testing is an internal detail
+// used for testing purposes.
+OPENSSL_EXPORT void CRYPTO_fork_detect_ignore_pthread_atfork_for_testing(void);
+
 #if defined(__cplusplus)
 }  // extern C
 #endif

--- a/crypto/fipsmodule/rand/fork_detect_test.cc
+++ b/crypto/fipsmodule/rand/fork_detect_test.cc
@@ -100,6 +100,15 @@ static void ForkInChild(std::function<void()> f) {
 }
 
 TEST(ForkDetect, Test) {
+
+  if (getenv("BORINGSSL_IGNORE_MADV_WIPEONFORK")) {
+    CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing();
+  }
+
+  if (getenv("BORINGSSL_IGNORE_PTHREAD_ATFORK")) {
+    CRYPTO_fork_detect_ignore_pthread_atfork_for_testing();
+  }
+
   const uint64_t start = CRYPTO_get_fork_generation();
   if (start == 0) {
     fprintf(stderr, "Fork detection not supported. Skipping test.\n");

--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -512,6 +512,10 @@ int main(int argc, char **argv) {
     CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing();
   }
 
+  if (getenv("BORINGSSL_IGNORE_PTHREAD_ATFORK")) {
+    CRYPTO_fork_detect_ignore_pthread_atfork_for_testing();
+  }
+
   return RUN_ALL_TESTS();
 }
 

--- a/crypto/rand_extra/rand_test.cc
+++ b/crypto/rand_extra/rand_test.cc
@@ -40,7 +40,7 @@
 #endif
 
 static void maybe_disable_some_fork_detect_mechanisms(void) {
-#if !defined(OPENSSL_WINDOWS)
+#if !defined(OPENSSL_LINUX)
   if (getenv("BORINGSSL_IGNORE_MADV_WIPEONFORK")) {
     CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing();
   }

--- a/crypto/rand_extra/rand_test.cc
+++ b/crypto/rand_extra/rand_test.cc
@@ -40,6 +40,7 @@
 #endif
 
 static void maybe_disable_some_fork_detect_mechanisms(void) {
+#if !defined(OPENSSL_WINDOWS)
   if (getenv("BORINGSSL_IGNORE_MADV_WIPEONFORK")) {
     CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing();
   }
@@ -47,6 +48,7 @@ static void maybe_disable_some_fork_detect_mechanisms(void) {
   if (getenv("BORINGSSL_IGNORE_PTHREAD_ATFORK")) {
     CRYPTO_fork_detect_ignore_pthread_atfork_for_testing();
   }
+#endif
 }
 
 

--- a/crypto/rand_extra/rand_test.cc
+++ b/crypto/rand_extra/rand_test.cc
@@ -40,7 +40,7 @@
 #endif
 
 static void maybe_disable_some_fork_detect_mechanisms(void) {
-#if !defined(OPENSSL_LINUX)
+#if defined(OPENSSL_LINUX)
   if (getenv("BORINGSSL_IGNORE_MADV_WIPEONFORK")) {
     CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing();
   }

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -35,19 +35,44 @@
     "skip_valgrind": true
   },
   {
-    "comment": "No RDRAND and without WIPEONFORK",
+    "comment": "No RDRAND and without fork detection",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x4000000000000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
+    "env": ["OPENSSL_ia32cap=~0x4000000000000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1", "BORINGSSL_IGNORE_PTHREAD_ATFORK=1"],
     "skip_valgrind": true
   },
   {
-    "comment": "Potentially with RDRAND, but not Intel, and no WIPEONFORK",
+    "comment": "Potentially with RDRAND, but not Intel, and without fork detection",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x0000000040000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
+    "env": ["OPENSSL_ia32cap=~0x0000000040000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1", "BORINGSSL_IGNORE_PTHREAD_ATFORK=1"],
     "skip_valgrind": true
   },
   {
+    "comment": "Run RAND test suite without fork detection",
     "cmd": ["crypto/crypto_test", "--fork_unsafe_buffering", "--gtest_filter=RandTest.*:-RandTest.Fork"],
+    "skip_valgrind": true
+  },
+  {
+    "comment": "Run RAND test suite with only madv WIPEONFORK enabled",
+    "cmd": ["crypto/crypto_test", "--gtest_filter=RandTest.*"],
+    "env": ["BORINGSSL_IGNORE_PTHREAD_ATFORK=1"],
+    "skip_valgrind": true
+  },
+  {
+    "comment": "Run RAND test suite with only pthread_atfork enabled",
+    "cmd": ["crypto/crypto_test", "--gtest_filter=RandTest.*"],
+    "env": ["BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
+    "skip_valgrind": true
+  },
+  {
+    "comment": "Run fork detection test suite with only madv WIPEONFORK enabled",
+    "cmd": ["crypto/crypto_test", "--gtest_filter=ForkDetect.*"],
+    "env": ["BORINGSSL_IGNORE_PTHREAD_ATFORK=1"],
+    "skip_valgrind": true
+  },
+  {
+    "comment": "Run fork detection test suite with only pthread_atfork enabled",
+    "cmd": ["crypto/crypto_test", "--gtest_filter=ForkDetect.*"],
+    "env": ["BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
     "skip_valgrind": true
   },
   {

--- a/util/whitespace.txt
+++ b/util/whitespace.txt
@@ -1,1 +1,2 @@
 This file is ignored. It exists to make no-op commits to trigger new builds.
+ 

--- a/util/whitespace.txt
+++ b/util/whitespace.txt
@@ -1,2 +1,2 @@
 This file is ignored. It exists to make no-op commits to trigger new builds.
- 
+  


### PR DESCRIPTION
### Issues:

CryptoAlg-727

### Description of changes: 

AWS-LC currently has one fork detection mechanisms: `WIPEONFORK`. This PR implements an additional fork detection mechanism using the pthread library function `pthread_atfork`. Using this function, we can register a handler that is executed in the child after a fork call `fork()` that is used to flip a sentinel fork detection value. This change is intended to add defense-in-depth to the fork detection.

The code flow is roughly as follows:

* The fork detection is lazily initialised
* On first call: `init_fork_detect` is only called by the first thread entering it
* mmap a page that is acting as the sentinel informing whether a fork has occurred or not
* Initialise the two fork detection mechanisms
* If initialisation is successful, set the sentinel value to 1 (indicating no fork has occurred). The value 0 indicates that a fork has occurred.

### Call-outs:

Emphasis has been given to keeping the generation number logic in the function `CRYPTO_get_fork_generation` as is.

Had to move things around to be able to inject ignore flags into the code path for testing. This probably makes merging harder, but beneficial for possible future extensions.

### Testing:

Added extra dimensions that test each fork detection mechanism in isolation. This ensures that each mechanism is correctly initialised and can properly detect a fork. Existing tests cover the full combination of the mechanisms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
