### PR TITLE
Integrate s2n-bignum into ARMv8 for P-384

### DIFF
--- a/Arm/bignum_add_p384.S
+++ b/Arm/bignum_add_p384.S
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
+// Inputs x[6], y[6]; output z[6]
+//
+//    extern void bignum_add_p384
+//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define x x1
+#define y x2
+#define c x3
+#define l x4
+#define d0 x5
+#define d1 x6
+#define d2 x7
+#define d3 x8
+#define d4 x9
+#define d5 x10
+
+.text
+.globl bignum_add_p384
+
+bignum_add_p384:
+
+// First just add the numbers as c + [d5; d4; d3; d2; d1; d0]
+
+                ldp     d0, d1, [x]
+                ldp     l, c, [y]
+                adds    d0, d0, l
+                adcs    d1, d1, c
+                ldp     d2, d3, [x, #16]
+                ldp     l, c, [y, #16]
+                adcs    d2, d2, l
+                adcs    d3, d3, c
+                ldp     d4, d5, [x, #32]
+                ldp     l, c, [y, #32]
+                adcs    d4, d4, l
+                adcs    d5, d5, c
+                adc     c, xzr, xzr
+
+// Now compare [d5; d4; d3; d2; d1; d0] with p_384
+
+                mov     l, 0x00000000ffffffff
+                subs    xzr, d0, l
+                mov     l, 0xffffffff00000000
+                sbcs    xzr, d1, l
+                mov     l, 0xfffffffffffffffe
+                sbcs    xzr, d2, l
+                adcs    xzr, d3, xzr
+                adcs    xzr, d4, xzr
+                adcs    xzr, d5, xzr
+
+// Now CF is set (because of inversion) if (x + y) % 2^384 >= p_384
+// Thus we want to correct if either this is set or the original carry c was
+
+                adcs    c, c, xzr
+                csetm   c, ne
+
+// Now correct by subtracting masked p_384
+
+                mov     l, 0x00000000ffffffff
+                and     l, l, c
+                subs    d0, d0, l
+                eor     l, l, c
+                sbcs    d1, d1, l
+                mov     l, 0xfffffffffffffffe
+                and     l, l, c
+                sbcs    d2, d2, l
+                sbcs    d3, d3, c
+                sbcs    d4, d4, c
+                sbc     d5, d5, c
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+
+                ret

--- a/Arm/bignum_amontmul_p384.S
+++ b/Arm/bignum_amontmul_p384.S
@@ -1,0 +1,423 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Almost-Montgomery multiply, z :== (x * y / 2^384) (congruent mod p_384)
+// Inputs x[6], y[6]; output z[6]
+//
+//    extern void bignum_amontmul_p384
+//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//
+// Does z :== (x * y / 2^384) mod p_384, meaning that the result, in the native
+// size 6, is congruent modulo p_384, but might not be fully reduced mod p_384.
+// This is why it is called *almost* Montgomery multiplication.
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+.globl   bignum_amontmul_p384
+
+// ---------------------------------------------------------------------------
+// Macro returning (c,h,l) = 3-word 1s complement (x - y) * (w - z)
+// c,h,l,t should all be different
+// t,h should not overlap w,z
+// ---------------------------------------------------------------------------
+
+.macro muldiffn c,h,l, t, x,y, w,z
+        subs    \t, \x, \y
+        cneg    \t, \t, cc
+        csetm   \c, cc
+        subs    \h, \w, \z
+        cneg    \h, \h, cc
+        mul     \l, \t, \h
+        umulh   \h, \t, \h
+        cinv    \c, \c, cc
+        eor     \l, \l, \c
+        eor     \h, \h, \c
+.endm
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+.macro          montreds d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+// Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+// Recycle d0 (which we know gets implicitly cancelled) to store it
+                lsl     \t1, \d0, 32
+                add     \d0, \t1, \d0
+// Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)
+// We need to subtract 2^32 * this, and we can ignore its lower 32
+// bits since by design it will cancel anyway; we only need the w_hi
+// part to get the carry propagation going.
+                lsr     \t1, \d0, 32
+                subs    \t1, \t1, \d0
+                sbc     \t2, \d0, xzr
+// Now select in t1 the field to subtract from d1
+                extr    \t1, \t2, \t1, 32
+// And now get the terms to subtract from d2 and d3
+                lsr     \t2, \t2, 32
+                adds    \t2, \t2, \d0
+                adc     \t3, xzr, xzr
+// Do the subtraction of that portion
+                subs    \d1, \d1, \t1
+                sbcs    \d2, \d2, \t2
+                sbcs    \d3, \d3, \t3
+                sbcs    \d4, \d4, xzr
+                sbcs    \d5, \d5, xzr
+// Now effectively add 2^384 * w by taking d0 as the input for the last sbc
+                sbc     \d6, \d0, xzr
+.endm
+
+#define a0 x3
+#define a1 x4
+#define a2 x5
+#define a3 x6
+#define a4 x7
+#define a5 x8
+#define b0 x9
+#define b1 x10
+#define b2 x11
+#define b3 x12
+#define b4 x13
+#define b5 x14
+
+#define s0 x15
+#define s1 x16
+#define s2 x17
+#define s3 x19
+#define s4 x20
+#define s5 x1
+#define s6 x2
+
+#define t1 x21
+#define t2 x22
+#define t3 x23
+#define t4 x24
+
+bignum_amontmul_p384:
+
+// Save some registers
+
+                stp     x19, x20, [sp, -16]!
+                stp     x21, x22, [sp, -16]!
+                stp     x23, x24, [sp, -16]!
+
+// Load in all words of both inputs
+
+                ldp     a0, a1, [x1]
+                ldp     a2, a3, [x1, 16]
+                ldp     a4, a5, [x1, 32]
+                ldp     b0, b1, [x2]
+                ldp     b2, b3, [x2, 16]
+                ldp     b4, b5, [x2, 32]
+
+// Multiply low halves with a 3x3->6 ADK multiplier as [s5;s4;s3;s2;s1;s0]
+
+                mul     s0, a0, b0
+                mul     t1, a1, b1
+                mul     t2, a2, b2
+                umulh   t3, a0, b0
+                umulh   t4, a1, b1
+                umulh   s5, a2, b2
+
+                adds    t3, t3, t1
+                adcs    t4, t4, t2
+                adc     s5, s5, xzr
+
+                adds    s1, t3, s0
+                adcs    s2, t4, t3
+                adcs    s3, s5, t4
+                adc     s4, s5, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, t3
+                adcs    s4, s4, t4
+                adc     s5, s5, xzr
+
+                muldiffn t3,t2,t1, t4, a0,a1, b1,b0
+                adds    xzr, t3, 1
+                adcs    s1, s1, t1
+                adcs    s2, s2, t2
+                adcs    s3, s3, t3
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a0,a2, b2,b0
+                adds    xzr, t3, 1
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a1,a2, b2,b1
+                adds    xzr, t3, 1
+                adcs    s3, s3, t1
+                adcs    s4, s4, t2
+                adc     s5, s5, t3
+
+// Perform three "short" Montgomery steps on the low product
+// This shifts it to an offset compatible with middle terms
+// Stash the result temporarily in the output buffer
+// We could keep this in registers by directly adding to it in the next
+// ADK block, but if anything that seems to be slightly slower
+
+                montreds s0,s5,s4,s3,s2,s1,s0, t1,t2,t3
+
+                montreds s1,s0,s5,s4,s3,s2,s1, t1,t2,t3
+
+                montreds s2,s1,s0,s5,s4,s3,s2, t1,t2,t3
+
+                stp     s3, s4, [x0]
+                stp     s5, s0, [x0, 16]
+                stp     s1, s2, [x0, 32]
+
+// Multiply high halves with a 3x3->6 ADK multiplier as [s5;s4;s3;s2;s1;s0]
+
+                mul     s0, a3, b3
+                mul     t1, a4, b4
+                mul     t2, a5, b5
+                umulh   t3, a3, b3
+                umulh   t4, a4, b4
+                umulh   s5, a5, b5
+
+                adds    t3, t3, t1
+                adcs    t4, t4, t2
+                adc     s5, s5, xzr
+
+                adds    s1, t3, s0
+                adcs    s2, t4, t3
+                adcs    s3, s5, t4
+                adc     s4, s5, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, t3
+                adcs    s4, s4, t4
+                adc     s5, s5, xzr
+
+                muldiffn t3,t2,t1, t4, a3,a4, b4,b3
+                adds    xzr, t3, 1
+                adcs    s1, s1, t1
+                adcs    s2, s2, t2
+                adcs    s3, s3, t3
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a3,a5, b5,b3
+                adds    xzr, t3, 1
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a4,a5, b5,b4
+                adds    xzr, t3, 1
+                adcs    s3, s3, t1
+                adcs    s4, s4, t2
+                adc     s5, s5, t3
+
+// Compute sign-magnitude a0,[a5,a4,a3] = x_hi - x_lo
+
+                subs    a3, a3, a0
+                sbcs    a4, a4, a1
+                sbcs    a5, a5, a2
+                sbc     a0, xzr, xzr
+                adds    xzr, a0, 1
+                eor     a3, a3, a0
+                adcs    a3, a3, xzr
+                eor     a4, a4, a0
+                adcs    a4, a4, xzr
+                eor     a5, a5, a0
+                adc     a5, a5, xzr
+
+// Compute sign-magnitude b5,[b2,b1,b0] = y_lo - y_hi
+
+                subs    b0, b0, b3
+                sbcs    b1, b1, b4
+                sbcs    b2, b2, b5
+                sbc     b5, xzr, xzr
+
+                adds    xzr, b5, 1
+                eor     b0, b0, b5
+                adcs    b0, b0, xzr
+                eor     b1, b1, b5
+                adcs    b1, b1, xzr
+                eor     b2, b2, b5
+                adc     b2, b2, xzr
+
+// Save the correct sign for the sub-product in b5
+
+                eor     b5, a0, b5
+
+// Add the high H to the modified low term L' and re-stash 6 words,
+// keeping top word in s6
+
+                ldp     t1, t2, [x0]
+                adds    s0, s0, t1
+                adcs    s1, s1, t2
+                ldp     t1, t2, [x0, 16]
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                ldp     t1, t2, [x0, 32]
+                adcs    s4, s4, t1
+                adcs    s5, s5, t2
+                adc     s6, xzr, xzr
+                stp     s0, s1, [x0]
+                stp     s2, s3, [x0, 16]
+                stp     s4, s5, [x0, 32]
+
+// Multiply with yet a third 3x3 ADK for the complex mid-term
+
+                mul     s0, a3, b0
+                mul     t1, a4, b1
+                mul     t2, a5, b2
+                umulh   t3, a3, b0
+                umulh   t4, a4, b1
+                umulh   s5, a5, b2
+
+                adds    t3, t3, t1
+                adcs    t4, t4, t2
+                adc     s5, s5, xzr
+
+                adds    s1, t3, s0
+                adcs    s2, t4, t3
+                adcs    s3, s5, t4
+                adc     s4, s5, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, t3
+                adcs    s4, s4, t4
+                adc     s5, s5, xzr
+
+                muldiffn t3,t2,t1, t4, a3,a4, b1,b0
+                adds    xzr, t3, 1
+                adcs    s1, s1, t1
+                adcs    s2, s2, t2
+                adcs    s3, s3, t3
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a3,a5, b2,b0
+                adds    xzr, t3, 1
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a4,a5, b2,b1
+                adds    xzr, t3, 1
+                adcs    s3, s3, t1
+                adcs    s4, s4, t2
+                adc     s5, s5, t3
+
+// Unstash the H + L' sum to add in twice
+
+                ldp     a0, a1, [x0]
+                ldp     a2, a3, [x0, 16]
+                ldp     a4, a5, [x0, 32]
+
+// Set up a sign-modified version of the mid-product in a long accumulator
+// as [b3;b2;b1;b0;s5;s4;s3;s2;s1;s0], adding in the H + L' term once with
+// zero offset as this signed value is created
+
+                adds    xzr, b5, 1
+                eor     s0, s0, b5
+                adcs    s0, s0, a0
+                eor     s1, s1, b5
+                adcs    s1, s1, a1
+                eor     s2, s2, b5
+                adcs    s2, s2, a2
+                eor     s3, s3, b5
+                adcs    s3, s3, a3
+                eor     s4, s4, b5
+                adcs    s4, s4, a4
+                eor     s5, s5, b5
+                adcs    s5, s5, a5
+                adcs    b0, b5, s6
+                adcs    b1, b5, xzr
+                adcs    b2, b5, xzr
+                adc     b3, b5, xzr
+
+// Add in the stashed H + L' term an offset of 3 words as well
+
+                adds    s3, s3, a0
+                adcs    s4, s4, a1
+                adcs    s5, s5, a2
+                adcs    b0, b0, a3
+                adcs    b1, b1, a4
+                adcs    b2, b2, a5
+                adc     b3, b3, s6
+
+// Do three more Montgomery steps on the composed term
+
+                montreds s0,s5,s4,s3,s2,s1,s0, t1,t2,t3
+                montreds s1,s0,s5,s4,s3,s2,s1, t1,t2,t3
+                montreds s2,s1,s0,s5,s4,s3,s2, t1,t2,t3
+
+                adds    b0, b0, s0
+                adcs    b1, b1, s1
+                adcs    b2, b2, s2
+                adc     b3, b3, xzr
+
+// Because of the way we added L' in two places, we can overspill by
+// more than usual in Montgomery, with the result being only known to
+// be < 3 * p_384, not the usual < 2 * p_384. So now we do a more
+// elaborate final correction in the style of bignum_cmul_p384, just
+// a little bit simpler because we know q is small.
+
+                add     t2, b3, 1
+                lsl     t1, t2, 32
+                subs    t4, t2, t1
+                sbc     t1, t1, xzr
+
+                adds    s3, s3, t4
+                adcs    s4, s4, t1
+                adcs    s5, s5, t2
+                adcs    b0, b0, xzr
+                adcs    b1, b1, xzr
+                adcs    b2, b2, xzr
+
+                csetm   t2, cc
+
+                mov     t3, 0x00000000ffffffff
+                and     t3, t3, t2
+                adds    s3, s3, t3
+                eor     t3, t3, t2
+                adcs    s4, s4, t3
+                mov     t3, 0xfffffffffffffffe
+                and     t3, t3, t2
+                adcs    s5, s5, t3
+                adcs    b0, b0, t2
+                adcs    b1, b1, t2
+                adc     b2, b2, t2
+
+// Write back the result
+
+                stp     s3, s4, [x0]
+                stp     s5, b0, [x0, 16]
+                stp     b1, b2, [x0, 32]
+
+// Restore registers and return
+
+                ldp     x23, x24, [sp], 16
+                ldp     x21, x22, [sp], 16
+                ldp     x19, x20, [sp], 16
+
+                ret

--- a/Arm/bignum_amontsqr_p384.S
+++ b/Arm/bignum_amontsqr_p384.S
@@ -1,0 +1,356 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Almost-Montgomery square, z :== (x^2 / 2^384) (congruent mod p_384)
+// Input x[6]; output z[6]
+//
+//    extern void bignum_amontsqr_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// "Almost" means the 6-digit result is correct mod p_384 but might not be
+// fully reduced, i.e. it might be >= p_384. Use "bignum_montsqr_p384" instead
+// where full reduction to a result < p_384 is desired/needed.
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+.globl   bignum_amontsqr_p384
+
+// ---------------------------------------------------------------------------
+// Macro returning (c,h,l) = 3-word 1s complement (x - y) * (w - z)
+// c,h,l,t should all be different
+// t,h should not overlap w,z
+// ---------------------------------------------------------------------------
+
+.macro muldiffn c,h,l, t, x,y, w,z
+        subs    \t, \x, \y
+        cneg    \t, \t, cc
+        csetm   \c, cc
+        subs    \h, \w, \z
+        cneg    \h, \h, cc
+        mul     \l, \t, \h
+        umulh   \h, \t, \h
+        cinv    \c, \c, cc
+        eor     \l, \l, \c
+        eor     \h, \h, \c
+.endm
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+.macro          montreds d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+// Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+// Recycle d0 (which we know gets implicitly cancelled) to store it
+                lsl     \t1, \d0, 32
+                add     \d0, \t1, \d0
+// Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)
+// We need to subtract 2^32 * this, and we can ignore its lower 32
+// bits since by design it will cancel anyway; we only need the w_hi
+// part to get the carry propagation going.
+                lsr     \t1, \d0, 32
+                subs    \t1, \t1, \d0
+                sbc     \t2, \d0, xzr
+// Now select in t1 the field to subtract from d1
+                extr    \t1, \t2, \t1, 32
+// And now get the terms to subtract from d2 and d3
+                lsr     \t2, \t2, 32
+                adds    \t2, \t2, \d0
+                adc     \t3, xzr, xzr
+// Do the subtraction of that portion
+                subs    \d1, \d1, \t1
+                sbcs    \d2, \d2, \t2
+                sbcs    \d3, \d3, \t3
+                sbcs    \d4, \d4, xzr
+                sbcs    \d5, \d5, xzr
+// Now effectively add 2^384 * w by taking d0 as the input for the last sbc
+                sbc     \d6, \d0, xzr
+.endm
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define a4 x6
+#define a5 x7
+
+#define c0 x8
+#define c1 x9
+#define c2 x10
+#define c3 x11
+#define c4 x12
+#define c5 x13
+#define d1 x14
+#define d2 x15
+#define d3 x16
+#define d4 x17
+
+bignum_amontsqr_p384:
+
+// Load in all words of the input
+
+                ldp     a0, a1, [x1]
+                ldp     a2, a3, [x1, 16]
+                ldp     a4, a5, [x1, 32]
+
+// Square the low half getting a result in [c5;c4;c3;c2;c1;c0]
+
+                mul     d1, a0, a1
+                mul     d2, a0, a2
+                mul     d3, a1, a2
+                mul     c0, a0, a0
+                mul     c2, a1, a1
+                mul     c4, a2, a2
+
+                umulh   d4, a0, a1
+                adds    d2, d2, d4
+                umulh   d4, a0, a2
+                adcs    d3, d3, d4
+                umulh   d4, a1, a2
+                adcs    d4, d4, xzr
+
+                umulh   c1, a0, a0
+                umulh   c3, a1, a1
+                umulh   c5, a2, a2
+
+                adds    d1, d1, d1
+                adcs    d2, d2, d2
+                adcs    d3, d3, d3
+                adcs    d4, d4, d4
+                adc     c5, c5, xzr
+
+                adds    c1, c1, d1
+                adcs    c2, c2, d2
+                adcs    c3, c3, d3
+                adcs    c4, c4, d4
+                adc     c5, c5, xzr
+
+// Perform three "short" Montgomery steps on the low square
+// This shifts it to an offset compatible with middle product
+// Stash the result temporarily in the output buffer (to avoid more registers)
+
+                montreds c0,c5,c4,c3,c2,c1,c0, d1,d2,d3
+
+                montreds c1,c0,c5,c4,c3,c2,c1, d1,d2,d3
+
+                montreds c2,c1,c0,c5,c4,c3,c2, d1,d2,d3
+
+                stp     c3, c4, [x0]
+                stp     c5, c0, [x0, 16]
+                stp     c1, c2, [x0, 32]
+
+// Compute product of the cross-term with ADK 3x3->6 multiplier
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define a4 x6
+#define a5 x7
+#define s0 x8
+#define s1 x9
+#define s2 x10
+#define s3 x11
+#define s4 x12
+#define s5 x13
+
+#define l1 x14
+#define l2 x15
+#define h0 x16
+#define h1 x17
+#define h2 x1
+
+#define s6 h1
+#define c  l1
+#define h  l2
+#define l  h0
+#define t  h1
+
+                mul     s0, a0, a3
+                mul     l1, a1, a4
+                mul     l2, a2, a5
+                umulh   h0, a0, a3
+                umulh   h1, a1, a4
+                umulh   h2, a2, a5
+
+                adds    h0, h0, l1
+                adcs    h1, h1, l2
+                adc     h2, h2, xzr
+
+                adds    s1, h0, s0
+                adcs    s2, h1, h0
+                adcs    s3, h2, h1
+                adc     s4, h2, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, h0
+                adcs    s4, s4, h1
+                adc     s5, h2, xzr
+
+                muldiffn c,h,l, t, a0,a1, a4,a3
+                adds    xzr, c, 1
+                adcs    s1, s1, l
+                adcs    s2, s2, h
+                adcs    s3, s3, c
+                adcs    s4, s4, c
+                adc     s5, s5, c
+
+                muldiffn c,h,l, t, a0,a2, a5,a3
+                adds    xzr, c, 1
+                adcs    s2, s2, l
+                adcs    s3, s3, h
+                adcs    s4, s4, c
+                adc     s5, s5, c
+
+                muldiffn c,h,l, t, a1,a2, a5,a4
+                adds    xzr, c, 1
+                adcs    s3, s3, l
+                adcs    s4, s4, h
+                adc     s5, s5, c
+
+// Double it and add the stashed Montgomerified low square
+
+                adds    s0, s0, s0
+                adcs    s1, s1, s1
+                adcs    s2, s2, s2
+                adcs    s3, s3, s3
+                adcs    s4, s4, s4
+                adcs    s5, s5, s5
+                adc     s6, xzr, xzr
+
+                ldp     a0, a1, [x0]
+                adds    s0, s0, a0
+                adcs    s1, s1, a1
+                ldp     a0, a1, [x0, 16]
+                adcs    s2, s2, a0
+                adcs    s3, s3, a1
+                ldp     a0, a1, [x0, 32]
+                adcs    s4, s4, a0
+                adcs    s5, s5, a1
+                adc     s6, s6, xzr
+
+// Montgomery-reduce the combined low and middle term another thrice
+
+                montreds s0,s5,s4,s3,s2,s1,s0, a0,a1,a2
+
+                montreds s1,s0,s5,s4,s3,s2,s1, a0,a1,a2
+
+                montreds s2,s1,s0,s5,s4,s3,s2, a0,a1,a2
+
+                adds    s6, s6, s0
+                adcs    s0, s1, xzr
+                adcs    s1, s2, xzr
+                adcs    s2, xzr, xzr
+
+// Our sum so far is in [s2;s1;s0;s6;s5;s4;s3]
+// Choose more intuitive names
+
+#define r0 x11
+#define r1 x12
+#define r2 x13
+#define r3 x17
+#define r4 x8
+#define r5 x9
+#define r6 x10
+
+// Remind ourselves what else we can't destroy
+
+#define a3 x5
+#define a4 x6
+#define a5 x7
+
+// So we can have these as temps
+
+#define t1 x1
+#define t2 x14
+#define t3 x15
+#define t4 x16
+
+// Add in all the pure squares 33 + 44 + 55
+
+                mul     t1, a3, a3
+                adds    r0, r0, t1
+                mul     t2, a4, a4
+                mul     t3, a5, a5
+                umulh   t1, a3, a3
+                adcs    r1, r1, t1
+                umulh   t1, a4, a4
+                adcs    r2, r2, t2
+                adcs    r3, r3, t1
+                umulh   t1, a5, a5
+                adcs    r4, r4, t3
+                adcs    r5, r5, t1
+                adc     r6, r6, xzr
+
+// Now compose the 34 + 35 + 45 terms, which need doubling
+
+                mul     t1, a3, a4
+                mul     t2, a3, a5
+                mul     t3, a4, a5
+                umulh   t4, a3, a4
+                adds    t2, t2, t4
+                umulh   t4, a3, a5
+                adcs    t3, t3, t4
+                umulh   t4, a4, a5
+                adc     t4, t4, xzr
+
+// Double and add. Recycle one of the no-longer-needed inputs as a temp
+
+#define t5 x5
+
+                adds    t1, t1, t1
+                adcs    t2, t2, t2
+                adcs    t3, t3, t3
+                adcs    t4, t4, t4
+                adc     t5, xzr, xzr
+
+                adds    r1, r1, t1
+                adcs    r2, r2, t2
+                adcs    r3, r3, t3
+                adcs    r4, r4, t4
+                adcs    r5, r5, t5
+                adc     r6, r6, xzr
+
+// Turn r6 into a bitmask and do a masked addition of
+// [0;0;0;t3;t2;t1] = 2^384 - p_384, hence masked subtraction of p_384
+
+                neg     r6, r6
+                mov     t1, 0xffffffff00000001
+                and     t1, t1, r6
+                adds    r0, r0, t1
+                mov     t2, 0x00000000ffffffff
+                and     t2, t2, r6
+                adcs    r1, r1, t2
+                mov     t3, 0x0000000000000001
+                and     t3, t3, r6
+                adcs    r2, r2, t3
+                adcs    r3, r3, xzr
+                adcs    r4, r4, xzr
+                adc     r5, r5, xzr
+
+// Store it back
+
+                stp     r0, r1, [x0]
+                stp     r2, r3, [x0, 16]
+                stp     r4, r5, [x0, 32]
+
+                ret

--- a/Arm/bignum_cmul_p384.S
+++ b/Arm/bignum_cmul_p384.S
@@ -1,0 +1,141 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply by a single word modulo p_384, z := (c * x) mod p_384, assuming
+// x reduced
+// Inputs c, x[6]; output z[6]
+//
+//    extern void bignum_cmul_p384
+//     (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = c, X2 = x
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define c x1
+#define x x2
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+#define a0 x8
+#define a1 x9
+#define a2 x10
+#define a3 x11
+#define a4 x12
+#define a5 x13
+
+// Some shared here
+
+#define h x1
+#define h1 x12
+#define hn x13
+#define m x8
+#define l x9
+
+.text
+.globl bignum_cmul_p384
+
+bignum_cmul_p384:
+
+// First do the multiply, straightforwardly, getting [h; d5; ...; d0]
+
+                ldp     a0, a1, [x]
+                ldp     a2, a3, [x, #16]
+                ldp     a4, a5, [x, #32]
+                mul     d0, c, a0
+                mul     d1, c, a1
+                mul     d2, c, a2
+                mul     d3, c, a3
+                mul     d4, c, a4
+                mul     d5, c, a5
+                umulh   a0, c, a0
+                umulh   a1, c, a1
+                umulh   a2, c, a2
+                umulh   a3, c, a3
+                umulh   a4, c, a4
+                umulh   h, c, a5
+                adds    d1, d1, a0
+                adcs    d2, d2, a1
+                adcs    d3, d3, a2
+                adcs    d4, d4, a3
+                adcs    d5, d5, a4
+                adc     h, h, xzr
+
+// Let h be the top word of this intermediate product and l the low 6 words.
+// By the range hypothesis on the input, we know h1 = h + 1 does not wrap
+// And then -p_384 <= z - h1 * p_384 < p_384, so we just need to subtract
+// h1 * p_384 and then correct if that is negative by adding p_384.
+//
+// Write p_384 = 2^384 - r where r = 2^128 + 2^96 - 2^32 + 1
+//
+// We want z - (h + 1) * (2^384 - r)
+//       = (2^384 * h + l) - (h + 1) * (2^384 - r)
+//       = (l + (h + 1) * r) - 2^384.
+//
+// Thus we can do the computation in 6 words of l + (h + 1) * r, and if it
+// does *not* carry we need to add p_384. We can rewrite this as the following,
+// using ~h = 2^64 - (h + 1) and absorbing the 2^64 in the higher term
+// using h instead of h + 1.
+//
+//         l + (h + 1) * r
+//       = l + 2^128 * (h + 1) + 2^96 * (h + 1) - 2^32 * (h + 1) + (h + 1)
+//       = l + 2^128 * (h + 1) + 2^96 * h + 2^32 * ~h + (h + 1)
+
+                add     h1, h, 1
+                orn     hn, xzr, h
+                lsl     a0, hn, 32
+                extr    a1, h, hn, 32
+                lsr     a2, h, 32
+
+                adds    a0, a0, h1
+                adcs    a1, a1, xzr
+                adcs    a2, a2, h1
+                adc     a3, xzr, xzr
+
+                adds    d0, d0, a0
+                adcs    d1, d1, a1
+                adcs    d2, d2, a2
+                adcs    d3, d3, a3
+                adcs    d4, d4, xzr
+                adcs    d5, d5, xzr
+
+// Catch the carry and do a masked addition of p_384
+
+                csetm   m, cc
+
+                mov     l, 0x00000000ffffffff
+                and     l, l, m
+                adds    d0, d0, l
+                eor     l, l, m
+                adcs    d1, d1, l
+                mov     l, 0xfffffffffffffffe
+                and     l, l, m
+                adcs    d2, d2, l
+                adcs    d3, d3, m
+                adcs    d4, d4, m
+                adc     d5, d5, m
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+
+                ret

--- a/Arm/bignum_deamont_p384.S
+++ b/Arm/bignum_deamont_p384.S
@@ -1,0 +1,146 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
+// Input x[6]; output z[6]
+//
+//    extern void bignum_deamont_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Convert a 6-digit bignum x out of its (optionally almost) Montgomery form,
+// "almost" meaning any 6-digit input will work, with no range restriction.
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+.globl   bignum_deamont_p384
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+.macro          montreds d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+// Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+// Recycle d0 (which we know gets implicitly cancelled) to store it
+                lsl     \t1, \d0, 32
+                add     \d0, \t1, \d0
+// Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)
+// We need to subtract 2^32 * this, and we can ignore its lower 32
+// bits since by design it will cancel anyway; we only need the w_hi
+// part to get the carry propagation going.
+                lsr     \t1, \d0, 32
+                subs    \t1, \t1, \d0
+                sbc     \t2, \d0, xzr
+// Now select in t1 the field to subtract from d1
+                extr    \t1, \t2, \t1, 32
+// And now get the terms to subtract from d2 and d3
+                lsr     \t2, \t2, 32
+                adds    \t2, \t2, \d0
+                adc     \t3, xzr, xzr
+// Do the subtraction of that portion
+                subs    \d1, \d1, \t1
+                sbcs    \d2, \d2, \t2
+                sbcs    \d3, \d3, \t3
+                sbcs    \d4, \d4, xzr
+                sbcs    \d5, \d5, xzr
+// Now effectively add 2^384 * w by taking d0 as the input for the last sbc
+                sbc     \d6, \d0, xzr
+.endm
+
+// Input parameters
+
+#define z x0
+#define x x1
+
+// Rotating registers for the intermediate windows
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+
+// Other temporaries
+
+#define u x8
+#define v x9
+#define w x10
+
+bignum_deamont_p384:
+
+// Set up an initial window with the input x and an extra leading zero
+
+                ldp     d0, d1, [x]
+                ldp     d2, d3, [x, 16]
+                ldp     d4, d5, [x, 32]
+
+// Systematically scroll left doing 1-step reductions
+
+                montreds d0,d5,d4,d3,d2,d1,d0, u,v,w
+
+                montreds d1,d0,d5,d4,d3,d2,d1, u,v,w
+
+                montreds d2,d1,d0,d5,d4,d3,d2, u,v,w
+
+                montreds d3,d2,d1,d0,d5,d4,d3, u,v,w
+
+                montreds d4,d3,d2,d1,d0,d5,d4, u,v,w
+
+                montreds d5,d4,d3,d2,d1,d0,d5, u,v,w
+
+// Now compare end result in [d5;d4;d3;d2;d1;d0] = dd with p_384 by *adding*
+// 2^384 - p_384 = [0;0;0;w;v;u]. This will set CF if
+// dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384
+
+                mov     u, 0xffffffff00000001
+                mov     v, 0x00000000ffffffff
+                mov     w, 0x0000000000000001
+
+                adds    xzr, d0, u
+                adcs    xzr, d1, v
+                adcs    xzr, d2, w
+                adcs    xzr, d3, xzr
+                adcs    xzr, d4, xzr
+                adcs    xzr, d5, xzr
+
+// Convert the condition dd >= p_384 into a bitmask in w and do a masked
+// subtraction of p_384, via a masked addition of 2^384 - p_384:
+
+                csetm   w, cs
+                and     u, u, w
+                adds    d0, d0, u
+                and     v, v, w
+                adcs    d1, d1, v
+                and     w, w, 1
+                adcs    d2, d2, w
+                adcs    d3, d3, xzr
+                adcs    d4, d4, xzr
+                adc     d5, d5, xzr
+
+// Store it back
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, 16]
+                stp     d4, d5, [z, 32]
+
+                ret

--- a/Arm/bignum_demont_p384.S
+++ b/Arm/bignum_demont_p384.S
@@ -1,0 +1,117 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+//
+//    extern void bignum_demont_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// This assumes the input is < p_384 for correctness. If this is not the case,
+// use the variant "bignum_deamont_p384" instead.
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+.globl   bignum_demont_p384
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+.macro          montreds d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+// Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+// Recycle d0 (which we know gets implicitly cancelled) to store it
+                lsl     \t1, \d0, 32
+                add     \d0, \t1, \d0
+// Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)
+// We need to subtract 2^32 * this, and we can ignore its lower 32
+// bits since by design it will cancel anyway; we only need the w_hi
+// part to get the carry propagation going.
+                lsr     \t1, \d0, 32
+                subs    \t1, \t1, \d0
+                sbc     \t2, \d0, xzr
+// Now select in t1 the field to subtract from d1
+                extr    \t1, \t2, \t1, 32
+// And now get the terms to subtract from d2 and d3
+                lsr     \t2, \t2, 32
+                adds    \t2, \t2, \d0
+                adc     \t3, xzr, xzr
+// Do the subtraction of that portion
+                subs    \d1, \d1, \t1
+                sbcs    \d2, \d2, \t2
+                sbcs    \d3, \d3, \t3
+                sbcs    \d4, \d4, xzr
+                sbcs    \d5, \d5, xzr
+// Now effectively add 2^384 * w by taking d0 as the input for the last sbc
+                sbc     \d6, \d0, xzr
+.endm
+
+// Input parameters
+
+#define z x0
+#define x x1
+
+// Rotating registers for the intermediate windows
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+
+// Other temporaries
+
+#define u x8
+#define v x9
+#define w x10
+
+bignum_demont_p384:
+
+// Set up an initial window with the input x and an extra leading zero
+
+                ldp     d0, d1, [x]
+                ldp     d2, d3, [x, 16]
+                ldp     d4, d5, [x, 32]
+
+// Systematically scroll left doing 1-step reductions
+
+                montreds d0,d5,d4,d3,d2,d1,d0, u,v,w
+
+                montreds d1,d0,d5,d4,d3,d2,d1, u,v,w
+
+                montreds d2,d1,d0,d5,d4,d3,d2, u,v,w
+
+                montreds d3,d2,d1,d0,d5,d4,d3, u,v,w
+
+                montreds d4,d3,d2,d1,d0,d5,d4, u,v,w
+
+                montreds d5,d4,d3,d2,d1,d0,d5, u,v,w
+
+// This is already our answer with no correction needed
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, 16]
+                stp     d4, d5, [z, 32]
+
+                ret

--- a/Arm/bignum_double_p384.S
+++ b/Arm/bignum_double_p384.S
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Double modulo p_384, z := (2 * x) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+//
+//    extern void bignum_double_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define x x1
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+#define c x8
+#define n0 x9
+#define n1 x10
+#define n2 x11
+#define n3 x12
+#define n4 x13
+#define n5 x14
+
+.text
+.globl bignum_double_p384
+
+bignum_double_p384:
+
+// Double the input number as 2 * x = c + [d5; d4; d3; d2; d1; d0]
+// It's worth considering doing this with extr...63 instead
+
+                ldp     d0, d1, [x]
+                ldp     d2, d3, [x, #16]
+                ldp     d4, d5, [x, #32]
+                adds    d0, d0, d0
+                adcs    d1, d1, d1
+                adcs    d2, d2, d2
+                adcs    d3, d3, d3
+                adcs    d4, d4, d4
+                adcs    d5, d5, d5
+                adc     c, xzr, xzr
+
+// Subtract p_384 to give 2 * x - p_384 = c + [n5; n4; n3; n2; n1; n0]
+
+                mov     n0, 0x00000000ffffffff
+                subs    n0, d0, n0
+                mov     n1, 0xffffffff00000000
+                sbcs    n1, d1, n1
+                mov     n2, 0xfffffffffffffffe
+                sbcs    n2, d2, n2
+                adcs    n3, d3, xzr
+                adcs    n4, d4, xzr
+                adcs    n5, d5, xzr
+                sbcs    c, c, xzr
+
+// Now CF is set (because of inversion) if 2 * x >= p_384, in which case the
+// correct result is [n5; n4; n3; n2; n1; n0], otherwise
+// [d5; d4; d3; d2; d1; d0]
+
+                csel    d0, d0, n0, cc
+                csel    d1, d1, n1, cc
+                csel    d2, d2, n2, cc
+                csel    d3, d3, n3, cc
+                csel    d4, d4, n4, cc
+                csel    d5, d5, n5, cc
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+
+                ret

--- a/Arm/bignum_half_p384.S
+++ b/Arm/bignum_half_p384.S
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Halve modulo p_384, z := (x / 2) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+//
+//    extern void bignum_half_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define x x1
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+#define d6 x8
+#define d7 x9
+#define m x10
+#define n x11
+
+.text
+.globl bignum_half_p384
+
+bignum_half_p384:
+
+// Load the 4 digits of x
+
+                ldp     d0, d1, [x]
+                ldp     d2, d3, [x, 16]
+                ldp     d4, d5, [x, 32]
+
+// Get a bitmask corresponding to the lowest bit of the input
+
+                and     m, d0, 1
+                neg     m, m
+
+// Do a masked addition of p_384, catching carry in a 7th word
+
+                mov     n, 0x00000000ffffffff
+                and     n, n, m
+                adds    d0, d0, n
+                mov     n, 0xffffffff00000000
+                and     n, n, m
+                adcs    d1, d1, n
+                mov     n, 0xfffffffffffffffe
+                and     n, n, m
+                adcs    d2, d2, n
+                adcs    d3, d3, m
+                adcs    d4, d4, m
+                adcs    d5, d5, m
+                adc     d6, xzr, xzr
+
+// Now shift that sum right one place
+
+                extr    d0, d1, d0, 1
+                extr    d1, d2, d1, 1
+                extr    d2, d3, d2, 1
+                extr    d3, d4, d3, 1
+                extr    d4, d5, d4, 1
+                extr    d5, d6, d5, 1
+
+// Store back
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, 16]
+                stp     d4, d5, [z, 32]
+
+// Return
+
+                ret

--- a/Arm/bignum_mod_p384.S
+++ b/Arm/bignum_mod_p384.S
@@ -1,0 +1,177 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Reduce modulo field characteristic, z := x mod p_384
+// Input x[k]; output z[6]
+//
+//    extern void bignum_mod_p384
+//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//
+// Standard ARM ABI: X0 = z, X1 = k, X2 = x
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define k x1
+#define x x2
+
+#define m0 x3
+#define m1 x4
+#define m2 x5
+#define m3 x6
+#define m4 x7
+#define m5 x8
+
+#define t0 x9
+#define t1 x10
+#define t2 x11
+#define t3 x12
+#define t4 x13
+#define t5 x14
+
+#define n0 x15
+#define n1 x16
+#define n2 x17
+
+.text
+.globl bignum_mod_p384
+
+bignum_mod_p384:
+
+// If the input is already <= 5 words long, go to a trivial "copy" path
+
+                cmp     k, 6
+                bcc     short
+
+// Otherwise load the top 6 digits (top-down) and reduce k by 6
+
+                sub     k, k, 6
+                lsl     t0, k, 3
+                add     t0, t0, x
+                ldp     m4, m5, [t0, 32]
+                ldp     m2, m3, [t0, 16]
+                ldp     m0, m1, [t0]
+
+// Load the complicated lower three words of p_384 = [-1;-1;-1;n2;n1;n0]
+
+                mov     n0, 0x00000000ffffffff
+                mov     n1, 0xffffffff00000000
+                mov     n2, 0xfffffffffffffffe
+
+// Reduce the top 6 digits mod p_384 (a conditional subtraction of p_384)
+
+                subs    t0, m0, n0
+                sbcs    t1, m1, n1
+                sbcs    t2, m2, n2
+                adcs    t3, m3, xzr
+                adcs    t4, m4, xzr
+                adcs    t5, m5, xzr
+                csel    m0, m0, t0, cc
+                csel    m1, m1, t1, cc
+                csel    m2, m2, t2, cc
+                csel    m3, m3, t3, cc
+                csel    m4, m4, t4, cc
+                csel    m5, m5, t5, cc
+
+// Now do (k-6) iterations of 7->6 word modular reduction
+
+                cbz     k, writeback
+loop:
+
+// Decrement k and load the next digit as t5. We now want to reduce
+// [m5;m4;m3;m2;m1;m0;t5] |-> [m5;m4;m3;m2;m1;m0]; the shuffling downwards is
+// absorbed into the various ALU operations
+
+                sub     k, k, 1
+                ldr     t5, [x, k, LSL 3]
+
+// Initial quotient approximation q = min (h + 1) (2^64 - 1)
+
+                adds    m5, m5, 1
+                csetm   t3, cs
+                add     m5, m5, t3
+                orn     n1, xzr, t3
+                sub     t2, m5, 1
+                sub     t1, xzr, m5
+
+// Correction term [m5;t2;t1;t0] = q * (2^384 - p_384), using m5 as a temp
+
+                lsl     t0, t1, 32
+                extr    t1, t2, t1, 32
+                lsr     t2, t2, 32
+                adds    t0, t0, m5
+                adcs    t1, t1, xzr
+                adcs    t2, t2, m5
+                adc     m5, xzr, xzr
+
+// Addition to the initial value
+
+                adds    t0, t5, t0
+                adcs    t1, m0, t1
+                adcs    t2, m1, t2
+                adcs    t3, m2, m5
+                adcs    t4, m3, xzr
+                adcs    t5, m4, xzr
+                adc     n1, n1, xzr
+
+// Use net top of the 7-word answer (now in n1) for masked correction
+
+                and     m5, n0, n1
+                adds    m0, t0, m5
+                eor     m5, m5, n1
+                adcs    m1, t1, m5
+                and     m5, n2, n1
+                adcs    m2, t2, m5
+                adcs    m3, t3, n1
+                adcs    m4, t4, n1
+                adc     m5, t5, n1
+
+                cbnz    k, loop
+
+// Finally write back [m5;m4;m3;m2;m1;m0] and return
+
+writeback:
+                stp     m0, m1, [z]
+                stp     m2, m3, [z, 16]
+                stp     m4, m5, [z, 32]
+
+                ret
+
+// Short case: just copy the input with zero-padding
+
+short:
+                mov     m0, xzr
+                mov     m1, xzr
+                mov     m2, xzr
+                mov     m3, xzr
+                mov     m4, xzr
+                mov     m5, xzr
+
+                cbz     k, writeback
+                ldr     m0, [x]
+                subs    k, k, 1
+                beq     writeback
+                ldr     m1, [x, 8]
+                subs    k, k, 1
+                beq     writeback
+                ldr     m2, [x, 16]
+                subs    k, k, 1
+                beq     writeback
+                ldr     m3, [x, 24]
+                subs    k, k, 1
+                beq     writeback
+                ldr     m4, [x, 32]
+                b       writeback
+

--- a/Arm/bignum_montmul_p384.S
+++ b/Arm/bignum_montmul_p384.S
@@ -1,0 +1,423 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^384) mod p_384
+// Inputs x[6], y[6]; output z[6]
+//
+//    extern void bignum_montmul_p384
+//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//
+// Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
+// satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in
+// the "usual" case x < p_384 and y < p_384).
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+.globl   bignum_montmul_p384
+
+// ---------------------------------------------------------------------------
+// Macro returning (c,h,l) = 3-word 1s complement (x - y) * (w - z)
+// c,h,l,t should all be different
+// t,h should not overlap w,z
+// ---------------------------------------------------------------------------
+
+.macro muldiffn c,h,l, t, x,y, w,z
+        subs    \t, \x, \y
+        cneg    \t, \t, cc
+        csetm   \c, cc
+        subs    \h, \w, \z
+        cneg    \h, \h, cc
+        mul     \l, \t, \h
+        umulh   \h, \t, \h
+        cinv    \c, \c, cc
+        eor     \l, \l, \c
+        eor     \h, \h, \c
+.endm
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+.macro          montreds d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+// Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+// Recycle d0 (which we know gets implicitly cancelled) to store it
+                lsl     \t1, \d0, 32
+                add     \d0, \t1, \d0
+// Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)
+// We need to subtract 2^32 * this, and we can ignore its lower 32
+// bits since by design it will cancel anyway; we only need the w_hi
+// part to get the carry propagation going.
+                lsr     \t1, \d0, 32
+                subs    \t1, \t1, \d0
+                sbc     \t2, \d0, xzr
+// Now select in t1 the field to subtract from d1
+                extr    \t1, \t2, \t1, 32
+// And now get the terms to subtract from d2 and d3
+                lsr     \t2, \t2, 32
+                adds    \t2, \t2, \d0
+                adc     \t3, xzr, xzr
+// Do the subtraction of that portion
+                subs    \d1, \d1, \t1
+                sbcs    \d2, \d2, \t2
+                sbcs    \d3, \d3, \t3
+                sbcs    \d4, \d4, xzr
+                sbcs    \d5, \d5, xzr
+// Now effectively add 2^384 * w by taking d0 as the input for the last sbc
+                sbc     \d6, \d0, xzr
+.endm
+
+#define a0 x3
+#define a1 x4
+#define a2 x5
+#define a3 x6
+#define a4 x7
+#define a5 x8
+#define b0 x9
+#define b1 x10
+#define b2 x11
+#define b3 x12
+#define b4 x13
+#define b5 x14
+
+#define s0 x15
+#define s1 x16
+#define s2 x17
+#define s3 x19
+#define s4 x20
+#define s5 x1
+#define s6 x2
+
+#define t1 x21
+#define t2 x22
+#define t3 x23
+#define t4 x24
+
+bignum_montmul_p384:
+
+// Save some registers
+
+                stp     x19, x20, [sp, -16]!
+                stp     x21, x22, [sp, -16]!
+                stp     x23, x24, [sp, -16]!
+
+// Load in all words of both inputs
+
+                ldp     a0, a1, [x1]
+                ldp     a2, a3, [x1, 16]
+                ldp     a4, a5, [x1, 32]
+                ldp     b0, b1, [x2]
+                ldp     b2, b3, [x2, 16]
+                ldp     b4, b5, [x2, 32]
+
+// Multiply low halves with a 3x3->6 ADK multiplier as [s5;s4;s3;s2;s1;s0]
+
+                mul     s0, a0, b0
+                mul     t1, a1, b1
+                mul     t2, a2, b2
+                umulh   t3, a0, b0
+                umulh   t4, a1, b1
+                umulh   s5, a2, b2
+
+                adds    t3, t3, t1
+                adcs    t4, t4, t2
+                adc     s5, s5, xzr
+
+                adds    s1, t3, s0
+                adcs    s2, t4, t3
+                adcs    s3, s5, t4
+                adc     s4, s5, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, t3
+                adcs    s4, s4, t4
+                adc     s5, s5, xzr
+
+                muldiffn t3,t2,t1, t4, a0,a1, b1,b0
+                adds    xzr, t3, 1
+                adcs    s1, s1, t1
+                adcs    s2, s2, t2
+                adcs    s3, s3, t3
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a0,a2, b2,b0
+                adds    xzr, t3, 1
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a1,a2, b2,b1
+                adds    xzr, t3, 1
+                adcs    s3, s3, t1
+                adcs    s4, s4, t2
+                adc     s5, s5, t3
+
+// Perform three "short" Montgomery steps on the low product
+// This shifts it to an offset compatible with middle terms
+// Stash the result temporarily in the output buffer
+// We could keep this in registers by directly adding to it in the next
+// ADK block, but if anything that seems to be slightly slower
+
+                montreds s0,s5,s4,s3,s2,s1,s0, t1,t2,t3
+
+                montreds s1,s0,s5,s4,s3,s2,s1, t1,t2,t3
+
+                montreds s2,s1,s0,s5,s4,s3,s2, t1,t2,t3
+
+                stp     s3, s4, [x0]
+                stp     s5, s0, [x0, 16]
+                stp     s1, s2, [x0, 32]
+
+// Multiply high halves with a 3x3->6 ADK multiplier as [s5;s4;s3;s2;s1;s0]
+
+                mul     s0, a3, b3
+                mul     t1, a4, b4
+                mul     t2, a5, b5
+                umulh   t3, a3, b3
+                umulh   t4, a4, b4
+                umulh   s5, a5, b5
+
+                adds    t3, t3, t1
+                adcs    t4, t4, t2
+                adc     s5, s5, xzr
+
+                adds    s1, t3, s0
+                adcs    s2, t4, t3
+                adcs    s3, s5, t4
+                adc     s4, s5, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, t3
+                adcs    s4, s4, t4
+                adc     s5, s5, xzr
+
+                muldiffn t3,t2,t1, t4, a3,a4, b4,b3
+                adds    xzr, t3, 1
+                adcs    s1, s1, t1
+                adcs    s2, s2, t2
+                adcs    s3, s3, t3
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a3,a5, b5,b3
+                adds    xzr, t3, 1
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a4,a5, b5,b4
+                adds    xzr, t3, 1
+                adcs    s3, s3, t1
+                adcs    s4, s4, t2
+                adc     s5, s5, t3
+
+// Compute sign-magnitude a0,[a5,a4,a3] = x_hi - x_lo
+
+                subs    a3, a3, a0
+                sbcs    a4, a4, a1
+                sbcs    a5, a5, a2
+                sbc     a0, xzr, xzr
+                adds    xzr, a0, 1
+                eor     a3, a3, a0
+                adcs    a3, a3, xzr
+                eor     a4, a4, a0
+                adcs    a4, a4, xzr
+                eor     a5, a5, a0
+                adc     a5, a5, xzr
+
+// Compute sign-magnitude b5,[b2,b1,b0] = y_lo - y_hi
+
+                subs    b0, b0, b3
+                sbcs    b1, b1, b4
+                sbcs    b2, b2, b5
+                sbc     b5, xzr, xzr
+
+                adds    xzr, b5, 1
+                eor     b0, b0, b5
+                adcs    b0, b0, xzr
+                eor     b1, b1, b5
+                adcs    b1, b1, xzr
+                eor     b2, b2, b5
+                adc     b2, b2, xzr
+
+// Save the correct sign for the sub-product in b5
+
+                eor     b5, a0, b5
+
+// Add the high H to the modified low term L' and re-stash 6 words,
+// keeping top word in s6
+
+                ldp     t1, t2, [x0]
+                adds    s0, s0, t1
+                adcs    s1, s1, t2
+                ldp     t1, t2, [x0, 16]
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                ldp     t1, t2, [x0, 32]
+                adcs    s4, s4, t1
+                adcs    s5, s5, t2
+                adc     s6, xzr, xzr
+                stp     s0, s1, [x0]
+                stp     s2, s3, [x0, 16]
+                stp     s4, s5, [x0, 32]
+
+// Multiply with yet a third 3x3 ADK for the complex mid-term
+
+                mul     s0, a3, b0
+                mul     t1, a4, b1
+                mul     t2, a5, b2
+                umulh   t3, a3, b0
+                umulh   t4, a4, b1
+                umulh   s5, a5, b2
+
+                adds    t3, t3, t1
+                adcs    t4, t4, t2
+                adc     s5, s5, xzr
+
+                adds    s1, t3, s0
+                adcs    s2, t4, t3
+                adcs    s3, s5, t4
+                adc     s4, s5, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, t3
+                adcs    s4, s4, t4
+                adc     s5, s5, xzr
+
+                muldiffn t3,t2,t1, t4, a3,a4, b1,b0
+                adds    xzr, t3, 1
+                adcs    s1, s1, t1
+                adcs    s2, s2, t2
+                adcs    s3, s3, t3
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a3,a5, b2,b0
+                adds    xzr, t3, 1
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a4,a5, b2,b1
+                adds    xzr, t3, 1
+                adcs    s3, s3, t1
+                adcs    s4, s4, t2
+                adc     s5, s5, t3
+
+// Unstash the H + L' sum to add in twice
+
+                ldp     a0, a1, [x0]
+                ldp     a2, a3, [x0, 16]
+                ldp     a4, a5, [x0, 32]
+
+// Set up a sign-modified version of the mid-product in a long accumulator
+// as [b3;b2;b1;b0;s5;s4;s3;s2;s1;s0], adding in the H + L' term once with
+// zero offset as this signed value is created
+
+                adds    xzr, b5, 1
+                eor     s0, s0, b5
+                adcs    s0, s0, a0
+                eor     s1, s1, b5
+                adcs    s1, s1, a1
+                eor     s2, s2, b5
+                adcs    s2, s2, a2
+                eor     s3, s3, b5
+                adcs    s3, s3, a3
+                eor     s4, s4, b5
+                adcs    s4, s4, a4
+                eor     s5, s5, b5
+                adcs    s5, s5, a5
+                adcs    b0, b5, s6
+                adcs    b1, b5, xzr
+                adcs    b2, b5, xzr
+                adc     b3, b5, xzr
+
+// Add in the stashed H + L' term an offset of 3 words as well
+
+                adds    s3, s3, a0
+                adcs    s4, s4, a1
+                adcs    s5, s5, a2
+                adcs    b0, b0, a3
+                adcs    b1, b1, a4
+                adcs    b2, b2, a5
+                adc     b3, b3, s6
+
+// Do three more Montgomery steps on the composed term
+
+                montreds s0,s5,s4,s3,s2,s1,s0, t1,t2,t3
+                montreds s1,s0,s5,s4,s3,s2,s1, t1,t2,t3
+                montreds s2,s1,s0,s5,s4,s3,s2, t1,t2,t3
+
+                adds    b0, b0, s0
+                adcs    b1, b1, s1
+                adcs    b2, b2, s2
+                adc     b3, b3, xzr
+
+// Because of the way we added L' in two places, we can overspill by
+// more than usual in Montgomery, with the result being only known to
+// be < 3 * p_384, not the usual < 2 * p_384. So now we do a more
+// elaborate final correction in the style of bignum_cmul_p384, just
+// a little bit simpler because we know q is small.
+
+                add     t2, b3, 1
+                lsl     t1, t2, 32
+                subs    t4, t2, t1
+                sbc     t1, t1, xzr
+
+                adds    s3, s3, t4
+                adcs    s4, s4, t1
+                adcs    s5, s5, t2
+                adcs    b0, b0, xzr
+                adcs    b1, b1, xzr
+                adcs    b2, b2, xzr
+
+                csetm   t2, cc
+
+                mov     t3, 0x00000000ffffffff
+                and     t3, t3, t2
+                adds    s3, s3, t3
+                eor     t3, t3, t2
+                adcs    s4, s4, t3
+                mov     t3, 0xfffffffffffffffe
+                and     t3, t3, t2
+                adcs    s5, s5, t3
+                adcs    b0, b0, t2
+                adcs    b1, b1, t2
+                adc     b2, b2, t2
+
+// Write back the result
+
+                stp     s3, s4, [x0]
+                stp     s5, b0, [x0, 16]
+                stp     b1, b2, [x0, 32]
+
+// Restore registers and return
+
+                ldp     x23, x24, [sp], 16
+                ldp     x21, x22, [sp], 16
+                ldp     x19, x20, [sp], 16
+
+                ret

--- a/Arm/bignum_montsqr_p384.S
+++ b/Arm/bignum_montsqr_p384.S
@@ -1,0 +1,380 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^384) mod p_384
+// Input x[6]; output z[6]
+//
+//    extern void bignum_montsqr_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
+// guaranteed in particular if x < p_384 initially (the "intended" case).
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+.globl   bignum_montsqr_p384
+
+// ---------------------------------------------------------------------------
+// Macro returning (c,h,l) = 3-word 1s complement (x - y) * (w - z)
+// c,h,l,t should all be different
+// t,h should not overlap w,z
+// ---------------------------------------------------------------------------
+
+.macro muldiffn c,h,l, t, x,y, w,z
+        subs    \t, \x, \y
+        cneg    \t, \t, cc
+        csetm   \c, cc
+        subs    \h, \w, \z
+        cneg    \h, \h, cc
+        mul     \l, \t, \h
+        umulh   \h, \t, \h
+        cinv    \c, \c, cc
+        eor     \l, \l, \c
+        eor     \h, \h, \c
+.endm
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+.macro          montreds d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+// Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+// Recycle d0 (which we know gets implicitly cancelled) to store it
+                lsl     \t1, \d0, 32
+                add     \d0, \t1, \d0
+// Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)
+// We need to subtract 2^32 * this, and we can ignore its lower 32
+// bits since by design it will cancel anyway; we only need the w_hi
+// part to get the carry propagation going.
+                lsr     \t1, \d0, 32
+                subs    \t1, \t1, \d0
+                sbc     \t2, \d0, xzr
+// Now select in t1 the field to subtract from d1
+                extr    \t1, \t2, \t1, 32
+// And now get the terms to subtract from d2 and d3
+                lsr     \t2, \t2, 32
+                adds    \t2, \t2, \d0
+                adc     \t3, xzr, xzr
+// Do the subtraction of that portion
+                subs    \d1, \d1, \t1
+                sbcs    \d2, \d2, \t2
+                sbcs    \d3, \d3, \t3
+                sbcs    \d4, \d4, xzr
+                sbcs    \d5, \d5, xzr
+// Now effectively add 2^384 * w by taking d0 as the input for the last sbc
+                sbc     \d6, \d0, xzr
+.endm
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define a4 x6
+#define a5 x7
+
+#define c0 x8
+#define c1 x9
+#define c2 x10
+#define c3 x11
+#define c4 x12
+#define c5 x13
+#define d1 x14
+#define d2 x15
+#define d3 x16
+#define d4 x17
+
+bignum_montsqr_p384:
+
+// Load in all words of the input
+
+                ldp     a0, a1, [x1]
+                ldp     a2, a3, [x1, 16]
+                ldp     a4, a5, [x1, 32]
+
+// Square the low half getting a result in [c5;c4;c3;c2;c1;c0]
+
+                mul     d1, a0, a1
+                mul     d2, a0, a2
+                mul     d3, a1, a2
+                mul     c0, a0, a0
+                mul     c2, a1, a1
+                mul     c4, a2, a2
+
+                umulh   d4, a0, a1
+                adds    d2, d2, d4
+                umulh   d4, a0, a2
+                adcs    d3, d3, d4
+                umulh   d4, a1, a2
+                adcs    d4, d4, xzr
+
+                umulh   c1, a0, a0
+                umulh   c3, a1, a1
+                umulh   c5, a2, a2
+
+                adds    d1, d1, d1
+                adcs    d2, d2, d2
+                adcs    d3, d3, d3
+                adcs    d4, d4, d4
+                adc     c5, c5, xzr
+
+                adds    c1, c1, d1
+                adcs    c2, c2, d2
+                adcs    c3, c3, d3
+                adcs    c4, c4, d4
+                adc     c5, c5, xzr
+
+// Perform three "short" Montgomery steps on the low square
+// This shifts it to an offset compatible with middle product
+// Stash the result temporarily in the output buffer (to avoid more registers)
+
+                montreds c0,c5,c4,c3,c2,c1,c0, d1,d2,d3
+
+                montreds c1,c0,c5,c4,c3,c2,c1, d1,d2,d3
+
+                montreds c2,c1,c0,c5,c4,c3,c2, d1,d2,d3
+
+                stp     c3, c4, [x0]
+                stp     c5, c0, [x0, 16]
+                stp     c1, c2, [x0, 32]
+
+// Compute product of the cross-term with ADK 3x3->6 multiplier
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define a4 x6
+#define a5 x7
+#define s0 x8
+#define s1 x9
+#define s2 x10
+#define s3 x11
+#define s4 x12
+#define s5 x13
+
+#define l1 x14
+#define l2 x15
+#define h0 x16
+#define h1 x17
+#define h2 x1
+
+#define s6 h1
+#define c  l1
+#define h  l2
+#define l  h0
+#define t  h1
+
+                mul     s0, a0, a3
+                mul     l1, a1, a4
+                mul     l2, a2, a5
+                umulh   h0, a0, a3
+                umulh   h1, a1, a4
+                umulh   h2, a2, a5
+
+                adds    h0, h0, l1
+                adcs    h1, h1, l2
+                adc     h2, h2, xzr
+
+                adds    s1, h0, s0
+                adcs    s2, h1, h0
+                adcs    s3, h2, h1
+                adc     s4, h2, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, h0
+                adcs    s4, s4, h1
+                adc     s5, h2, xzr
+
+                muldiffn c,h,l, t, a0,a1, a4,a3
+                adds    xzr, c, 1
+                adcs    s1, s1, l
+                adcs    s2, s2, h
+                adcs    s3, s3, c
+                adcs    s4, s4, c
+                adc     s5, s5, c
+
+                muldiffn c,h,l, t, a0,a2, a5,a3
+                adds    xzr, c, 1
+                adcs    s2, s2, l
+                adcs    s3, s3, h
+                adcs    s4, s4, c
+                adc     s5, s5, c
+
+                muldiffn c,h,l, t, a1,a2, a5,a4
+                adds    xzr, c, 1
+                adcs    s3, s3, l
+                adcs    s4, s4, h
+                adc     s5, s5, c
+
+// Double it and add the stashed Montgomerified low square
+
+                adds    s0, s0, s0
+                adcs    s1, s1, s1
+                adcs    s2, s2, s2
+                adcs    s3, s3, s3
+                adcs    s4, s4, s4
+                adcs    s5, s5, s5
+                adc     s6, xzr, xzr
+
+                ldp     a0, a1, [x0]
+                adds    s0, s0, a0
+                adcs    s1, s1, a1
+                ldp     a0, a1, [x0, 16]
+                adcs    s2, s2, a0
+                adcs    s3, s3, a1
+                ldp     a0, a1, [x0, 32]
+                adcs    s4, s4, a0
+                adcs    s5, s5, a1
+                adc     s6, s6, xzr
+
+// Montgomery-reduce the combined low and middle term another thrice
+
+                montreds s0,s5,s4,s3,s2,s1,s0, a0,a1,a2
+
+                montreds s1,s0,s5,s4,s3,s2,s1, a0,a1,a2
+
+                montreds s2,s1,s0,s5,s4,s3,s2, a0,a1,a2
+
+                adds    s6, s6, s0
+                adcs    s0, s1, xzr
+                adcs    s1, s2, xzr
+                adcs    s2, xzr, xzr
+
+// Our sum so far is in [s2;s1;s0;s6;s5;s4;s3]
+// Choose more intuitive names
+
+#define r0 x11
+#define r1 x12
+#define r2 x13
+#define r3 x17
+#define r4 x8
+#define r5 x9
+#define r6 x10
+
+// Remind ourselves what else we can't destroy
+
+#define a3 x5
+#define a4 x6
+#define a5 x7
+
+// So we can have these as temps
+
+#define t1 x1
+#define t2 x14
+#define t3 x15
+#define t4 x16
+
+// Add in all the pure squares 33 + 44 + 55
+
+                mul     t1, a3, a3
+                adds    r0, r0, t1
+                mul     t2, a4, a4
+                mul     t3, a5, a5
+                umulh   t1, a3, a3
+                adcs    r1, r1, t1
+                umulh   t1, a4, a4
+                adcs    r2, r2, t2
+                adcs    r3, r3, t1
+                umulh   t1, a5, a5
+                adcs    r4, r4, t3
+                adcs    r5, r5, t1
+                adc     r6, r6, xzr
+
+// Now compose the 34 + 35 + 45 terms, which need doubling
+
+                mul     t1, a3, a4
+                mul     t2, a3, a5
+                mul     t3, a4, a5
+                umulh   t4, a3, a4
+                adds    t2, t2, t4
+                umulh   t4, a3, a5
+                adcs    t3, t3, t4
+                umulh   t4, a4, a5
+                adc     t4, t4, xzr
+
+// Double and add. Recycle one of the no-longer-needed inputs as a temp
+
+#define t5 x5
+
+                adds    t1, t1, t1
+                adcs    t2, t2, t2
+                adcs    t3, t3, t3
+                adcs    t4, t4, t4
+                adc     t5, xzr, xzr
+
+                adds    r1, r1, t1
+                adcs    r2, r2, t2
+                adcs    r3, r3, t3
+                adcs    r4, r4, t4
+                adcs    r5, r5, t5
+                adc     r6, r6, xzr
+
+// We know, writing B = 2^{6*64} that the full implicit result is
+// B^2 c <= z + (B - 1) * p < B * p + (B - 1) * p < 2 * B * p,
+// so the top half is certainly < 2 * p. If c = 1 already, we know
+// subtracting p will give the reduced modulus. But now we do a
+// comparison to catch cases where the residue is >= p.
+// First set [0;0;0;t3;t2;t1] = 2^384 - p_384
+
+                mov     t1, 0xffffffff00000001
+                mov     t2, 0x00000000ffffffff
+                mov     t3, 0x0000000000000001
+
+// Let dd = [] be the 6-word intermediate result.
+// Set CF if the addition dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384.
+
+                adds    xzr, r0, t1
+                adcs    xzr, r1, t2
+                adcs    xzr, r2, t3
+                adcs    xzr, r3, xzr
+                adcs    xzr, r4, xzr
+                adcs    xzr, r5, xzr
+
+// Now just add this new carry into the existing r6. It's easy to see they
+// can't both be 1 by our range assumptions, so this gives us a {0,1} flag
+
+                adc     r6, r6, xzr
+
+// Now convert it into a bitmask
+
+                sub     r6, xzr, r6
+
+// Masked addition of 2^384 - p_384, hence subtraction of p_384
+
+                and     t1, t1, r6
+                adds    r0, r0, t1
+                and     t2, t2, r6
+                adcs    r1, r1, t2
+                and     t3, t3, r6
+                adcs    r2, r2, t3
+                adcs    r3, r3, xzr
+                adcs    r4, r4, xzr
+                adc     r5, r5, xzr
+
+// Store it back
+
+                stp     r0, r1, [x0]
+                stp     r2, r3, [x0, 16]
+                stp     r4, r5, [x0, 32]
+
+                ret

--- a/Arm/bignum_neg_p384.S
+++ b/Arm/bignum_neg_p384.S
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Negate modulo p_384, z := (-x) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+//
+//    extern void bignum_neg_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define x x1
+
+#define p x2
+#define t x3
+
+#define d0 x4
+#define d1 x5
+#define d2 x6
+#define d3 x7
+#define d4 x8
+#define d5 x9
+
+.text
+.globl bignum_neg_p384
+
+bignum_neg_p384:
+
+// Load the 6 digits of x
+
+                ldp     d0, d1, [x]
+                ldp     d2, d3, [x, 16]
+                ldp     d4, d5, [x, 32]
+
+// Set a bitmask p for the input being nonzero, so that we avoid doing
+// -0 = p_384 and hence maintain strict modular reduction
+
+                orr     p, d0, d1
+                orr     t, d2, d3
+                orr     p, p, t
+                orr     t, d4, d5
+                orr     p, p, t
+                cmp     p, 0
+                csetm   p, ne
+
+// Load and mask the complicated lower three words of
+// p_384 = [-1;-1;-1;n2;n1;n0] and subtract, using mask itself for upper digits
+
+                mov     t, 0x00000000ffffffff
+                and     t, t, p
+                subs    d0, t, d0
+
+                mov     t, 0xffffffff00000000
+                and     t, t, p
+                sbcs    d1, t, d1
+
+                mov     t, 0xfffffffffffffffe
+                and     t, t, p
+                sbcs    d2, t, d2
+
+                sbcs    d3, p, d3
+                sbcs    d4, p, d4
+                sbc     d5, p, d5
+
+// Write back the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, 16]
+                stp     d4, d5, [z, 32]
+
+// Return
+
+                ret

--- a/Arm/bignum_optneg_p384.S
+++ b/Arm/bignum_optneg_p384.S
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Optionally negate modulo p_384, z := (-x) mod p_384 (if p nonzero) or
+// z := x (if p zero), assuming x reduced
+// Inputs p, x[6]; output z[6]
+//
+//    extern void bignum_optneg_p384
+//      (uint64_t z[static 6], uint64_t p, uint64_t x[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = p, X2 = x
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define p x1
+#define x x2
+
+#define d0 x3
+#define d1 x4
+#define d2 x5
+#define d3 x6
+#define d4 x7
+#define d5 x8
+#define n0 x9
+#define n1 x10
+#define n2 x11
+#define n3 x12
+#define n4 x13
+#define n5 x14
+
+.text
+.globl bignum_optneg_p384
+
+bignum_optneg_p384:
+
+// Load the 6 digits of x
+
+                ldp     d0, d1, [x]
+                ldp     d2, d3, [x, 16]
+                ldp     d4, d5, [x, 32]
+
+// Adjust p by zeroing it if the input is zero (to avoid giving -0 = p, which
+// is not strictly reduced even though it's correct modulo p)
+
+                orr     n0, d0, d1
+                orr     n1, d2, d3
+                orr     n2, d4, d5
+                orr     n3, n0, n1
+                orr     n4, n2, n3
+                cmp     n4, 0
+                csel    p, xzr, p, eq
+
+// Load the complicated lower three words of p_384 = [-1;-1;-1;n2;n1;n0] and -1
+
+                mov     n0, 0x00000000ffffffff
+                mov     n1, 0xffffffff00000000
+                mov     n2, 0xfffffffffffffffe
+                mov     n5, 0xffffffffffffffff
+
+// Do the subtraction, which by hypothesis does not underflow
+
+                subs    n0, n0, d0
+                sbcs    n1, n1, d1
+                sbcs    n2, n2, d2
+                sbcs    n3, n5, d3
+                sbcs    n4, n5, d4
+                sbcs    n5, n5, d5
+
+// Set condition code if original x is nonzero and p was nonzero
+
+                cmp     p, 0
+
+// Hence multiplex and write back
+
+                csel    n0, n0, d0, ne
+                csel    n1, n1, d1, ne
+                csel    n2, n2, d2, ne
+                csel    n3, n3, d3, ne
+                csel    n4, n4, d4, ne
+                csel    n5, n5, d5, ne
+
+                stp     n0, n1, [z]
+                stp     n2, n3, [z, 16]
+                stp     n4, n5, [z, 32]
+
+// Return
+
+                ret

--- a/Arm/bignum_sub_p384.S
+++ b/Arm/bignum_sub_p384.S
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Subtract modulo p_384, z := (x - y) mod p_384
+// Inputs x[6], y[6]; output z[6]
+//
+//    extern void bignum_sub_p384
+//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define x x1
+#define y x2
+
+#define c x3
+#define l x4
+#define d0 x5
+#define d1 x6
+#define d2 x7
+#define d3 x8
+#define d4 x9
+#define d5 x10
+
+.text
+.globl bignum_sub_p384
+
+bignum_sub_p384:
+
+// First just subtract the numbers as [d5; d4; d3; d2; d1; d0]
+// Set a mask based on (inverted) carry indicating x < y = correction is needed
+
+                ldp     d0, d1, [x]
+                ldp     l, c, [y]
+                subs    d0, d0, l
+                sbcs    d1, d1, c
+                ldp     d2, d3, [x, #16]
+                ldp     l, c, [y, #16]
+                sbcs    d2, d2, l
+                sbcs    d3, d3, c
+                ldp     d4, d5, [x, #32]
+                ldp     l, c, [y, #32]
+                sbcs    d4, d4, l
+                sbcs    d5, d5, c
+
+// Create a mask for the condition x < y, when we need to correct
+
+                csetm   c, cc
+
+// Now correct by adding masked p_384
+
+                mov     l, 0x00000000ffffffff
+                and     l, l, c
+                adds    d0, d0, l
+                eor     l, l, c
+                adcs    d1, d1, l
+                mov     l, 0xfffffffffffffffe
+                and     l, l, c
+                adcs    d2, d2, l
+                adcs    d3, d3, c
+                adcs    d4, d4, c
+                adc     d5, d5, c
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+
+                ret

--- a/Arm/bignum_tomont_p384.S
+++ b/Arm/bignum_tomont_p384.S
@@ -1,0 +1,133 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert to Montgomery form z := (2^256 * x) mod p_256
+// Input x[6]; output z[6]
+//
+//    extern void bignum_tomont_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+.globl   bignum_tomont_p384
+
+// ----------------------------------------------------------------------------
+// Core "x |-> (2^64 * x) mod p_384" macro, with x assumed to be < p_384.
+// Input is in [d6;d5;d4;d3;d2;d1] and output in [d5;d4;d3;d2;d1;d0]
+// using d6 as well as t1, t2, t3 as temporaries.
+// ----------------------------------------------------------------------------
+
+.macro modstep_p384 d6,d5,d4,d3,d2,d1,d0, t1,t2,t3
+// Initial quotient approximation q = min (h + 1) (2^64 - 1)
+                adds    \d6, \d6, 1
+                csetm   \t3, cs
+                add     \d6, \d6, \t3
+                orn     \t3, xzr, \t3
+                sub     \t2, \d6, 1
+                sub     \t1, xzr, \d6
+// Correction term [d6;t2;t1;d0] = q * (2^384 - p_384)
+                lsl     \d0, \t1, 32
+                extr    \t1, \t2, \t1, 32
+                lsr     \t2, \t2, 32
+                adds    \d0, \d0, \d6
+                adcs    \t1, \t1, xzr
+                adcs    \t2, \t2, \d6
+                adc     \d6, xzr, xzr
+// Addition to the initial value
+                adds    \d1, \d1, \t1
+                adcs    \d2, \d2, \t2
+                adcs    \d3, \d3, \d6
+                adcs    \d4, \d4, xzr
+                adcs    \d5, \d5, xzr
+                adc     \t3, \t3, xzr
+// Use net top of the 7-word answer in t3 for masked correction
+                mov     \t1, 0x00000000ffffffff
+                and     \t1, \t1, \t3
+                adds    \d0, \d0, \t1
+                eor     \t1, \t1, \t3
+                adcs    \d1, \d1, \t1
+                mov     \t1, 0xfffffffffffffffe
+                and     \t1, \t1, \t3
+                adcs    \d2, \d2, \t1
+                adcs    \d3, \d3, \t3
+                adcs    \d4, \d4, \t3
+                adc     \d5, \d5, \t3
+.endm
+
+bignum_tomont_p384:
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+#define d6 x8
+
+#define t1 x9
+#define t2 x10
+#define t3 x11
+
+#define n0 x8
+#define n1 x9
+#define n2 x10
+#define n3 x11
+#define n4 x12
+#define n5 x1
+
+// Load the inputs
+
+                ldp     d0, d1, [x1]
+                ldp     d2, d3, [x1, 16]
+                ldp     d4, d5, [x1, 32]
+
+// Do an initial reduction to make sure this is < p_384, using just
+// a copy of the bignum_mod_p384 code. This is needed to set up the
+// invariant "input < p_384" for the main modular reduction steps.
+
+                mov     n0, 0x00000000ffffffff
+                mov     n1, 0xffffffff00000000
+                mov     n2, 0xfffffffffffffffe
+                subs    n0, d0, n0
+                sbcs    n1, d1, n1
+                sbcs    n2, d2, n2
+                adcs    n3, d3, xzr
+                adcs    n4, d4, xzr
+                adcs    n5, d5, xzr
+                csel    d0, d0, n0, cc
+                csel    d1, d1, n1, cc
+                csel    d2, d2, n2, cc
+                csel    d3, d3, n3, cc
+                csel    d4, d4, n4, cc
+                csel    d5, d5, n5, cc
+
+// Successively multiply by 2^64 and reduce
+
+                modstep_p384 d5,d4,d3,d2,d1,d0,d6, t1,t2,t3
+                modstep_p384 d4,d3,d2,d1,d0,d6,d5, t1,t2,t3
+                modstep_p384 d3,d2,d1,d0,d6,d5,d4, t1,t2,t3
+                modstep_p384 d2,d1,d0,d6,d5,d4,d3, t1,t2,t3
+                modstep_p384 d1,d0,d6,d5,d4,d3,d2, t1,t2,t3
+                modstep_p384 d0,d6,d5,d4,d3,d2,d1, t1,t2,t3
+
+// Store the result and return
+
+                stp     d1, d2, [x0]
+                stp     d3, d4, [x0, #16]
+                stp     d5, d6, [x0, #32]
+
+                ret

--- a/Arm/bignum_triple_p384.S
+++ b/Arm/bignum_triple_p384.S
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Triple modulo p_384, z := (3 * x) mod p_384
+// Input x[6]; output z[6]
+//
+//    extern void bignum_triple_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// The input x can be any 6-digit bignum, not necessarily reduced modulo p_384,
+// and the result is always fully reduced, i.e. z = (3 * x) mod p_384.
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define x x1
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+#define h x8
+
+// Slightly offset aliases for the d_i for readability.
+
+#define a0 x3
+#define a1 x4
+#define a2 x5
+#define a3 x6
+#define a4 x7
+#define a5 x8
+
+// More aliases for the same thing at different stages
+
+#define q x8
+#define c x8
+
+// Other temporary variables
+
+#define t0 x9
+#define t1 x10
+
+.text
+.globl bignum_triple_p384
+
+bignum_triple_p384:
+
+// Load the inputs
+
+                ldp     a0, a1, [x]
+                ldp     a2, a3, [x, #16]
+                ldp     a4, a5, [x, #32]
+
+// First do the multiplication by 3, getting z = [h; d5; ...; d0]
+
+                lsl     d0, a0, 1
+                adds    d0, d0, a0
+                extr    d1, a1, a0, 63
+                adcs    d1, d1, a1
+                extr    d2, a2, a1, 63
+                adcs    d2, d2, a2
+                extr    d3, a3, a2, 63
+                adcs    d3, d3, a3
+                extr    d4, a4, a3, 63
+                adcs    d4, d4, a4
+                extr    d5, a5, a4, 63
+                adcs    d5, d5, a5
+                lsr     h, a5, 63
+                adc     h, h, xzr
+
+// For this limited range a simple quotient estimate of q = h + 1 works, where
+// h = floor(z / 2^384). Then -p_384 <= z - q * p_384 < p_384, so we just need
+// to subtract q * p_384 and then if that's negative, add back p_384.
+
+                add     q, h, 1
+
+// Initial subtraction of z - q * p_384, with bitmask c for the carry
+// Actually done as an addition of (z - 2^384 * h) + q * (2^384 - p_384)
+// which, because q = h + 1, is exactly 2^384 + (z - q * p_384), and
+// therefore CF <=> 2^384 + (z - q * p_384) >= 2^384 <=> z >= q * p_384.
+
+                lsl     t1, q, 32
+                subs    t0, q, t1
+                sbc     t1, t1, xzr
+
+                adds    d0, d0, t0
+                adcs    d1, d1, t1
+                adcs    d2, d2, q
+                adcs    d3, d3, xzr
+                adcs    d4, d4, xzr
+                adcs    d5, d5, xzr
+                csetm   c, cc
+
+// Use the bitmask c for final masked addition of p_384.
+
+                mov     t0, 0x00000000ffffffff
+                and     t0, t0, c
+                adds    d0, d0, t0
+                eor     t0, t0, c
+                adcs    d1, d1, t0
+                mov     t0, 0xfffffffffffffffe
+                and     t0, t0, c
+                adcs    d2, d2, t0
+                adcs    d3, d3, c
+                adcs    d4, d4, c
+                adc     d5, d5, c
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+
+                ret

--- a/X86/bignum_add_p384.asm
+++ b/X86/bignum_add_p384.asm
@@ -1,0 +1,111 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
+; Inputs x[6], y[6]; output z[6]
+;
+;    extern void bignum_add_p384
+;     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+;
+; Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+%define y rdx
+
+%define d0 rax
+%define d1 rcx
+%define d2 r8
+%define d3 r9
+%define d4 r10
+%define d5 r11
+
+; Re-use the input pointers as temporaries once we're done
+
+%define a rsi
+%define c rdx
+
+        global  bignum_add_p384
+
+bignum_add_p384:
+
+; Add the inputs as 2^384 * c + [d5;d4;d3;d2;d1;d0] = x + y
+; This could be combined with the next block using ADCX and ADOX.
+
+        mov     d0, [x]
+        add     d0, [y]
+        mov     d1, [x+8]
+        adc     d1, [y+8]
+        mov     d2, [x+16]
+        adc     d2, [y+16]
+        mov     d3, [x+24]
+        adc     d3, [y+24]
+        mov     d4, [x+32]
+        adc     d4, [y+32]
+        mov     d5, [x+40]
+        adc     d5, [y+40]
+        mov     c, 0
+        adc     c, c
+
+; Now subtract p_384 from 2^384 * c + [d5;d4;d3;d2;d1;d0] to get x + y - p_384
+; This is actually done by *adding* the 7-word negation r_384 = 2^448 - p_384
+; where r_384 = [-1; 0; 0; 0; 1; 0x00000000ffffffff; 0xffffffff00000001]
+
+        mov     a, 0xffffffff00000001
+        add     d0, a
+        mov     a, 0x00000000ffffffff
+        adc     d1, a
+        adc     d2, 1
+        adc     d3, 0
+        adc     d4, 0
+        adc     d5, 0
+        adc     c, -1
+
+; Since by hypothesis x < p_384 we know x + y - p_384 < 2^384, so the top
+; carry c actually gives us a bitmask for x + y - p_384 < 0, which we
+; now use to make r' = mask * (2^384 - p_384) for a compensating subtraction.
+; We don't quite have enough ABI-modifiable registers to create all three
+; nonzero digits of r while maintaining d0..d5, but make the first two now.
+
+        and     c, a                    ; c = masked 0x00000000ffffffff
+        xor     a, a
+        sub     a, c                    ; a = masked 0xffffffff00000001
+
+; Do the first two digits of addition and writeback
+
+        sub     d0, a
+        mov     [z], d0
+        sbb     d1, c
+        mov     [z+8], d1
+
+; Preserve the carry chain while creating the extra masked digit since
+; the logical operation will clear CF
+
+        sbb     d0, d0
+        and     c, a                    ; c = masked 0x0000000000000001
+        neg     d0
+
+; Do the rest of the addition and writeback
+
+        sbb     d2, c
+        mov     [z+16], d2
+        sbb     d3, 0
+        mov     [z+24], d3
+        sbb     d4, 0
+        mov     [z+32], d4
+        sbb     d5, 0
+        mov     [z+40], d5
+
+        ret

--- a/X86/bignum_amontmul_p384.asm
+++ b/X86/bignum_amontmul_p384.asm
@@ -1,0 +1,295 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Almost-Montgomery multiply, z :== (x * y / 2^384) (congruent mod p_384)
+; Inputs x[6], y[6]; output z[6]
+;
+;    extern void bignum_amontmul_p384
+;     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+;
+; Does z :== (x * y / 2^384) mod p_384, meaning that the result, in the native
+; size 6, is congruent modulo p_384, but might not be fully reduced mod p_384.
+; This is why it is called *almost* Montgomery multiplication.
+;
+; Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+
+; We move the y argument here so we can use rdx for multipliers
+
+%define y rcx
+
+; Fairly consistently used as a zero register
+
+%define zero rbp
+
+; Some temp registers for the last correction stage
+
+%define d rax
+%define u rdx
+%define v rcx
+%define w rbx
+
+; Macro "mulpadd i x" adds rdx * x to the (i,i+1) position of
+; the rotating register window r15,...,r8 maintaining consistent
+; double-carrying using ADCX and ADOX and using rbx/rax as temps
+
+%macro mulpadd 2
+        mulx    rbx, rax, %2
+%if (%1 % 8 == 0)
+        adcx    r8, rax
+        adox    r9, rbx
+%elif (%1 % 8 == 1)
+        adcx    r9, rax
+        adox    r10, rbx
+%elif (%1 % 8 == 2)
+        adcx    r10, rax
+        adox    r11, rbx
+%elif (%1 % 8 == 3)
+        adcx    r11, rax
+        adox    r12, rbx
+%elif (%1 % 8 == 4)
+        adcx    r12, rax
+        adox    r13, rbx
+%elif (%1 % 8 == 5)
+        adcx    r13, rax
+        adox    r14, rbx
+%elif (%1 % 8 == 6)
+        adcx    r14, rax
+        adox    r15, rbx
+%elif (%1 % 8 == 7)
+        adcx    r15, rax
+        adox    r8, rbx
+%endif
+
+%endm
+
+; Core one-step Montgomery reduction macro. Takes input in
+; [d7;d6;d5;d4;d3;d2;d1;d0] and returns result in [d7;d6;d5;d4;d3;d2;d1],
+; adding to the existing contents, re-using d0 as a temporary internally
+;
+; We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+; where w = [d0 + (d0<<32)] mod 2^64
+;
+;       montredc d7,d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+;
+; This particular variant, with its mix of addition and subtraction
+; at the top, is not intended to maintain a coherent carry or borrow out.
+; It is assumed the final result would fit in [d7;d6;d5;d4;d3;d2;d1].
+; which is always the case here as the top word is even always in {0,1}
+
+%macro montredc 8
+; Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+                mov     rdx, %8
+                shl     rdx, 32
+                add     rdx, %8
+; Construct [rbp;rbx;rax;-] = (2^384 - p_384) * w
+; We know the lowest word will cancel so we can re-use %8 as a temp
+                xor     rbp, rbp
+                mov     rax, 0xffffffff00000001
+                mulx    rax, rbx, rax
+                mov     rbx, 0x00000000ffffffff
+                mulx    rbx, %8, rbx
+                adc     rax, %8
+                adc     rbx, rdx
+                adc     rbp, 0
+; Now subtract that and add 2^384 * w
+                sub     %7, rax
+                sbb     %6, rbx
+                sbb     %5, rbp
+                sbb     %4, 0
+                sbb     %3, 0
+                sbb     rdx, 0
+                add     %2, rdx
+                adc     %1, 0
+%endm
+
+                global  bignum_amontmul_p384
+                section .text
+
+bignum_amontmul_p384:
+
+; Save more registers to play with
+
+        push    rbx
+        push    rbp
+        push    r12
+        push    r13
+        push    r14
+        push    r15
+
+; Copy y into a safe register to start with
+
+        mov     y, rdx
+
+; Do row 0 computation, which is a bit different:
+; set up initial window [r14,r13,r12,r11,r10,r9,r8] = y[0] * x
+; Unlike later, we only need a single carry chain
+
+        mov     rdx, [y+8*0]
+        mulx    r9, r8, [x+8*0]
+        mulx    r10, rbx, [x+8*1]
+        add     r9, rbx
+        mulx    r11, rbx, [x+8*2]
+        adc     r10, rbx
+        mulx    r12, rbx, [x+8*3]
+        adc     r11, rbx
+        mulx    r13, rbx, [x+8*4]
+        adc     r12, rbx
+        mulx    r14, rbx, [x+8*5]
+        adc     r13, rbx
+        adc     r14, 0
+
+; Montgomery reduce the zeroth window
+
+        xor     r15, r15
+        montredc r15, r14,r13,r12,r11,r10,r9,r8
+
+; Add row 1
+
+        xor     zero, zero
+        mov     rdx, [y+8*1]
+        xor     r8, r8
+        mulpadd 1, [x]
+        mulpadd 2, [x+8*1]
+        mulpadd 3, [x+8*2]
+        mulpadd 4, [x+8*3]
+        mulpadd 5, [x+8*4]
+        mulpadd 6, [x+8*5]
+        adcx    r15, zero
+        adox    r8, zero
+        adcx    r8, zero
+
+; Montgomery reduce window 1
+
+        montredc r8, r15,r14,r13,r12,r11,r10,r9
+
+; Add row 2
+
+        xor     zero, zero
+        mov     rdx, [y+8*2]
+        xor     r9, r9
+        mulpadd 2, [x]
+        mulpadd 3, [x+8*1]
+        mulpadd 4, [x+8*2]
+        mulpadd 5, [x+8*3]
+        mulpadd 6, [x+8*4]
+        mulpadd 7, [x+8*5]
+        adcx    r8, zero
+        adox    r9, zero
+        adcx    r9, zero
+
+; Montgomery reduce window 2
+
+        montredc r9, r8,r15,r14,r13,r12,r11,r10
+
+; Add row 3
+
+        xor     zero, zero
+        mov     rdx, [y+8*3]
+        xor     r10, r10
+        mulpadd 3, [x]
+        mulpadd 4, [x+8*1]
+        mulpadd 5, [x+8*2]
+        mulpadd 6, [x+8*3]
+        mulpadd 7, [x+8*4]
+        mulpadd 8, [x+8*5]
+        adcx    r9, zero
+        adox    r10, zero
+        adcx    r10, zero
+
+; Montgomery reduce window 3
+
+        montredc r10, r9,r8,r15,r14,r13,r12,r11
+
+; Add row 4
+
+        xor     zero, zero
+        mov     rdx, [y+8*4]
+        xor     r11, r11
+        mulpadd 4, [x]
+        mulpadd 5, [x+8*1]
+        mulpadd 6, [x+8*2]
+        mulpadd 7, [x+8*3]
+        mulpadd 8, [x+8*4]
+        mulpadd 9, [x+8*5]
+        adcx    r10, zero
+        adox    r11, zero
+        adcx    r11, zero
+
+; Montgomery reduce window 4
+
+        montredc r11, r10,r9,r8,r15,r14,r13,r12
+
+; Add row 5
+
+        xor     zero, zero
+        mov     rdx, [y+8*5]
+        xor     r12, r12
+        mulpadd 5, [x]
+        mulpadd 6, [x+8*1]
+        mulpadd 7, [x+8*2]
+        mulpadd 8, [x+8*3]
+        mulpadd 9, [x+8*4]
+        mulpadd 10, [x+8*5]
+        adcx    r11, zero
+        adox    r12, zero
+        adcx    r12, zero
+
+; Montgomery reduce window 5
+
+        montredc r12, r11,r10,r9,r8,r15,r14,r13
+
+; We now have a pre-reduced 7-word form [r12;r11;r10;r9;r8;r15;r14]
+; Load non-trivial digits of 2^384 - p_384 = [0; 0; 0; w; v; u] masked with r12
+; Note that this only gives *almost* Montgomery reduction
+
+        neg     r12
+        mov     u, 0xffffffff00000001
+        and     u, r12
+        mov     v, 0x00000000ffffffff
+        and     v, r12
+        mov     w, 0x0000000000000001
+        and     w, r12
+
+; Masked addition of 2^384 - p_384, hence subtraction of p_384
+
+        add    r14, u
+        adc    r15, v
+        adc    r8, w
+        adc    r9, 0
+        adc    r10, 0
+        adc    r11, 0
+
+; Write back the result
+
+        mov     [z], r14
+        mov     [z+8*1], r15
+        mov     [z+8*2], r8
+        mov     [z+8*3], r9
+        mov     [z+8*4], r10
+        mov     [z+8*5], r11
+
+; Restore registers and return
+
+        pop     r15
+        pop     r14
+        pop     r13
+        pop     r12
+        pop     rbp
+        pop     rbx
+
+        ret

--- a/X86/bignum_amontsqr_p384.asm
+++ b/X86/bignum_amontsqr_p384.asm
@@ -1,0 +1,292 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Almost-Montgomery square, z :== (x^2 / 2^384) (congruent mod p_384)
+; Input x[6]; output z[6]
+;
+;    extern void bignum_amontsqr_p384
+;     (uint64_t z[static 6], uint64_t x[static 6]);
+;
+; "Almost" means the 6-digit result is correct mod p_384 but might not be
+; fully reduced, i.e. it might be >= p_384. Use "bignum_montsqr_p384" instead
+; where full reduction to a result < p_384 is desired/needed.
+;
+; Standard x86-64 ABI: RDI = z, RSI = x
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+
+; Some temp registers for the last correction stage
+
+%define d rax
+%define u rdx
+%define v r10
+%define w r11
+
+; A zero register, very often
+
+%define zero rbp
+
+; Macro "mulpadd i x" adds rdx * x to the (i,i+1) position of the
+; rotating register window r15,...,r8 maintaining consistent
+; double-carrying using ADCX and ADOX and using rbx/rax as temps
+
+%macro mulpadd 2
+        mulx    rbx, rax, %2
+%if (%1 % 8 == 0)
+        adcx    r8, rax
+        adox    r9, rbx
+%elif (%1 % 8 == 1)
+        adcx    r9, rax
+        adox    r10, rbx
+%elif (%1 % 8 == 2)
+        adcx    r10, rax
+        adox    r11, rbx
+%elif (%1 % 8 == 3)
+        adcx    r11, rax
+        adox    r12, rbx
+%elif (%1 % 8 == 4)
+        adcx    r12, rax
+        adox    r13, rbx
+%elif (%1 % 8 == 5)
+        adcx    r13, rax
+        adox    r14, rbx
+%elif (%1 % 8 == 6)
+        adcx    r14, rax
+        adox    r15, rbx
+%elif (%1 % 8 == 7)
+        adcx    r15, rax
+        adox    r8, rbx
+%endif
+
+%endm
+
+; Core one-step "short" Montgomery reduction macro. Takes input in
+; [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+; adding to the existing [d5;d4;d3;d2;d1] and re-using d0 as a
+; temporary internally, as well as rdx, rax and the temporary t.
+; It is OK for d6 and d0 to be the same register (they often are)
+;
+; We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+; where w = [d0 + (d0<<32)] mod 2^64
+;
+;       montreds d6,d5,d4,d3,d2,d1,d0, t
+
+%macro montreds 8
+; Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+                mov     rdx, %7
+                shl     rdx, 32
+                add     rdx, %7
+; Construct [%8;%7;rax;-] = (2^384 - p_384) * w
+; We know the lowest word will cancel so we can re-use %7 as a temp, and %8
+                mov     rax, 0xffffffff00000001
+                mulx    rax, %7, rax
+                mov     %8, 0x00000000ffffffff
+                mulx    %7, %8, %8
+                add     rax, %8
+                adc     %7, rdx
+                mov     %8, 0
+                adc     %8, %8
+; Now subtract that and add 2^384 * w
+                sub     %6, rax
+                sbb     %5, %7
+                sbb     %4, %8
+                sbb     %3, 0
+                sbb     %2, 0
+                mov     %1, rdx
+                sbb     %1, 0
+%endm
+
+                global  bignum_amontsqr_p384
+
+bignum_amontsqr_p384:
+
+; Save more registers to play with
+
+        push    rbx
+        push    rbp
+        push    r12
+        push    r13
+        push    r14
+        push    r15
+
+; Set up an initial window [rcx;r15;...r9] = [34;05;03;01]
+; Note that we are using rcx as the first step past the rotating window
+
+        mov     rdx, [x]
+        mulx    r10, r9, [x+8*1]
+        mulx    r12, r11, [x+8*3]
+        mulx    r14, r13, [x+8*5]
+        mov     rdx, [x+8*3]
+        mulx    rcx, r15, [x+8*4]
+
+; Clear our zero register, and also initialize the flags for the carry chain
+
+        xor     zero, zero
+
+; Chain in the addition of 02 + 12 + 13 + 14 + 15 to that window
+; (no carry-out possible)
+
+        mov     rdx, [x+8*2]
+        mulpadd 2,[x]
+        mulpadd 3, [x+8*1]
+        mov     rdx, [x+8*1]
+        mulpadd 4, [x+8*3]
+        mulpadd 5, [x+8*4]
+        mulpadd 6, [x+8*5]
+        adcx    r15, zero
+        adox    rcx, zero
+        adcx    rcx, zero
+
+; Again zero out the flags. Actually they are already cleared but it may
+; help decouple these in the OOO engine not to wait for the chain above
+
+        xor     zero, zero
+
+; Now chain in the 04 + 23 + 24 + 25 + 35 + 45 terms
+; We are running out of registers in our rotating window, so we start
+; using rbx (and hence need care with using mulpadd after this). Thus
+; our result so far is in [rbp;rbx;rcx;r15;...r9]
+
+        mov     rdx, [x+8*4]
+        mulpadd 4, [x]
+        mov     rdx, [x+8*2]
+        mulpadd 5, [x+8*3]
+        mulpadd 6, [x+8*4]
+        mulx    rdx, rax, [x+8*5]
+        adcx    r15, rax
+        adox    rcx, rdx
+
+; First set up the last couple of spots in our window, [rbp;rbx] = 45
+; then add the last other term 35
+
+        mov     rdx, [x+8*5]
+        mulx    rbp, rbx, [x+8*4]
+        mulx    rdx, rax, [x+8*3]
+        adcx    rcx, rax
+        adox    rbx, rdx
+        mov     rax, 0
+        adcx    rbx, rax
+        adox    rbp, rax
+        adcx    rbp, rax
+
+; Just for a clear fresh start for the flags; we don't use the zero
+
+        xor     rax, rax
+
+; Double and add to the 00 + 11 + 22 + 33 + 44 + 55 terms
+; For one glorious moment the entire squaring result is all in the
+; register file as [rsi;rbp;rbx;rcx;r15;...;r8]
+; (since we've now finished with x we can re-use rsi)
+
+        mov     rdx, [x]
+        mulx    rax, r8, [x]
+        adcx    r9, r9
+        adox    r9, rax
+        mov     rdx, [x+8*1]
+        mulx    rdx, rax, rdx
+        adcx    r10, r10
+        adox    r10, rax
+        adcx    r11, r11
+        adox    r11, rdx
+        mov     rdx, [x+8*2]
+        mulx    rdx, rax, rdx
+        adcx    r12, r12
+        adox    r12, rax
+        adcx    r13, r13
+        adox    r13, rdx
+        mov     rdx, [x+8*3]
+        mulx    rdx, rax, rdx
+        adcx    r14, r14
+        adox    r14, rax
+        adcx    r15, r15
+        adox    r15, rdx
+        mov     rdx, [x+8*4]
+        mulx    rdx, rax, rdx
+        adcx    rcx, rcx
+        adox    rcx, rax
+        adcx    rbx, rbx
+        adox    rbx, rdx
+        mov     rdx, [x+8*5]
+        mulx    rsi, rax, rdx
+        adcx    rbp, rbp
+        adox    rbp, rax
+        mov     rax, 0
+        adcx    rsi, rax
+        adox    rsi, rax
+
+; We need just *one* more register as a temp for the Montgomery steps.
+; Since we are writing to the z buffer anyway, make use of that to stash rbx.
+
+        mov     [z], rbx
+
+; Montgomery reduce the r13,...,r8 window 6 times
+
+        montreds r8,r13,r12,r11,r10,r9,r8, rbx
+        montreds r9,r8,r13,r12,r11,r10,r9, rbx
+        montreds r10,r9,r8,r13,r12,r11,r10, rbx
+        montreds r11,r10,r9,r8,r13,r12,r11, rbx
+        montreds r12,r11,r10,r9,r8,r13,r12, rbx
+        montreds r13,r12,r11,r10,r9,r8,r13, rbx
+
+; Now we can safely restore rbx before accumulating
+
+        mov     rbx, [z]
+
+        add     r14, r8
+        adc     r15, r9
+        adc     rcx, r10
+        adc     rbx, r11
+        adc     rbp, r12
+        adc     rsi, r13
+        sbb     r8, r8
+
+; We now have a pre-reduced 7-word form [-r8;rsi;rbp;rbx;rcx;r15;r14]
+; Load non-trivial digits [0;0;0;w;v;u] = 2^384 - p_384 masked by r8
+
+        mov     u, 0xffffffff00000001
+        and     u, r8
+        mov     v, 0x00000000ffffffff
+        and     v, r8
+        mov     w, 0x0000000000000001
+        and     w, r8
+
+; Masked addition of 2^384 - p_384, hence subtraction of p_384
+
+        add    r14, u
+        adc    r15, v
+        adc    rcx, w
+        adc    rbx, 0
+        adc    rbp, 0
+        adc    rsi, 0
+
+; Write back the result
+
+        mov     [z], r14
+        mov     [z+8*1], r15
+        mov     [z+8*2], rcx
+        mov     [z+8*3], rbx
+        mov     [z+8*4], rbp
+        mov     [z+8*5], rsi
+
+; Restore registers and return
+
+        pop     r15
+        pop     r14
+        pop     r13
+        pop     r12
+        pop     rbp
+        pop     rbx
+        ret

--- a/X86/bignum_cmul_p384.asm
+++ b/X86/bignum_cmul_p384.asm
@@ -1,0 +1,132 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Multiply by a single word modulo p_384, z := (c * x) mod p_384, assuming
+; x reduced
+; Inputs c, x[6]; output z[6]
+;
+;    extern void bignum_cmul_p384
+;     (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
+;
+; Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
+; ----------------------------------------------------------------------------
+
+%define z rdi
+
+%define x rcx   ; Temporarily moved here for initial multiply
+%define m rdx   ; Likewise this is thrown away after initial multiply
+
+%define a rax
+%define c rcx
+
+%define d0 rsi
+%define d1 r8
+%define d2 r9
+%define d3 r10
+%define d4 r11
+%define d5 r12
+
+%define q rdx   ; Multiplier again for second stage
+
+        section .text
+        global  bignum_cmul_p384
+
+bignum_cmul_p384:
+
+; We seem to need (just!) one extra register, which we need to save and restore
+
+                push    r12
+
+; Shuffle inputs (since we want multiplier in rdx)
+
+                mov     x, rdx
+                mov     m, rsi
+
+; Multiply, accumulating the result as 2^384 * h + [d5;d4;d3;d2;d1;d0]
+; but actually immediately producing q = h + 1, our quotient approximation,
+; by adding 1 to it. Note that by hypothesis x is reduced mod p_384, so our
+; product is <= (2^64 - 1) * (p_384 - 1) and hence  h <= 2^64 - 2, meaning
+; there is no danger this addition of 1 could wrap.
+
+                mulx    d1, d0, [x]
+                mulx    d2, a, [x+8]
+                add     d1, a
+                mulx    d3,a, [x+16]
+                adc     d2, a
+                mulx    d4,a, [x+24]
+                adc     d3, a
+                mulx    d5,a, [x+32]
+                adc     d4, a
+                mulx    q,a, [x+40]
+                adc     d5, a
+                adc     q, 1
+
+; It's easy to see -p_384 <= z - q * p_384 < p_384, so we just need to
+; subtract q * p_384 and then correct if that is negative by adding p_384.
+;
+; Write p_384 = 2^384 - r where r = 2^128 + 2^96 - 2^32 + 1
+;
+; We want z - q * (2^384 - r)
+;       = (2^384 * h + l) - q * (2^384 - r)
+;       = 2^384 * (h - q) + (l + q * r)
+;       = 2^384 * (-1) + (l + q * r)
+
+                xor     c, c
+                mov     a, 0xffffffff00000001
+                mulx    c, a, a
+                adcx    d0, a
+                adox    d1, c
+                mov     a, 0x00000000ffffffff
+                mulx    c, a, a
+                adcx    d1, a
+                adox    d2, c
+                adcx    d2, q
+                mov     a, 0
+                mov     c, 0
+                adox    a, a
+                adc     d3, a
+                adc     d4, c
+                adc     d5, c
+                adc     c, c
+                sub     c, 1
+
+; The net c value is now the top word of the 7-word answer, hence will
+; be -1 if we need a corrective addition, 0 otherwise, usable as a mask.
+; Now use that mask for a masked addition of p_384, which again is in
+; fact done by a masked subtraction of 2^384 - p_384, so that we only
+; have three nonzero digits and so can avoid using another register.
+
+                mov     q, 0x00000000ffffffff
+                xor     a, a
+                and     q, c
+                sub     a, q
+                and     c, 1
+
+                sub     d0, a
+                mov     [z], d0
+                sbb     d1, q
+                mov     [z+8], d1
+                sbb     d2, c
+                mov     [z+16], d2
+                sbb     d3, 0
+                mov     [z+24], d3
+                sbb     d4, 0
+                mov     [z+32], d4
+                sbb     d5, 0
+                mov     [z+40], d5
+
+; Return
+
+                pop     r12
+                ret

--- a/X86/bignum_deamont_p384.asm
+++ b/X86/bignum_deamont_p384.asm
@@ -1,0 +1,168 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
+; Input x[6]; output z[6]
+;
+;    extern void bignum_deamont_p384
+;     (uint64_t z[static 6], uint64_t x[static 6]);
+;
+; Convert a 6-digit bignum x out of its (optionally almost) Montgomery form,
+; "almost" meaning any 6-digit input will work, with no range restriction.
+;
+; Standard x86-64 ABI: RDI = z, RSI = x
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+
+; Additional temps in the correction phase
+
+%define u rax
+%define v rcx
+%define w rdx
+
+; Core one-step "short" Montgomery reduction macro. Takes input in
+; [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+; adding to the existing contents of [d5;d4;d3;d2;d1;d0]. This
+; is intended only for 6-word inputs as in mapping out of Montgomery,
+; not for the general case of Montgomery multiplication. It is fine
+; for d6 to be the same register as d0.
+;
+; Parms:  montreds d6,d5,d4,d3,d2,d1,d0
+;
+; We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+; where w = [d0 + (d0<<32)] mod 2^64
+
+%macro montreds 7
+; Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+                mov     rdx, %7
+                shl     rdx, 32
+                add     rdx, %7
+; Construct [rsi;rcx;rax;-] = (2^384 - p_384) * w
+; We know the lowest word will cancel so we can re-use %7 as a temp
+                xor     rsi, rsi
+                mov     rax, 0xffffffff00000001
+                mulx    rax, rcx, rax
+                mov     rcx, 0x00000000ffffffff
+                mulx    rcx, %7, rcx
+                adc     rax, %7
+                adc     rcx, rdx
+                adc     rsi, 0
+; Now subtract that and add 2^384 * w
+                sub     %6, rax
+                sbb     %5, rcx
+                sbb     %4, rsi
+                sbb     %3, 0
+                sbb     %2, 0
+                mov     %1, rdx
+                sbb     %1, 0
+%endm
+
+
+                global  bignum_deamont_p384
+                section .text
+
+bignum_deamont_p384:
+
+; Save more registers to play with
+
+        push    r12
+        push    r13
+
+; Set up an initial window [r13,r12,r11,r10,r9,r8] = x
+
+        mov     r8, [x+8*0]
+        mov     r9, [x+8*1]
+        mov     r10, [x+8*2]
+        mov     r11, [x+8*3]
+        mov     r12, [x+8*4]
+        mov     r13, [x+8*5]
+
+; Montgomery reduce window 0
+
+        montreds r8,r13,r12,r11,r10,r9,r8
+
+; Montgomery reduce window 1
+
+        montreds r9,r8,r13,r12,r11,r10,r9
+
+; Montgomery reduce window 2
+
+        montreds r10,r9,r8,r13,r12,r11,r10
+
+; Montgomery reduce window 3
+
+        montreds r11,r10,r9,r8,r13,r12,r11
+
+; Montgomery reduce window 4
+
+        montreds r12,r11,r10,r9,r8,r13,r12
+
+; Montgomery reduce window 5
+
+        montreds r13,r12,r11,r10,r9,r8,r13
+
+; Do a test addition of dd = [r13;r12;r11;r10;r9;r8] and
+; 2^384 - p_384 = [0;0;0;1;v;u], hence setting CF iff
+; dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384.
+
+        mov     u, 0xffffffff00000001
+        mov     v, 0x00000000ffffffff
+
+        mov     w, r8
+        add     w, u
+        mov     w, r9
+        adc     w, v
+        mov     w, r10
+        adc     w, 1
+        mov     w, r11
+        adc     w, 0
+        mov     w, r12
+        adc     w, 0
+        mov     w, r13
+        adc     w, 0
+
+; Convert CF to a bitmask in w
+
+        sbb     w, w
+
+; Masked addition of 2^384 - p_384, hence subtraction of p_384
+
+        and     u, w
+        and     v, w
+        and     w, 1
+
+        add    r8, u
+        adc    r9, v
+        adc    r10, w
+        adc    r11, 0
+        adc    r12, 0
+        adc    r13, 0
+
+; Write back the result
+
+        mov     [z], r8
+        mov     [z+8*1], r9
+        mov     [z+8*2], r10
+        mov     [z+8*3], r11
+        mov     [z+8*4], r12
+        mov     [z+8*5], r13
+
+; Restore registers and return
+
+        pop     r13
+        pop     r12
+
+        ret

--- a/X86/bignum_demont_p384.asm
+++ b/X86/bignum_demont_p384.asm
@@ -1,0 +1,125 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
+; Input x[6]; output z[6]
+;
+;    extern void bignum_demont_p384
+;     (uint64_t z[static 6], uint64_t x[static 6]);
+;
+; This assumes the input is < p_384 for correctness. If this is not the case,
+; use the variant "bignum_deamont_p384" instead.
+;
+; Standard x86-64 ABI: RDI = z, RSI = x
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+
+; Core one-step "short" Montgomery reduction macro. Takes input in
+; [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+; adding to the existing contents of [d5;d4;d3;d2;d1;d0]. This
+; is intended only for 6-word inputs as in mapping out of Montgomery,
+; not for the general case of Montgomery multiplication. It is fine
+; for d6 to be the same register as d0.
+;
+; Parms:  montreds d6,d5,d4,d3,d2,d1,d0
+;
+; We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+; where w = [d0 + (d0<<32)] mod 2^64
+
+%macro montreds 7
+; Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+                mov     rdx, %7
+                shl     rdx, 32
+                add     rdx, %7
+; Construct [rsi;rcx;rax;-] = (2^384 - p_384) * w
+; We know the lowest word will cancel so we can re-use %7 as a temp
+                xor     rsi, rsi
+                mov     rax, 0xffffffff00000001
+                mulx    rax, rcx, rax
+                mov     rcx, 0x00000000ffffffff
+                mulx    rcx, %7, rcx
+                adc     rax, %7
+                adc     rcx, rdx
+                adc     rsi, 0
+; Now subtract that and add 2^384 * w
+                sub     %6, rax
+                sbb     %5, rcx
+                sbb     %4, rsi
+                sbb     %3, 0
+                sbb     %2, 0
+                mov     %1, rdx
+                sbb     %1, 0
+%endm
+
+
+                global  bignum_demont_p384
+                section .text
+
+bignum_demont_p384:
+
+; Save more registers to play with
+
+        push    r12
+        push    r13
+
+; Set up an initial window [r13,r12,r11,r10,r9,r8] = x
+
+        mov     r8, [x+8*0]
+        mov     r9, [x+8*1]
+        mov     r10, [x+8*2]
+        mov     r11, [x+8*3]
+        mov     r12, [x+8*4]
+        mov     r13, [x+8*5]
+
+; Montgomery reduce window 0
+
+        montreds r8,r13,r12,r11,r10,r9,r8
+
+; Montgomery reduce window 1
+
+        montreds r9,r8,r13,r12,r11,r10,r9
+
+; Montgomery reduce window 2
+
+        montreds r10,r9,r8,r13,r12,r11,r10
+
+; Montgomery reduce window 3
+
+        montreds r11,r10,r9,r8,r13,r12,r11
+
+; Montgomery reduce window 4
+
+        montreds r12,r11,r10,r9,r8,r13,r12
+
+; Montgomery reduce window 5
+
+        montreds r13,r12,r11,r10,r9,r8,r13
+
+; Write back the result
+
+        mov     [z], r8
+        mov     [z+8*1], r9
+        mov     [z+8*2], r10
+        mov     [z+8*3], r11
+        mov     [z+8*4], r12
+        mov     [z+8*5], r13
+
+; Restore registers and return
+
+        pop     r13
+        pop     r12
+
+        ret

--- a/X86/bignum_double_p384.asm
+++ b/X86/bignum_double_p384.asm
@@ -1,0 +1,111 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Double modulo p_384, z := (2 * x) mod p_384, assuming x reduced
+; Input x[6]; output z[6]
+;
+;    extern void bignum_double_p384
+;     (uint64_t z[static 6], uint64_t x[static 6]);
+;
+; Standard x86-64 ABI: RDI = z, RSI = x
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+
+%define d0 rdx
+%define d1 rcx
+%define d2 r8
+%define d3 r9
+%define d4 r10
+%define d5 r11
+%define c rax
+
+; Re-use the input pointer as a temporary once we're done
+
+%define a rsi
+
+        global  bignum_double_p384
+
+bignum_double_p384:
+
+; Load the input and double it so that 2^384 * c + [d5;d4;d3;d2;d1;d0] = 2 * x
+; Could also consider using shld to decouple carries *or* combining this
+; and the next block into a double carry chain with ADCX and ADOX.
+
+        xor     c, c
+        mov     d0, [x]
+        add     d0, d0
+        mov     d1, [x+8]
+        adc     d1, d1
+        mov     d2, [x+16]
+        adc     d2, d2
+        mov     d3, [x+24]
+        adc     d3, d3
+        mov     d4, [x+32]
+        adc     d4, d4
+        mov     d5, [x+40]
+        adc     d5, d5
+        adc     c, c
+
+; Now subtract p_384 from 2^384 * c + [d5;d4;d3;d2;d1;d0] to get 2 * x - p_384
+; This is actually done by *adding* the 7-word negation r_384 = 2^448 - p_384
+; where r_384 = [-1; 0; 0; 0; 1; 0x00000000ffffffff; 0xffffffff00000001]
+
+        mov     a, 0xffffffff00000001
+        add     d0, a
+        mov     a, 0x00000000ffffffff
+        adc     d1, a
+        adc     d2, 1
+        adc     d3, 0
+        adc     d4, 0
+        adc     d5, 0
+        adc     c, -1
+
+; Since by hypothesis x < p_384 we know 2 * x - p_384 < 2^384, so the top
+; carry c actually gives us a bitmask for 2 * x - p_384 < 0, which we
+; now use to make r' = mask * (2^384 - p_384) for a compensating subtraction.
+; We don't quite have enough ABI-modifiable registers to create all three
+; nonzero digits of r while maintaining d0..d5, but make the first two now.
+
+        and     c, a                    ; c = masked 0x00000000ffffffff
+        xor     a, a
+        sub     a, c                    ; a = masked 0xffffffff00000001
+
+; Do the first two digits of addition and writeback
+
+        sub     d0, a
+        mov     [z], d0
+        sbb     d1, c
+        mov     [z+8], d1
+
+; Preserve the carry chain while creating the extra masked digit since
+; the logical operation will clear CF
+
+        sbb     d0, d0
+        and     c, a                    ; c = masked 0x0000000000000001
+        neg     d0
+
+; Do the rest of the addition and writeback
+
+        sbb     d2, c
+        mov     [z+16], d2
+        sbb     d3, 0
+        mov     [z+24], d3
+        sbb     d4, 0
+        mov     [z+32], d4
+        sbb     d5, 0
+        mov     [z+40], d5
+
+        ret

--- a/X86/bignum_half_p384.asm
+++ b/X86/bignum_half_p384.asm
@@ -1,0 +1,87 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Halve modulo p_384, z := (x / 2) mod p_384, assuming x reduced
+; Input x[6]; output z[6]
+;
+;    extern void bignum_half_p384
+;     (uint64_t z[static 6], uint64_t x[static 6]);
+;
+; Standard x86-64 ABI: RDI = z, RSI = x
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+
+%define a rax
+%define d0 rcx
+%define d1 rdx
+%define d2 r8
+%define d3 r9
+%define d4 r10
+%define d5 r11
+
+        global bignum_half_p384
+        section .text
+
+bignum_half_p384:
+
+; Load lowest digit and get a mask for its lowest bit in d3
+
+                mov     a, [x]
+                mov     d3, 1
+                and     d3, a
+                neg     d3
+
+; Create a masked version of p_384 (top 3 words = the mask itself)
+
+                mov     d0, 0x00000000ffffffff
+                and     d0, d3
+                mov     d1, d0
+                xor     d1, d3
+                mov     d2, d3
+                add     d2, d2
+                and     d2, d3
+                mov     d4, d3
+                mov     d5, d3
+
+; Perform addition with masked p_384. Catch the carry in a, as a bitmask
+; for convenience though we only use its LSB below with SHRD
+
+                add     d0, a
+                adc     d1, [x+8]
+                adc     d2, [x+16]
+                adc     d3, [x+24]
+                adc     d4, [x+32]
+                adc     d5, [x+40]
+                sbb     a, a
+
+; Shift right, pushing the carry back down, and store back
+
+                shrd    d0, d1, 1
+                mov     [z], d0
+                shrd    d1, d2, 1
+                mov     [z+8], d1
+                shrd    d2, d3, 1
+                mov     [z+16], d2
+                shrd    d3, d4, 1
+                mov     [z+24], d3
+                shrd    d4, d5, 1
+                mov     [z+32], d4
+                shrd    d5, a, 1
+                mov     [z+40], d5
+
+; Return
+
+                ret

--- a/X86/bignum_mod_p384.asm
+++ b/X86/bignum_mod_p384.asm
@@ -1,0 +1,209 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Reduce modulo field characteristic, z := x mod p_384
+; Input x[k]; output z[6]
+;
+;    extern void bignum_mod_p384
+;     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+;
+; Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define k rsi
+%define x rcx
+
+%define m0 r8
+%define m1 r9
+%define m2 r10
+%define m3 r11
+%define m4 r12
+%define m5 r13
+%define d r14
+
+%define n0 rax
+%define n1 rbx
+%define n2 rdx
+%define q rdx
+
+        section .text
+        global  bignum_mod_p384
+
+bignum_mod_p384:
+
+; Save extra registers
+
+                push    rbx
+                push    r12
+                push    r13
+                push    r14
+
+; If the input is already <= 5 words long, go to a trivial "copy" path
+
+                cmp     k, 6
+                jc      shortinput
+
+; Otherwise load the top 6 digits (top-down) and reduce k by 6
+
+                sub     k, 6
+                mov     m5, [rdx+8*k+40]
+                mov     m4, [rdx+8*k+32]
+                mov     m3, [rdx+8*k+24]
+                mov     m2, [rdx+8*k+16]
+                mov     m1, [rdx+8*k+8]
+                mov     m0, [rdx+8*k]
+
+; Move x into another register to leave rdx free for multiplies and use of n2
+
+                mov     x, rdx
+
+; Reduce the top 6 digits mod p_384 (a conditional subtraction of p_384)
+
+                mov     n0, 0x00000000ffffffff
+                mov     n1, 0xffffffff00000000
+                mov     n2, 0xfffffffffffffffe
+
+                sub     m0, n0
+                sbb     m1, n1
+                sbb     m2, n2
+                sbb     m3, -1
+                sbb     m4, -1
+                sbb     m5, -1
+
+                sbb     d, d
+                and     n0, d
+                and     n1, d
+                and     n2, d
+                add     m0, n0
+                adc     m1, n1
+                adc     m2, n2
+                adc     m3, d
+                adc     m4, d
+                adc     m5, d
+
+; Now do (k-6) iterations of 7->6 word modular reduction
+
+                test    k, k
+                jz      writeback
+
+loop:
+
+; Compute q = min (m5 + 1) (2^64 - 1)
+
+                mov     q, 1
+                add     q, m5
+                sbb     d, d
+                or      q, d
+
+; Load the next digit so current m to reduce = [m5;m4;m3;m2;m1;m0;d]
+
+                mov     d, [x+8*k-8]
+
+; Now form [m5;m4;m3;m2;m1;m0;d] = m - q * p_384. To use an addition for
+; the main calculation we do (m - 2^384 * q) + q * (2^384 - p_384)
+; where 2^384 - p_384 = [0;0;0;1;0x00000000ffffffff;0xffffffff00000001].
+; The extra subtraction of 2^384 * q is the first instruction.
+
+                sub     m5, q
+                xor     n0, n0
+                mov     n0, 0xffffffff00000001
+                mulx    n1, n0, n0
+                adcx    d, n0
+                adox    m0, n1
+                mov     n0, 0x00000000ffffffff
+                mulx    n1, n0, n0
+                adcx    m0, n0
+                adox    m1, n1
+                adcx    m1, q
+                mov     n0, 0
+                adox    n0, n0
+                adcx    m2, n0
+                adc     m3, 0
+                adc     m4, 0
+                adc     m5, 0
+
+; Now our top word m5 is either zero or all 1s. Use it for a masked
+; addition of p_384, which we can do by a *subtraction* of
+; 2^384 - p_384 from our portion
+
+                mov     n0, 0xffffffff00000001
+                and     n0, m5
+                mov     n1, 0x00000000ffffffff
+                and     n1, m5
+                and     m5, 1
+
+                sub     d, n0
+                sbb     m0, n1
+                sbb     m1, m5
+                sbb     m2, 0
+                sbb     m3, 0
+                sbb     m4, 0
+
+; Now shuffle registers up and loop
+
+                mov     m5, m4
+                mov     m4, m3
+                mov     m3, m2
+                mov     m2, m1
+                mov     m1, m0
+                mov     m0, d
+
+                dec     k
+                jnz     loop
+
+; Write back
+
+writeback:
+
+                mov     [z], m0
+                mov     [z+8], m1
+                mov     [z+16], m2
+                mov     [z+24], m3
+                mov     [z+32], m4
+                mov     [z+40], m5
+
+; Restore registers and return
+
+                pop     r14
+                pop     r13
+                pop     r12
+                pop     rbx
+                ret
+
+shortinput:
+
+                xor     m0, m0
+                xor     m1, m1
+                xor     m2, m2
+                xor     m3, m3
+                xor     m4, m4
+                xor     m5, m5
+
+                test    k, k
+                jz      writeback
+                mov     m0, [rdx]
+                dec     k
+                jz      writeback
+                mov     m1, [rdx + 8]
+                dec     k
+                jz      writeback
+                mov     m2, [rdx + 16]
+                dec     k
+                jz      writeback
+                mov     m3, [rdx + 24]
+                dec     k
+                jz      writeback
+                mov     m4, [rdx + 32]
+                jmp     writeback

--- a/X86/bignum_montmul_p384.asm
+++ b/X86/bignum_montmul_p384.asm
@@ -1,0 +1,325 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Montgomery multiply, z := (x * y / 2^384) mod p_384
+; Inputs x[6], y[6]; output z[6]
+;
+;    extern void bignum_montmul_p384
+;     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+;
+; Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
+; satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in
+; the "usual" case x < p_384 and y < p_384).
+;
+; Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+; -----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+
+; We move the y argument here so we can use rdx for multipliers
+
+%define y rcx
+
+; Fairly consistently used as a zero register
+
+%define zero rbp
+
+; Some temp registers for the last correction stage
+
+%define d rax
+%define u rdx
+%define v rcx
+%define w rbx
+
+; Macro "mulpadd i x" adds rdx * x to the (i,i+1) position of
+; the rotating register window r15,...,r8 maintaining consistent
+; double-carrying using ADCX and ADOX and using rbx/rax as temps
+
+%macro mulpadd 2
+        mulx    rbx, rax, %2
+%if (%1 % 8 == 0)
+        adcx    r8, rax
+        adox    r9, rbx
+%elif (%1 % 8 == 1)
+        adcx    r9, rax
+        adox    r10, rbx
+%elif (%1 % 8 == 2)
+        adcx    r10, rax
+        adox    r11, rbx
+%elif (%1 % 8 == 3)
+        adcx    r11, rax
+        adox    r12, rbx
+%elif (%1 % 8 == 4)
+        adcx    r12, rax
+        adox    r13, rbx
+%elif (%1 % 8 == 5)
+        adcx    r13, rax
+        adox    r14, rbx
+%elif (%1 % 8 == 6)
+        adcx    r14, rax
+        adox    r15, rbx
+%elif (%1 % 8 == 7)
+        adcx    r15, rax
+        adox    r8, rbx
+%endif
+
+%endm
+
+; Core one-step Montgomery reduction macro. Takes input in
+; [d7;d6;d5;d4;d3;d2;d1;d0] and returns result in [d7;d6;d5;d4;d3;d2;d1],
+; adding to the existing contents, re-using d0 as a temporary internally
+;
+; We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+; where w = [d0 + (d0<<32)] mod 2^64
+;
+;       montredc d7,d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+;
+; This particular variant, with its mix of addition and subtraction
+; at the top, is not intended to maintain a coherent carry or borrow out.
+; It is assumed the final result would fit in [d7;d6;d5;d4;d3;d2;d1].
+; which is always the case here as the top word is even always in {0,1}
+
+%macro montredc 8
+; Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+                mov     rdx, %8
+                shl     rdx, 32
+                add     rdx, %8
+; Construct [rbp;rbx;rax;-] = (2^384 - p_384) * w
+; We know the lowest word will cancel so we can re-use %8 as a temp
+                xor     rbp, rbp
+                mov     rax, 0xffffffff00000001
+                mulx    rax, rbx, rax
+                mov     rbx, 0x00000000ffffffff
+                mulx    rbx, %8, rbx
+                adc     rax, %8
+                adc     rbx, rdx
+                adc     rbp, 0
+; Now subtract that and add 2^384 * w
+                sub     %7, rax
+                sbb     %6, rbx
+                sbb     %5, rbp
+                sbb     %4, 0
+                sbb     %3, 0
+                sbb     rdx, 0
+                add     %2, rdx
+                adc     %1, 0
+%endm
+
+                global  bignum_montmul_p384
+                section .text
+
+bignum_montmul_p384:
+
+; Save more registers to play with
+
+        push    rbx
+        push    rbp
+        push    r12
+        push    r13
+        push    r14
+        push    r15
+
+; Copy y into a safe register to start with
+
+        mov     y, rdx
+
+; Do row 0 computation, which is a bit different:
+; set up initial window [r14,r13,r12,r11,r10,r9,r8] = y[0] * x
+; Unlike later, we only need a single carry chain
+
+        mov     rdx, [y+8*0]
+        mulx    r9, r8, [x+8*0]
+        mulx    r10, rbx, [x+8*1]
+        add     r9, rbx
+        mulx    r11, rbx, [x+8*2]
+        adc     r10, rbx
+        mulx    r12, rbx, [x+8*3]
+        adc     r11, rbx
+        mulx    r13, rbx, [x+8*4]
+        adc     r12, rbx
+        mulx    r14, rbx, [x+8*5]
+        adc     r13, rbx
+        adc     r14, 0
+
+; Montgomery reduce the zeroth window
+
+        xor     r15, r15
+        montredc r15, r14,r13,r12,r11,r10,r9,r8
+
+; Add row 1
+
+        xor     zero, zero
+        mov     rdx, [y+8*1]
+        xor     r8, r8
+        mulpadd 1, [x]
+        mulpadd 2, [x+8*1]
+        mulpadd 3, [x+8*2]
+        mulpadd 4, [x+8*3]
+        mulpadd 5, [x+8*4]
+        mulpadd 6, [x+8*5]
+        adcx    r15, zero
+        adox    r8, zero
+        adcx    r8, zero
+
+; Montgomery reduce window 1
+
+        montredc r8, r15,r14,r13,r12,r11,r10,r9
+
+; Add row 2
+
+        xor     zero, zero
+        mov     rdx, [y+8*2]
+        xor     r9, r9
+        mulpadd 2, [x]
+        mulpadd 3, [x+8*1]
+        mulpadd 4, [x+8*2]
+        mulpadd 5, [x+8*3]
+        mulpadd 6, [x+8*4]
+        mulpadd 7, [x+8*5]
+        adcx    r8, zero
+        adox    r9, zero
+        adcx    r9, zero
+
+; Montgomery reduce window 2
+
+        montredc r9, r8,r15,r14,r13,r12,r11,r10
+
+; Add row 3
+
+        xor     zero, zero
+        mov     rdx, [y+8*3]
+        xor     r10, r10
+        mulpadd 3, [x]
+        mulpadd 4, [x+8*1]
+        mulpadd 5, [x+8*2]
+        mulpadd 6, [x+8*3]
+        mulpadd 7, [x+8*4]
+        mulpadd 8, [x+8*5]
+        adcx    r9, zero
+        adox    r10, zero
+        adcx    r10, zero
+
+; Montgomery reduce window 3
+
+        montredc r10, r9,r8,r15,r14,r13,r12,r11
+
+; Add row 4
+
+        xor     zero, zero
+        mov     rdx, [y+8*4]
+        xor     r11, r11
+        mulpadd 4, [x]
+        mulpadd 5, [x+8*1]
+        mulpadd 6, [x+8*2]
+        mulpadd 7, [x+8*3]
+        mulpadd 8, [x+8*4]
+        mulpadd 9, [x+8*5]
+        adcx    r10, zero
+        adox    r11, zero
+        adcx    r11, zero
+
+; Montgomery reduce window 4
+
+        montredc r11, r10,r9,r8,r15,r14,r13,r12
+
+; Add row 5
+
+        xor     zero, zero
+        mov     rdx, [y+8*5]
+        xor     r12, r12
+        mulpadd 5, [x]
+        mulpadd 6, [x+8*1]
+        mulpadd 7, [x+8*2]
+        mulpadd 8, [x+8*3]
+        mulpadd 9, [x+8*4]
+        mulpadd 10, [x+8*5]
+        adcx    r11, zero
+        adox    r12, zero
+        adcx    r12, zero
+
+; Montgomery reduce window 5
+
+        montredc r12, r11,r10,r9,r8,r15,r14,r13
+
+; We now have a pre-reduced 7-word form [r12;r11;r10;r9;r8;r15;r14]
+
+; We know, writing B = 2^{6*64} that the full implicit result is
+; B^2 c <= z + (B - 1) * p < B * p + (B - 1) * p < 2 * B * p,
+; so the top half is certainly < 2 * p. If c = 1 already, we know
+; subtracting p will give the reduced modulus. But now we do a
+; comparison to catch cases where the residue is >= p.
+; First set [0;0;0;w;v;u] = 2^384 - p_384
+
+        mov     u, 0xffffffff00000001
+        mov     v, 0x00000000ffffffff
+        mov     w, 0x0000000000000001
+
+; Let dd = [r11;r10;r9;r8;r15;r14] be the topless 6-word intermediate result.
+; Set CF if the addition dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384.
+
+        mov     d, r14
+        add     d, u
+        mov     d, r15
+        adc     d, v
+        mov     d, r8
+        adc     d, w
+        mov     d, r9
+        adc     d, 0
+        mov     d, r10
+        adc     d, 0
+        mov     d, r11
+        adc     d, 0
+
+; Now just add this new carry into the existing r12. It's easy to see they
+; can't both be 1 by our range assumptions, so this gives us a {0,1} flag
+
+        adc     r12, 0
+
+; Now convert it into a bitmask
+
+        neg     r12
+
+; Masked addition of 2^384 - p_384, hence subtraction of p_384
+
+        and     u, r12
+        and     v, r12
+        and     w, r12
+
+        add    r14, u
+        adc    r15, v
+        adc    r8, w
+        adc    r9, 0
+        adc    r10, 0
+        adc    r11, 0
+
+; Write back the result
+
+        mov     [z], r14
+        mov     [z+8*1], r15
+        mov     [z+8*2], r8
+        mov     [z+8*3], r9
+        mov     [z+8*4], r10
+        mov     [z+8*5], r11
+
+; Restore registers and return
+
+        pop     r15
+        pop     r14
+        pop     r13
+        pop     r12
+        pop     rbp
+        pop     rbx
+
+        ret

--- a/X86/bignum_montsqr_p384.asm
+++ b/X86/bignum_montsqr_p384.asm
@@ -1,0 +1,324 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Montgomery square, z := (x^2 / 2^384) mod p_384
+; Input x[6]; output z[6]
+;
+;    extern void bignum_montsqr_p384
+;     (uint64_t z[static 6], uint64_t x[static 6]);
+;
+; Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
+; guaranteed in particular if x < p_384 initially (the "intended" case).
+;
+; Standard x86-64 ABI: RDI = z, RSI = x
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+
+; Some temp registers for the last correction stage
+
+%define d rax
+%define u rdx
+%define v r10
+%define w r11
+
+; A zero register, very often
+
+%define zero rbp
+
+; Macro "mulpadd i x" adds rdx * x to the (i,i+1) position of the
+; rotating register window r15,...,r8 maintaining consistent
+; double-carrying using ADCX and ADOX and using rbx/rax as temps
+
+%macro mulpadd 2
+        mulx    rbx, rax, %2
+%if (%1 % 8 == 0)
+        adcx    r8, rax
+        adox    r9, rbx
+%elif (%1 % 8 == 1)
+        adcx    r9, rax
+        adox    r10, rbx
+%elif (%1 % 8 == 2)
+        adcx    r10, rax
+        adox    r11, rbx
+%elif (%1 % 8 == 3)
+        adcx    r11, rax
+        adox    r12, rbx
+%elif (%1 % 8 == 4)
+        adcx    r12, rax
+        adox    r13, rbx
+%elif (%1 % 8 == 5)
+        adcx    r13, rax
+        adox    r14, rbx
+%elif (%1 % 8 == 6)
+        adcx    r14, rax
+        adox    r15, rbx
+%elif (%1 % 8 == 7)
+        adcx    r15, rax
+        adox    r8, rbx
+%endif
+
+%endm
+
+; Core one-step "short" Montgomery reduction macro. Takes input in
+; [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+; adding to the existing [d5;d4;d3;d2;d1] and re-using d0 as a
+; temporary internally, as well as rdx, rax and the temporary t.
+; It is OK for d6 and d0 to be the same register (they often are)
+;
+; We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+; where w = [d0 + (d0<<32)] mod 2^64
+;
+;       montreds d6,d5,d4,d3,d2,d1,d0, t
+
+%macro montreds 8
+; Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+                mov     rdx, %7
+                shl     rdx, 32
+                add     rdx, %7
+; Construct [%8;%7;rax;-] = (2^384 - p_384) * w
+; We know the lowest word will cancel so we can re-use %7 as a temp, and %8
+                mov     rax, 0xffffffff00000001
+                mulx    rax, %7, rax
+                mov     %8, 0x00000000ffffffff
+                mulx    %7, %8, %8
+                add     rax, %8
+                adc     %7, rdx
+                mov     %8, 0
+                adc     %8, %8
+; Now subtract that and add 2^384 * w
+                sub     %6, rax
+                sbb     %5, %7
+                sbb     %4, %8
+                sbb     %3, 0
+                sbb     %2, 0
+                mov     %1, rdx
+                sbb     %1, 0
+%endm
+
+                global  bignum_montsqr_p384
+
+bignum_montsqr_p384:
+
+; Save more registers to play with
+
+        push    rbx
+        push    rbp
+        push    r12
+        push    r13
+        push    r14
+        push    r15
+
+; Set up an initial window [rcx;r15;...r9] = [34;05;03;01]
+; Note that we are using rcx as the first step past the rotating window
+
+        mov     rdx, [x]
+        mulx    r10, r9, [x+8*1]
+        mulx    r12, r11, [x+8*3]
+        mulx    r14, r13, [x+8*5]
+        mov     rdx, [x+8*3]
+        mulx    rcx, r15, [x+8*4]
+
+; Clear our zero register, and also initialize the flags for the carry chain
+
+        xor     zero, zero
+
+; Chain in the addition of 02 + 12 + 13 + 14 + 15 to that window
+; (no carry-out possible)
+
+        mov     rdx, [x+8*2]
+        mulpadd 2,[x]
+        mulpadd 3, [x+8*1]
+        mov     rdx, [x+8*1]
+        mulpadd 4, [x+8*3]
+        mulpadd 5, [x+8*4]
+        mulpadd 6, [x+8*5]
+        adcx    r15, zero
+        adox    rcx, zero
+        adcx    rcx, zero
+
+; Again zero out the flags. Actually they are already cleared but it may
+; help decouple these in the OOO engine not to wait for the chain above
+
+        xor     zero, zero
+
+; Now chain in the 04 + 23 + 24 + 25 + 35 + 45 terms
+; We are running out of registers in our rotating window, so we start
+; using rbx (and hence need care with using mulpadd after this). Thus
+; our result so far is in [rbp;rbx;rcx;r15;...r9]
+
+        mov     rdx, [x+8*4]
+        mulpadd 4, [x]
+        mov     rdx, [x+8*2]
+        mulpadd 5, [x+8*3]
+        mulpadd 6, [x+8*4]
+        mulx    rdx, rax, [x+8*5]
+        adcx    r15, rax
+        adox    rcx, rdx
+
+; First set up the last couple of spots in our window, [rbp;rbx] = 45
+; then add the last other term 35
+
+        mov     rdx, [x+8*5]
+        mulx    rbp, rbx, [x+8*4]
+        mulx    rdx, rax, [x+8*3]
+        adcx    rcx, rax
+        adox    rbx, rdx
+        mov     rax, 0
+        adcx    rbx, rax
+        adox    rbp, rax
+        adcx    rbp, rax
+
+; Just for a clear fresh start for the flags; we don't use the zero
+
+        xor     rax, rax
+
+; Double and add to the 00 + 11 + 22 + 33 + 44 + 55 terms
+; For one glorious moment the entire squaring result is all in the
+; register file as [rsi;rbp;rbx;rcx;r15;...;r8]
+; (since we've now finished with x we can re-use rsi)
+
+        mov     rdx, [x]
+        mulx    rax, r8, [x]
+        adcx    r9, r9
+        adox    r9, rax
+        mov     rdx, [x+8*1]
+        mulx    rdx, rax, rdx
+        adcx    r10, r10
+        adox    r10, rax
+        adcx    r11, r11
+        adox    r11, rdx
+        mov     rdx, [x+8*2]
+        mulx    rdx, rax, rdx
+        adcx    r12, r12
+        adox    r12, rax
+        adcx    r13, r13
+        adox    r13, rdx
+        mov     rdx, [x+8*3]
+        mulx    rdx, rax, rdx
+        adcx    r14, r14
+        adox    r14, rax
+        adcx    r15, r15
+        adox    r15, rdx
+        mov     rdx, [x+8*4]
+        mulx    rdx, rax, rdx
+        adcx    rcx, rcx
+        adox    rcx, rax
+        adcx    rbx, rbx
+        adox    rbx, rdx
+        mov     rdx, [x+8*5]
+        mulx    rsi, rax, rdx
+        adcx    rbp, rbp
+        adox    rbp, rax
+        mov     rax, 0
+        adcx    rsi, rax
+        adox    rsi, rax
+
+; We need just *one* more register as a temp for the Montgomery steps.
+; Since we are writing to the z buffer anyway, make use of that to shash rbx.
+
+        mov     [z], rbx
+
+; Montgomery reduce the r13,...,r8 window 6 times
+
+        montreds r8,r13,r12,r11,r10,r9,r8, rbx
+        montreds r9,r8,r13,r12,r11,r10,r9, rbx
+        montreds r10,r9,r8,r13,r12,r11,r10, rbx
+        montreds r11,r10,r9,r8,r13,r12,r11, rbx
+        montreds r12,r11,r10,r9,r8,r13,r12, rbx
+        montreds r13,r12,r11,r10,r9,r8,r13, rbx
+
+; Now we can safely restore rbx before accumulating
+
+        mov     rbx, [z]
+
+        add     r14, r8
+        adc     r15, r9
+        adc     rcx, r10
+        adc     rbx, r11
+        adc     rbp, r12
+        adc     rsi, r13
+        mov     r8, 0
+        adc     r8, 0
+
+; We now have a pre-reduced 7-word form [r8;rsi;rbp;rbx;rcx;r15;r14]
+
+; We know, writing B = 2^{6*64} that the full implicit result is
+; B^2 c <= z + (B - 1) * p < B * p + (B - 1) * p < 2 * B * p,
+; so the top half is certainly < 2 * p. If c = 1 already, we know
+; subtracting p will give the reduced modulus. But now we do a
+; comparison to catch cases where the residue is >= p.
+; First set [0;0;0;w;v;u] = 2^384 - p_384
+
+        mov     u, 0xffffffff00000001
+        mov     v, 0x00000000ffffffff
+        mov     w, 0x0000000000000001
+
+; Let dd = [rsi;rbp;rbx;rcx;r15;r14] be the topless 6-word intermediate result.
+; Set CF if the addition dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384.
+
+        mov     d, r14
+        add     d, u
+        mov     d, r15
+        adc     d, v
+        mov     d, rcx
+        adc     d, w
+        mov     d, rbx
+        adc     d, 0
+        mov     d, rbp
+        adc     d, 0
+        mov     d, rsi
+        adc     d, 0
+
+; Now just add this new carry into the existing r8. It's easy to see they
+; can't both be 1 by our range assumptions, so this gives us a {0,1} flag
+
+        adc     r8, 0
+
+; Now convert it into a bitmask
+
+        neg     r8
+
+; Masked addition of 2^384 - p_384, hence subtraction of p_384
+
+        and     u, r8
+        and     v, r8
+        and     w, r8
+
+        add    r14, u
+        adc    r15, v
+        adc    rcx, w
+        adc    rbx, 0
+        adc    rbp, 0
+        adc    rsi, 0
+
+; Write back the result
+
+        mov     [z], r14
+        mov     [z+8*1], r15
+        mov     [z+8*2], rcx
+        mov     [z+8*3], rbx
+        mov     [z+8*4], rbp
+        mov     [z+8*5], rsi
+
+; Restore registers and return
+
+        pop     r15
+        pop     r14
+        pop     r13
+        pop     r12
+        pop     rbp
+        pop     rbx
+        ret

--- a/X86/bignum_neg_p384.asm
+++ b/X86/bignum_neg_p384.asm
@@ -1,0 +1,82 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Negate modulo p_384, z := (-x) mod p_384, assuming x reduced
+; Input x[6]; output z[6]
+;
+;    extern void bignum_neg_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+;
+; Standard x86-64 ABI: RDI = z, RSI = x
+; ----------------------------------------------------------------------------
+
+                global  bignum_neg_p384
+                section .text
+
+
+%define z rdi
+%define x rsi
+
+%define n0 rax
+%define n1 rcx
+%define n2 rdx
+%define n3 r8
+%define n4 r9
+%define q r10
+
+bignum_neg_p384:
+
+; Or together the input digits and create a bitmask q if this is nonzero, so
+; that we avoid doing -0 = p_384 and hence maintain strict modular reduction
+
+                mov     n0, [x]
+                or      n0, [x+8]
+                mov     n1, [x+16]
+                or      n1, [x+24]
+                mov     n2, [x+32]
+                or      n2, [x+40]
+                or      n0, n1
+                or      n0, n2
+                neg     n0
+                sbb     q, q
+
+; Let [q;n4;n3;n2;n1;n0] = if q then p_384 else 0
+
+                mov     n0, 0x00000000ffffffff
+                and     n0, q
+                mov     n1, 0xffffffff00000000
+                and     n1, q
+                mov     n2, 0xfffffffffffffffe
+                and     n2, q
+                mov     n3, q
+                mov     n4, q
+
+; Do the subtraction
+
+                sub     n0, [x]
+                sbb     n1, [x+8]
+                sbb     n2, [x+16]
+                sbb     n3, [x+24]
+                sbb     n4, [x+32]
+                sbb     q, [x+40]
+
+; Write back
+
+                mov     [z], n0
+                mov     [z+8], n1
+                mov     [z+16], n2
+                mov     [z+24], n3
+                mov     [z+32], n4
+                mov     [z+40], q
+
+                ret

--- a/X86/bignum_optneg_p384.asm
+++ b/X86/bignum_optneg_p384.asm
@@ -1,0 +1,103 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Optionally negate modulo p_384, z := (-x) mod p_384 (if p nonzero) or
+; z := x (if p zero), assuming x reduced
+; Inputs p, x[6]; output z[6]
+;
+;    extern void bignum_optneg_p384
+;      (uint64_t z[static 6], uint64_t p, uint64_t x[static 6]);
+;
+; Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
+; ----------------------------------------------------------------------------
+
+                global  bignum_optneg_p384
+                section .text
+
+
+%define z rdi
+%define q rsi
+%define x rdx
+
+%define n0 rax
+%define n1 rcx
+%define n2 r8
+%define n3 r9
+%define n4 r10
+%define n5 r11
+
+bignum_optneg_p384:
+
+; Adjust q by zeroing it if the input is zero (to avoid giving -0 = p_384,
+; which is not strictly reduced even though it's correct modulo p_384).
+; This step is redundant if we know a priori that the input is nonzero, which
+; is the case for the y coordinate of points on the P-384 curve, for example.
+
+                mov     n0, [x]
+                or      n0, [x+8]
+                mov     n1, [x+16]
+                or      n1, [x+24]
+                mov     n2, [x+32]
+                or      n2, [x+40]
+                or      n0, n1
+                or      n0, n2
+                neg     n0
+                sbb     n0, n0
+                and     q, n0
+
+; Turn q into a bitmask, all 1s for q=false, all 0s for q=true
+
+                neg     q
+                sbb     q, q
+                not     q
+
+; Let [n5;n4;n3;n2;n1] = if q then p_384 else -1
+
+                mov     n0, 0x00000000ffffffff
+                or      n0, q
+                mov     n1, 0xffffffff00000000
+                or      n1, q
+                mov     n2, 0xfffffffffffffffe
+                or      n2, q
+                mov     n3, 0xffffffffffffffff
+                mov     n4, n3
+                mov     n5, n3
+
+; Subtract so [n5;n4;n3;n2;n1;n0] = if q then p_384 - x else -1 - x
+
+                sub     n0, [x]
+                sbb     n1, [x+8]
+                sbb     n2, [x+16]
+                sbb     n3, [x+24]
+                sbb     n4, [x+32]
+                sbb     n5, [x+40]
+
+; XOR the words with the bitmask, which in the case q = false has the
+; effect of restoring ~(-1 - x) = -(-1 - x) - 1 = 1 + x - 1 = x
+; and write back the digits to the output
+
+                xor     n0, q
+                mov     [z], n0
+                xor     n1, q
+                mov     [z+8], n1
+                xor     n2, q
+                mov     [z+16], n2
+                xor     n3, q
+                mov     [z+24], n3
+                xor     n4, q
+                mov     [z+32], n4
+                xor     n5, q
+                mov     [z+40], n5
+
+                ret

--- a/X86/bignum_sub_p384.asm
+++ b/X86/bignum_sub_p384.asm
@@ -1,0 +1,96 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Subtract modulo p_384, z := (x - y) mod p_384
+; Inputs x[6], y[6]; output z[6]
+;
+;    extern void bignum_sub_p384
+;     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+;
+; Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+%define y rdx
+
+%define d0 rax
+%define d1 rcx
+%define d2 r8
+%define d3 r9
+%define d4 r10
+%define d5 r11
+
+; Re-use the input pointers as temporaries once we're done
+
+%define a rsi
+%define c rdx
+
+        global  bignum_sub_p384
+
+bignum_sub_p384:
+
+; Subtract the inputs as [d5;d4;d3;d2;d1;d0] = x - y (modulo 2^384)
+; Capture the top carry as a bitmask for the condition x < y
+
+        mov     d0, [x]
+        sub     d0, [y]
+        mov     d1, [x+8]
+        sbb     d1, [y+8]
+        mov     d2, [x+16]
+        sbb     d2, [y+16]
+        mov     d3, [x+24]
+        sbb     d3, [y+24]
+        mov     d4, [x+32]
+        sbb     d4, [y+32]
+        mov     d5, [x+40]
+        sbb     d5, [y+40]
+        sbb     c, c
+
+; Use mask to make r' = mask * (2^384 - p_384) for a compensating subtraction
+; of r_384 = 2^384 - p_384, equivalent to an addition of p_384.
+; We don't quite have enough ABI-modifiable registers to create all three
+; nonzero digits of r while maintaining d0..d5, but make the first two now.
+
+        mov     a, 0x00000000ffffffff
+        and     c, a                    ; c = masked 0x00000000ffffffff
+        xor     a, a
+        sub     a, c                    ; a = masked 0xffffffff00000001
+
+; Do the first two digits of addition and writeback
+
+        sub     d0, a
+        mov     [z], d0
+        sbb     d1, c
+        mov     [z+8], d1
+
+; Preserve the carry chain while creating the extra masked digit since
+; the logical operation will clear CF
+
+        sbb     d0, d0
+        and     c, a                    ; c = masked 0x0000000000000001
+        neg     d0
+
+; Do the rest of the addition and writeback
+
+        sbb     d2, c
+        mov     [z+16], d2
+        sbb     d3, 0
+        mov     [z+24], d3
+        sbb     d4, 0
+        mov     [z+32], d4
+        sbb     d5, 0
+        mov     [z+40], d5
+
+        ret

--- a/X86/bignum_tomont_p384.asm
+++ b/X86/bignum_tomont_p384.asm
@@ -1,0 +1,303 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Convert to Montgomery form z := (2^256 * x) mod p_256
+; Input x[6]; output z[6]
+;
+;    extern void bignum_tomont_p384
+;     (uint64_t z[static 6], uint64_t x[static 6]);
+;
+; Standard x86-64 ABI: RDI = z, RSI = x
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+
+; Fairly consistently used as a zero register
+
+%define zero rbp
+
+; Some temp registers for the last correction stage
+
+%define d rax
+%define u rdx
+%define v rcx
+%define w rsi
+
+; Macro "mulpadd i x" adds rdx * x to the (i,i+1) position of
+; the rotating register window r15,...,r8 maintaining consistent
+; double-carrying using ADCX and ADOX and using rcx/rax as temps
+
+%macro mulpadd 2
+        mulx    rcx, rax, %2
+%if (%1 % 8 == 0)
+        adcx    r8, rax
+        adox    r9, rcx
+%elif (%1 % 8 == 1)
+        adcx    r9, rax
+        adox    r10, rcx
+%elif (%1 % 8 == 2)
+        adcx    r10, rax
+        adox    r11, rcx
+%elif (%1 % 8 == 3)
+        adcx    r11, rax
+        adox    r12, rcx
+%elif (%1 % 8 == 4)
+        adcx    r12, rax
+        adox    r13, rcx
+%elif (%1 % 8 == 5)
+        adcx    r13, rax
+        adox    r14, rcx
+%elif (%1 % 8 == 6)
+        adcx    r14, rax
+        adox    r15, rcx
+%elif (%1 % 8 == 7)
+        adcx    r15, rax
+        adox    r8, rcx
+%endif
+
+%endm
+
+; Core one-step Montgomery reduction macro. Takes input in
+; [d7;d6;d5;d4;d3;d2;d1;d0] and returns result in [d7;d6;d5;d4;d3;d2;d1],
+; adding to the existing contents, re-using d0 as a temporary internally
+;
+; We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+; where w = [d0 + (d0<<32)] mod 2^64
+;
+;       montredc d7,d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+;
+; This particular variant, with its mix of addition and subtraction
+; at the top, is not intended to maintain a coherent carry or borrow out.
+; It is assumed the final result would fit in [d7;d6;d5;d4;d3;d2;d1].
+; which is always the case here as the top word is even always in {0,1}
+
+%macro montredc 8
+; Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+                mov     rdx, %8
+                shl     rdx, 32
+                add     rdx, %8
+; Construct [rbp;rcx;rax;-] = (2^384 - p_384) * w
+; We know the lowest word will cancel so we can re-use %8 as a temp
+                xor     rbp, rbp
+                mov     rax, 0xffffffff00000001
+                mulx    rax, rcx, rax
+                mov     rcx, 0x00000000ffffffff
+                mulx    rcx, %8, rcx
+                adc     rax, %8
+                adc     rcx, rdx
+                adc     rbp, 0
+; Now subtract that and add 2^384 * w
+                sub     %7, rax
+                sbb     %6, rcx
+                sbb     %5, rbp
+                sbb     %4, 0
+                sbb     %3, 0
+                sbb     rdx, 0
+                add     %2, rdx
+                adc     %1, 0
+%endm
+
+                global  bignum_tomont_p384
+                section .text
+
+bignum_tomont_p384:
+
+; We are essentially just doing a Montgomery multiplication of x and the
+; precomputed constant y = 2^768 mod p, so the code is almost the same
+; modulo a few registers and the change from loading y[i] to using constants,
+; plus the easy digits y[4] = 1 and y[5] = 0 being treated specially.
+; Because there is no y pointer to keep, we use one register less.
+
+        push    rbp
+        push    r12
+        push    r13
+        push    r14
+        push    r15
+
+; Do row 0 computation, which is a bit different:
+; set up initial window [r14,r13,r12,r11,r10,r9,r8] = y[0] * x
+; Unlike later, we only need a single carry chain
+
+        mov     rdx, 0xfffffffe00000001
+        mulx    r9, r8, [x+8*0]
+        mulx    r10, rcx, [x+8*1]
+        add     r9, rcx
+        mulx    r11, rcx, [x+8*2]
+        adc     r10, rcx
+        mulx    r12, rcx, [x+8*3]
+        adc     r11, rcx
+        mulx    r13, rcx, [x+8*4]
+        adc     r12, rcx
+        mulx    r14, rcx, [x+8*5]
+        adc     r13, rcx
+        adc     r14, 0
+
+; Montgomery reduce the zeroth window
+
+        xor     r15, r15
+        montredc r15, r14,r13,r12,r11,r10,r9,r8
+
+; Add row 1
+
+        xor     zero, zero
+        mov     rdx, 0x0000000200000000
+        xor     r8, r8
+        mulpadd 1, [x]
+        mulpadd 2, [x+8*1]
+        mulpadd 3, [x+8*2]
+        mulpadd 4, [x+8*3]
+        mulpadd 5, [x+8*4]
+        mulpadd 6, [x+8*5]
+        adcx    r15, zero
+        adox    r8, zero
+        adcx    r8, zero
+
+; Montgomery reduce window 1
+
+        montredc r8, r15,r14,r13,r12,r11,r10,r9
+
+; Add row 2
+
+        xor     zero, zero
+        mov     rdx, 0xfffffffe00000000
+        xor     r9, r9
+        mulpadd 2, [x]
+        mulpadd 3, [x+8*1]
+        mulpadd 4, [x+8*2]
+        mulpadd 5, [x+8*3]
+        mulpadd 6, [x+8*4]
+        mulpadd 7, [x+8*5]
+        adcx    r8, zero
+        adox    r9, zero
+        adcx    r9, zero
+
+; Montgomery reduce window 2
+
+        montredc r9, r8,r15,r14,r13,r12,r11,r10
+
+; Add row 3
+
+        xor     zero, zero
+        mov     rdx, 0x0000000200000000
+        xor     r10, r10
+        mulpadd 3, [x]
+        mulpadd 4, [x+8*1]
+        mulpadd 5, [x+8*2]
+        mulpadd 6, [x+8*3]
+        mulpadd 7, [x+8*4]
+        mulpadd 8, [x+8*5]
+        adcx    r9, zero
+        adox    r10, zero
+        adcx    r10, zero
+
+; Montgomery reduce window 3
+
+        montredc r10, r9,r8,r15,r14,r13,r12,r11
+
+; Add row 4. The multiplier y[4] = 1, so we just add x to the window
+; while extending it with one more digit, initially this carry
+
+        xor     r11, r11
+        add     r12, [x]
+        adc     r13, [x+8*1]
+        adc     r14, [x+8*2]
+        adc     r15, [x+8*3]
+        adc     r8, [x+8*4]
+        adc     r9, [x+8*5]
+        adc     r10, 0
+        adc     r11, 0
+
+; Montgomery reduce window 4
+
+        montredc r11, r10,r9,r8,r15,r14,r13,r12
+
+; Add row 5, The multiplier y[5] = 0, so this is trivial: all we do is
+; bring down another zero digit into the window.
+
+        xor     r12, r12
+
+; Montgomery reduce window 5
+
+        montredc r12, r11,r10,r9,r8,r15,r14,r13
+
+; We now have a pre-reduced 7-word form [r12;r11;r10;r9;r8;r15;r14]
+
+; We know, writing B = 2^{6*64} that the full implicit result is
+; B^2 c <= z + (B - 1) * p < B * p + (B - 1) * p < 2 * B * p,
+; so the top half is certainly < 2 * p. If c = 1 already, we know
+; subtracting p will give the reduced modulus. But now we do a
+; comparison to catch cases where the residue is >= p.
+; First set [0;0;0;w;v;u] = 2^384 - p_384
+
+        mov     u, 0xffffffff00000001
+        mov     v, 0x00000000ffffffff
+        mov     w, 0x0000000000000001
+
+; Let dd = [r11;r10;r9;r8;r15;r14] be the topless 6-word intermediate result.
+; Set CF if the addition dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384.
+
+        mov     d, r14
+        add     d, u
+        mov     d, r15
+        adc     d, v
+        mov     d, r8
+        adc     d, w
+        mov     d, r9
+        adc     d, 0
+        mov     d, r10
+        adc     d, 0
+        mov     d, r11
+        adc     d, 0
+
+; Now just add this new carry into the existing r12. It's easy to see they
+; can't both be 1 by our range assumptions, so this gives us a {0,1} flag
+
+        adc     r12, 0
+
+; Now convert it into a bitmask
+
+        neg     r12
+
+; Masked addition of 2^384 - p_384, hence subtraction of p_384
+
+        and     u, r12
+        and     v, r12
+        and     w, r12
+
+        add    r14, u
+        adc    r15, v
+        adc    r8, w
+        adc    r9, 0
+        adc    r10, 0
+        adc    r11, 0
+
+; Write back the result
+
+        mov     [z], r14
+        mov     [z+8*1], r15
+        mov     [z+8*2], r8
+        mov     [z+8*3], r9
+        mov     [z+8*4], r10
+        mov     [z+8*5], r11
+
+; Restore registers and return
+
+        pop     r15
+        pop     r14
+        pop     r13
+        pop     r12
+        pop     rbp
+
+        ret

--- a/X86/bignum_triple_p384.asm
+++ b/X86/bignum_triple_p384.asm
@@ -1,0 +1,116 @@
+ ; * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ ; *
+ ; * Licensed under the Apache License, Version 2.0 (the "License").
+ ; * You may not use this file except in compliance with the License.
+ ; * A copy of the License is located at
+ ; *
+ ; *  http://aws.amazon.com/apache2.0
+ ; *
+ ; * or in the "LICENSE" file accompanying this file. This file is distributed
+ ; * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ ; * express or implied. See the License for the specific language governing
+ ; * permissions and limitations under the License.
+
+; ----------------------------------------------------------------------------
+; Triple modulo p_384, z := (3 * x) mod p_384
+; Input x[6]; output z[6]
+;
+;    extern void bignum_triple_p384
+;     (uint64_t z[static 6], uint64_t x[static 6]);
+;
+; The input x can be any 6-digit bignum, not necessarily reduced modulo p_384,
+; and the result is always fully reduced, i.e. z = (3 * x) mod p_384.
+;
+; Standard x86-64 ABI: RDI = z, RSI = x
+; ----------------------------------------------------------------------------
+
+%define z rdi
+%define x rsi
+
+%define d0 r8
+%define d1 r9
+%define d2 r10
+%define d3 r11
+%define d4 rbx
+%define d5 rsi
+
+%define a rax
+%define c rcx
+%define q rdx
+
+        section .text
+        global  bignum_triple_p384
+
+bignum_triple_p384:
+
+; We seem to need (just!) one extra register, which we need to save and restore
+
+                push    rbx
+
+; Multiply, accumulating the result as 2^384 * h + [d5;d4;d3;d2;d1;d0]
+; but actually immediately producing q = h + 1, our quotient approximation,
+; by adding 1 to it. Note that by hypothesis x is reduced mod p_384, so our
+; product is <= (2^64 - 1) * (p_384 - 1) and hence  h <= 2^64 - 2, meaning
+; there is no danger this addition of 1 could wrap.
+
+                mov     q, 3
+                mulx    d1, d0, [x]
+                mulx    d2, a, [x+8]
+                add     d1, a
+                mulx    d3,a, [x+16]
+                adc     d2, a
+                mulx    d4,a, [x+24]
+                adc     d3, a
+                mulx    c, a, [x+32]
+                adc     d4, a
+                mulx    q, d5, [x+40]
+                adc     d5, c
+                adc     q, 1
+
+; Initial subtraction of z - q * p_384, with bitmask c for the carry
+; Actually done as an addition of (z - 2^384 * h) + q * (2^384 - p_384)
+; which, because q = h + 1, is exactly 2^384 + (z - q * p_384), and
+; therefore CF <=> 2^384 + (z - q * p_384) >= 2^384 <=> z >= q * p_384.
+
+                mov     c, q
+                shl     c, 32
+                mov     a, q
+                sub     a, c
+                sbb     c, 0
+
+                add     d0, a
+                adc     d1, c
+                adc     d2, q
+                adc     d3, 0
+                adc     d4, 0
+                adc     d5, 0
+                sbb     c, c
+                not     c
+
+; Now use that mask for a masked addition of p_384, which again is in
+; fact done by a masked subtraction of 2^384 - p_384, so that we only
+; have three nonzero digits and so can avoid using another register.
+
+                mov     q, 0x00000000ffffffff
+                xor     a, a
+                and     q, c
+                sub     a, q
+                and     c, 1
+
+                sub     d0, a
+                mov     [z], d0
+                sbb     d1, q
+                mov     [z+8], d1
+                sbb     d2, c
+                mov     [z+16], d2
+                sbb     d3, 0
+                mov     [z+24], d3
+                sbb     d4, 0
+                mov     [z+32], d4
+                sbb     d5, 0
+                mov     [z+40], d5
+
+; Return
+
+                pop     rbx
+                ret

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -152,6 +152,10 @@ if(${ARCH} STREQUAL "aarch64")
     ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_add_p384.S
     ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_montmul_p384.S
     ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_montsqr_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_sub_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_neg_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_tomont_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_demont_p384.S
   )
 endif()
 

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -143,11 +143,15 @@ if(${ARCH} STREQUAL "arm")
 endif()
 
 if(${ARCH} STREQUAL "aarch64")
+  message(STATUS "PROJECT_SOURCE_DIR: ${PROJECT_SOURCE_DIR}")
   set(
     CRYPTO_ARCH_SOURCES
 
     chacha/chacha-armv8.${ASM_EXT}
     test/trampoline-armv8.${ASM_EXT}
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_add_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_montmul_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_montsqr_p384.S
   )
 endif()
 

--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -19,6 +19,10 @@
 
 #if defined(BORINGSSL_HAS_UINT128)
 #define BORINGSSL_NISTP384_64BIT 1
+// the following is needed until the gradual transition from fiat is done
+OPENSSL_UNUSED static void fiat_p384_add(uint64_t out1[6], const uint64_t arg1[6], const uint64_t arg2[6]);
+OPENSSL_UNUSED static void fiat_p384_mul(uint64_t out1[6], const uint64_t arg1[6], const uint64_t arg2[6]);
+OPENSSL_UNUSED static void fiat_p384_square(uint64_t out1[6], const uint64_t arg1[6]);
 #include "../../../third_party/fiat/p384_64.h"
 #else
 #include "../../../third_party/fiat/p384_32.h"
@@ -37,6 +41,29 @@ typedef uint32_t fiat_p384_felem[FIAT_P384_NLIMBS];
 static const fiat_p384_felem fiat_p384_one = {
     0x1, 0xffffffff, 0xffffffff, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 #endif  // 64BIT
+
+#if !defined(OPENSSL_NO_ASM) && defined(BORINGSSL_NISTP384_64BIT) && \
+    defined(OPENSSL_AARCH64) &&                                      \
+    !defined(OPENSSL_SMALL)
+#include "../../../third_party/s2n-bignum/include/s2n-bignum.h"
+#define p384_add(c, a, b)       bignum_add_p384(c, a, b)
+#define p384_montmul(c, a, b)   bignum_montmul_p384(c, a, b)
+#define p384_montsqr(c, a)      bignum_montsqr_p384(c, a)
+
+#else
+
+#if 0 // to be enabled when all fiat is replaceable
+#if defined(BORINGSSL_NISTP384_64BIT)
+#include "../../../third_party/fiat/p384_64.h"
+#else
+#include "../../../third_party/fiat/p384_32.h"
+#endif // defined(BORINGSSL_NISTP384_64BIT)
+#endif // #if 0
+#define p384_add(c, a, b)       fiat_p384_add(c, a, b)
+#define p384_montmul(c, a, b)   fiat_p384_mul(c, a, b)
+#define p384_montsqr(c, a)      fiat_p384_square(c, a)
+#endif
+
 
 static fiat_p384_limb_t fiat_p384_nz(
     const fiat_p384_limb_t in1[FIAT_P384_NLIMBS]) {
@@ -90,59 +117,59 @@ static void fiat_p384_inv_square(fiat_p384_felem out,
   // squaring the element => doubling the exponent
   // multiplying by an element => adding to the exponent the power of that element
   fiat_p384_felem x2, x3, x6, x12, x15, x30, x60, x120;
-  fiat_p384_square(x2, in);   // 2^2 - 2^1
-  fiat_p384_mul(x2, x2, in);  // 2^2 - 2^0
+  p384_montsqr(x2, in);   // 2^2 - 2^1
+  p384_montmul(x2, x2, in);  // 2^2 - 2^0
 
-  fiat_p384_square(x3, x2);   // 2^3 - 2^1
-  fiat_p384_mul(x3, x3, in);  // 2^3 - 2^0
+  p384_montsqr(x3, x2);   // 2^3 - 2^1
+  p384_montmul(x3, x3, in);  // 2^3 - 2^0
 
-  fiat_p384_square(x6, x3);
+  p384_montsqr(x6, x3);
   for (int i = 1; i < 3; i++) {
-    fiat_p384_square(x6, x6);
+    p384_montsqr(x6, x6);
   }                           // 2^6 - 2^3
-  fiat_p384_mul(x6, x6, x3);  // 2^6 - 2^0
+  p384_montmul(x6, x6, x3);  // 2^6 - 2^0
 
-  fiat_p384_square(x12, x6);
+  p384_montsqr(x12, x6);
   for (int i = 1; i < 6; i++) {
-    fiat_p384_square(x12, x12);
+    p384_montsqr(x12, x12);
   }                             // 2^12 - 2^6
-  fiat_p384_mul(x12, x12, x6);  // 2^12 - 2^0
+  p384_montmul(x12, x12, x6);  // 2^12 - 2^0
 
-  fiat_p384_square(x15, x12);
+  p384_montsqr(x15, x12);
   for (int i = 1; i < 3; i++) {
-    fiat_p384_square(x15, x15);
+    p384_montsqr(x15, x15);
   }                             // 2^15 - 2^3
-  fiat_p384_mul(x15, x15, x3);  // 2^15 - 2^0
+  p384_montmul(x15, x15, x3);  // 2^15 - 2^0
 
-  fiat_p384_square(x30, x15);
+  p384_montsqr(x30, x15);
   for (int i = 1; i < 15; i++) {
-    fiat_p384_square(x30, x30);
+    p384_montsqr(x30, x30);
   }                              // 2^30 - 2^15
-  fiat_p384_mul(x30, x30, x15);  // 2^30 - 2^0
+  p384_montmul(x30, x30, x15);  // 2^30 - 2^0
 
-  fiat_p384_square(x60, x30);
+  p384_montsqr(x60, x30);
   for (int i = 1; i < 30; i++) {
-    fiat_p384_square(x60, x60);
+    p384_montsqr(x60, x60);
   }                              // 2^60 - 2^30
-  fiat_p384_mul(x60, x60, x30);  // 2^60 - 2^0
+  p384_montmul(x60, x60, x30);  // 2^60 - 2^0
 
-  fiat_p384_square(x120, x60);
+  p384_montsqr(x120, x60);
   for (int i = 1; i < 60; i++) {
-    fiat_p384_square(x120, x120);
+    p384_montsqr(x120, x120);
   }                                // 2^120 - 2^60
-  fiat_p384_mul(x120, x120, x60);  // 2^120 - 2^0
+  p384_montmul(x120, x120, x60);  // 2^120 - 2^0
 
   fiat_p384_felem ret;
-  fiat_p384_square(ret, x120);
+  p384_montsqr(ret, x120);
   for (int i = 1; i < 120; i++) {
-    fiat_p384_square(ret, ret);
+    p384_montsqr(ret, ret);
   }                                // 2^240 - 2^120
-  fiat_p384_mul(ret, ret, x120);   // 2^240 - 2^0
+  p384_montmul(ret, ret, x120);   // 2^240 - 2^0
 
   for (int i = 0; i < 15; i++) {
-    fiat_p384_square(ret, ret);
+    p384_montsqr(ret, ret);
   }                                // 2^255 - 2^15
-  fiat_p384_mul(ret, ret, x15);    // 2^255 - 2^0
+  p384_montmul(ret, ret, x15);    // 2^255 - 2^0
 
   // Why (1 + 30) in the loop?
   // This is as expressed in https://briansmith.org/ecc-inversion-addition-chains-01#p384_field_inversion
@@ -152,13 +179,13 @@ static void fiat_p384_inv_square(fiat_p384_felem out,
   // ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe ffffffff
   // (the last 2 1s are appended in the following step).
   for (int i = 0; i < (1 + 30); i++) {
-    fiat_p384_square(ret, ret);
+    p384_montsqr(ret, ret);
   }                                // 2^286 - 2^31
-  fiat_p384_mul(ret, ret, x30);    // 2^286 - 2^30 - 2^0
+  p384_montmul(ret, ret, x30);    // 2^286 - 2^30 - 2^0
 
-  fiat_p384_square(ret, ret);
-  fiat_p384_square(ret, ret);      // 2^288 - 2^32 - 2^2
-  fiat_p384_mul(ret, ret, x2);     // 2^288 - 2^32 - 2^0
+  p384_montsqr(ret, ret);
+  p384_montsqr(ret, ret);      // 2^288 - 2^32 - 2^2
+  p384_montmul(ret, ret, x2);     // 2^288 - 2^32 - 2^0
 
   // Why not 94 instead of (64 + 30) in the loop?
   // Similarly to the comment above, there is a shift of 94 bits but what will be added is x30,
@@ -166,12 +193,12 @@ static void fiat_p384_inv_square(fiat_p384_felem out,
   // 00000000 00000000 fffffffc
   // (the last 2 0s are appended by the last 2 shifts).
   for (int i = 0; i < (64 + 30); i++) {
-    fiat_p384_square(ret, ret);
+    p384_montsqr(ret, ret);
   }                                // 2^382 - 2^126 - 2^94
-  fiat_p384_mul(ret, ret, x30);    // 2^382 - 2^126 - 2^94 + 2^30 - 2^0
+  p384_montmul(ret, ret, x30);    // 2^382 - 2^126 - 2^94 + 2^30 - 2^0
 
-  fiat_p384_square(ret, ret);
-  fiat_p384_square(out, ret);      // 2^384 - 2^128 - 2^96 + 2^32 - 2^2 = p - 3
+  p384_montsqr(ret, ret);
+  p384_montsqr(out, ret);      // 2^384 - 2^128 - 2^96 + 2^32 - 2^2 = p - 3
 }
 
 // Group operations
@@ -198,41 +225,41 @@ static void fiat_p384_point_double(fiat_p384_felem x_out, fiat_p384_felem y_out,
                                    const fiat_p384_felem z_in) {
   fiat_p384_felem delta, gamma, beta, ftmp, ftmp2, tmptmp, alpha, fourbeta;
   // delta = z^2
-  fiat_p384_square(delta, z_in);
+  p384_montsqr(delta, z_in);
   // gamma = y^2
-  fiat_p384_square(gamma, y_in);
+  p384_montsqr(gamma, y_in);
   // beta = x*gamma
-  fiat_p384_mul(beta, x_in, gamma);
+  p384_montmul(beta, x_in, gamma);
 
   // alpha = 3*(x-delta)*(x+delta)
   fiat_p384_sub(ftmp, x_in, delta);
-  fiat_p384_add(ftmp2, x_in, delta);
+  p384_add(ftmp2, x_in, delta);
 
-  fiat_p384_add(tmptmp, ftmp2, ftmp2);
-  fiat_p384_add(ftmp2, ftmp2, tmptmp);
-  fiat_p384_mul(alpha, ftmp, ftmp2);
+  p384_add(tmptmp, ftmp2, ftmp2);
+  p384_add(ftmp2, ftmp2, tmptmp);
+  p384_montmul(alpha, ftmp, ftmp2);
 
   // x' = alpha^2 - 8*beta
-  fiat_p384_square(x_out, alpha);
-  fiat_p384_add(fourbeta, beta, beta);
-  fiat_p384_add(fourbeta, fourbeta, fourbeta);
-  fiat_p384_add(tmptmp, fourbeta, fourbeta);
+  p384_montsqr(x_out, alpha);
+  p384_add(fourbeta, beta, beta);
+  p384_add(fourbeta, fourbeta, fourbeta);
+  p384_add(tmptmp, fourbeta, fourbeta);
   fiat_p384_sub(x_out, x_out, tmptmp);
 
   // z' = (y + z)^2 - gamma - delta
   // The following calculation differs from that in p256.c:
   // An add is replaced with a sub in order to save 5 cmovznz.
-  fiat_p384_add(ftmp, y_in, z_in);
-  fiat_p384_square(z_out, ftmp);
+  p384_add(ftmp, y_in, z_in);
+  p384_montsqr(z_out, ftmp);
   fiat_p384_sub(z_out, z_out, gamma);
   fiat_p384_sub(z_out, z_out, delta);
 
   // y' = alpha*(4*beta - x') - 8*gamma^2
   fiat_p384_sub(y_out, fourbeta, x_out);
-  fiat_p384_add(gamma, gamma, gamma);
-  fiat_p384_square(gamma, gamma);
-  fiat_p384_mul(y_out, alpha, y_out);
-  fiat_p384_add(gamma, gamma, gamma);
+  p384_add(gamma, gamma, gamma);
+  p384_montsqr(gamma, gamma);
+  p384_montmul(y_out, alpha, y_out);
+  p384_add(gamma, gamma, gamma);
   fiat_p384_sub(y_out, y_out, gamma);
 }
 
@@ -258,40 +285,40 @@ static void fiat_p384_point_add(fiat_p384_felem x3, fiat_p384_felem y3,
 
   // z1z1 = z1z1 = z1**2
   fiat_p384_felem z1z1;
-  fiat_p384_square(z1z1, z1);
+  p384_montsqr(z1z1, z1);
 
   fiat_p384_felem u1, s1, two_z1z2;
   if (!mixed) {
     // z2z2 = z2**2
     fiat_p384_felem z2z2;
-    fiat_p384_square(z2z2, z2);
+    p384_montsqr(z2z2, z2);
 
     // u1 = x1*z2z2
-    fiat_p384_mul(u1, x1, z2z2);
+    p384_montmul(u1, x1, z2z2);
 
     // two_z1z2 = (z1 + z2)**2 - (z1z1 + z2z2) = 2z1z2
-    fiat_p384_add(two_z1z2, z1, z2);
-    fiat_p384_square(two_z1z2, two_z1z2);
+    p384_add(two_z1z2, z1, z2);
+    p384_montsqr(two_z1z2, two_z1z2);
     fiat_p384_sub(two_z1z2, two_z1z2, z1z1);
     fiat_p384_sub(two_z1z2, two_z1z2, z2z2);
 
     // s1 = y1 * z2**3
-    fiat_p384_mul(s1, z2, z2z2);
-    fiat_p384_mul(s1, s1, y1);
+    p384_montmul(s1, z2, z2z2);
+    p384_montmul(s1, s1, y1);
   } else {
     // We'll assume z2 = 1 (special case z2 = 0 is handled later).
 
     // u1 = x1*z2z2
     fiat_p384_copy(u1, x1);
     // two_z1z2 = 2z1z2
-    fiat_p384_add(two_z1z2, z1, z1);
+    p384_add(two_z1z2, z1, z1);
     // s1 = y1 * z2**3
     fiat_p384_copy(s1, y1);
   }
 
   // u2 = x2*z1z1
   fiat_p384_felem u2;
-  fiat_p384_mul(u2, x2, z1z1);
+  p384_montmul(u2, x2, z1z1);
 
   // h = u2 - u1
   fiat_p384_felem h;
@@ -300,20 +327,20 @@ static void fiat_p384_point_add(fiat_p384_felem x3, fiat_p384_felem y3,
   fiat_p384_limb_t xneq = fiat_p384_nz(h);
 
   // z_out = two_z1z2 * h
-  fiat_p384_mul(z_out, h, two_z1z2);
+  p384_montmul(z_out, h, two_z1z2);
 
   // z1z1z1 = z1 * z1z1
   fiat_p384_felem z1z1z1;
-  fiat_p384_mul(z1z1z1, z1, z1z1);
+  p384_montmul(z1z1z1, z1, z1z1);
 
   // s2 = y2 * z1**3
   fiat_p384_felem s2;
-  fiat_p384_mul(s2, y2, z1z1z1);
+  p384_montmul(s2, y2, z1z1z1);
 
   // r = (s2 - s1)*2
   fiat_p384_felem r;
   fiat_p384_sub(r, s2, s1);
-  fiat_p384_add(r, r, r);
+  p384_add(r, r, r);
 
   fiat_p384_limb_t yneq = fiat_p384_nz(r);
 
@@ -328,28 +355,28 @@ static void fiat_p384_point_add(fiat_p384_felem x3, fiat_p384_felem y3,
 
   // I = (2h)**2
   fiat_p384_felem i;
-  fiat_p384_add(i, h, h);
-  fiat_p384_square(i, i);
+  p384_add(i, h, h);
+  p384_montsqr(i, i);
 
   // J = h * I
   fiat_p384_felem j;
-  fiat_p384_mul(j, h, i);
+  p384_montmul(j, h, i);
 
   // V = U1 * I
   fiat_p384_felem v;
-  fiat_p384_mul(v, u1, i);
+  p384_montmul(v, u1, i);
 
   // x_out = r**2 - J - 2V
-  fiat_p384_square(x_out, r);
+  p384_montsqr(x_out, r);
   fiat_p384_sub(x_out, x_out, j);
   fiat_p384_sub(x_out, x_out, v);
   fiat_p384_sub(x_out, x_out, v);
 
   // y_out = r(V-x_out) - 2 * s1 * J
   fiat_p384_sub(y_out, v, x_out);
-  fiat_p384_mul(y_out, y_out, r);
+  p384_montmul(y_out, y_out, r);
   fiat_p384_felem s1j;
-  fiat_p384_mul(s1j, s1, j);
+  p384_montmul(s1j, s1, j);
   fiat_p384_sub(y_out, y_out, s1j);
   fiat_p384_sub(y_out, y_out, s1j);
 
@@ -380,16 +407,16 @@ static int ec_GFp_nistp384_point_get_affine_coordinates(
   if (x_out != NULL) {
     fiat_p384_felem x;
     fiat_p384_from_generic(x, &point->X);
-    fiat_p384_mul(x, x, z2);
+    p384_montmul(x, x, z2);
     fiat_p384_to_generic(x_out, x);
   }
 
   if (y_out != NULL) {
     fiat_p384_felem y;
     fiat_p384_from_generic(y, &point->Y);
-    fiat_p384_square(z2, z2);  // z^-4
-    fiat_p384_mul(y, y, z1);   // y * z
-    fiat_p384_mul(y, y, z2);   // y * z^-3
+    p384_montsqr(z2, z2);  // z^-4
+    p384_montmul(y, y, z1);   // y * z
+    p384_montmul(y, y, z2);   // y * z^-3
     fiat_p384_to_generic(y_out, y);
   }
 
@@ -468,11 +495,11 @@ static int ec_GFp_nistp384_cmp_x_coordinate(const EC_GROUP *group,
   // not.
   fiat_p384_felem Z2_mont;
   fiat_p384_from_generic(Z2_mont, &p->Z);
-  fiat_p384_mul(Z2_mont, Z2_mont, Z2_mont);
+  p384_montmul(Z2_mont, Z2_mont, Z2_mont);
 
   fiat_p384_felem r_Z2;
   fiat_p384_from_bytes(r_Z2, r->bytes);  // r < order < p, so this is valid.
-  fiat_p384_mul(r_Z2, r_Z2, Z2_mont);
+  p384_montmul(r_Z2, r_Z2, Z2_mont);
 
   fiat_p384_felem X;
   fiat_p384_from_generic(X, &p->X);
@@ -494,7 +521,7 @@ static int ec_GFp_nistp384_cmp_x_coordinate(const EC_GROUP *group,
     EC_FELEM tmp;
     bn_add_words(tmp.words, r->words, group->order.d, group->order.width);
     fiat_p384_from_generic(r_Z2, &tmp);
-    fiat_p384_mul(r_Z2, r_Z2, Z2_mont);
+    p384_montmul(r_Z2, r_Z2, Z2_mont);
     if (OPENSSL_memcmp(&r_Z2, &X, sizeof(r_Z2)) == 0) {
       return 1;
     }

--- a/include/s2n-bignum.h
+++ b/include/s2n-bignum.h
@@ -135,7 +135,7 @@ extern void bignum_demont_p256 (uint64_t z[static 4], uint64_t x[static 4]);
 
 // Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
-extern void bignum_demont_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+extern void bignum_demont_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
 
 // Select digit x[n]
 // Inputs x[k], n; output function return
@@ -319,7 +319,7 @@ extern void bignum_neg_p256 (uint64_t z[static 4], uint64_t x[static 4]);
 
 // Negate modulo p_384, z := (-x) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
-extern void bignum_neg_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+extern void bignum_neg_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
 
 // Negated modular inverse, z := (-1/x) mod 2^{64k}
 // Input x[k]; output z[k]
@@ -399,15 +399,15 @@ extern void bignum_sub_p256 (uint64_t z[static 4], uint64_t x[static 4], uint64_
 
 // Subtract modulo p_384, z := (x - y) mod p_384
 // Inputs x[6], y[6]; output z[6]
-extern void bignum_sub_p384 (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+extern void bignum_sub_p384 (uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
 
 // Convert to Montgomery form z := (2^256 * x) mod p_256
 // Input x[4]; output z[4]
 extern void bignum_tomont_p256 (uint64_t z[static 4], uint64_t x[static 4]);
 
-// Convert to Montgomery form z := (2^256 * x) mod p_256
+// Convert to Montgomery form z := (2^384 * x) mod p_384
 // Input x[6]; output z[6]
-extern void bignum_tomont_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+extern void bignum_tomont_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
 
 // Triple modulo p_256, z := (3 * x) mod p_256
 // Input x[4]; output z[4]

--- a/include/s2n-bignum.h
+++ b/include/s2n-bignum.h
@@ -1,0 +1,430 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// C prototypes for s2n-bignum functions, so you can use them in C programs via
+//
+//  #include "s2n-bignum.h"
+//
+// The functions are listed in alphabetical order with a brief description
+// in comments for each one. For more detailed documentation see the comment
+// banner at the top of the corresponding assembly (.S or .asm) file, and
+// for the last word in what properties it satisfies see the spec in the
+// formal proof (the .ml file in the architecture-specific directory).
+// ----------------------------------------------------------------------------
+
+// Add, z := x + y
+// Inputs x[m], y[n]; outputs function return (carry-out) and z[p]
+extern uint64_t bignum_add (uint64_t p, uint64_t *z, uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+
+// Add modulo p_256, z := (x + y) mod p_256, assuming x and y reduced
+// Inputs x[4], y[4]; output z[4]
+extern void bignum_add_p256 (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+
+// Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
+// Inputs x[6], y[6]; output z[6]
+extern void bignum_add_p384 (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+
+// Compute "amontification" constant z :== 2^{128k} (congruent mod m)
+// Input m[k]; output z[k]; temporary buffer t[>=k]
+extern void bignum_amontifier (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+
+// Almost-Montgomery multiply, z :== (x * y / 2^{64k}) (congruent mod m)
+// Inputs x[k], y[k], m[k]; output z[k]
+extern void bignum_amontmul (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+
+// Almost-Montgomery multiply, z :== (x * y / 2^256) (congruent mod p_256)
+// Inputs x[4], y[4]; output z[4]
+extern void bignum_amontmul_p256 (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+
+// Almost-Montgomery multiply, z :== (x * y / 2^384) (congruent mod p_384)
+// Inputs x[6], y[6]; output z[6]
+extern void bignum_amontmul_p384 (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+
+// Almost-Montgomery reduce, z :== (x' / 2^{64p}) (congruent mod m)
+// Inputs x[n], m[k], p; output z[k]
+extern void bignum_amontredc (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t *m, uint64_t p);
+
+// Almost-Montgomery square, z :== (x^2 / 2^{64k}) (congruent mod m)
+// Inputs x[k], y[k]; output z[k]
+extern void bignum_amontsqr (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y);
+
+// Almost-Montgomery square, z :== (x^2 / 2^256) (congruent mod p_256)
+// Input x[4]; output z[4]
+extern void bignum_amontsqr_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Almost-Montgomery square, z :== (x^2 / 2^384) (congruent mod p_384)
+// Input x[6]; output z[6]
+extern void bignum_amontsqr_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Select bitfield starting at bit n with length l <= 64
+// Inputs x[k], n, l; output function return
+extern uint64_t bignum_bitfield (uint64_t k, uint64_t *x, uint64_t n, uint64_t l);
+
+// Return size of bignum in bits
+// Input x[k]; output function return
+extern uint64_t bignum_bitsize (uint64_t k, uint64_t *x);
+
+// Count leading zero digits (64-bit words)
+// Input x[k]; output function return
+extern uint64_t bignum_cld (uint64_t k, uint64_t *x);
+
+// Connt leading zero bits
+// Input x[k]; output function return
+extern uint64_t bignum_clz (uint64_t k, uint64_t *x);
+
+// Multiply-add with single-word multiplier, z := z + c * y
+// Inputs c, y[n]; outputs function return (carry-out) and z[k]
+extern uint64_t bignum_cmadd (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+
+// Multiply by a single word, z := c * y
+// Inputs c, y[n]; outputs function return (carry-out) and z[k]
+extern uint64_t bignum_cmul (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+
+// Multiply by a single word modulo p_256, z := (c * x) mod p_256, assuming x reduced
+// Inputs c, x[4]; output z[4]
+extern void bignum_cmul_p256 (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+
+// Multiply by a single word modulo p_384, z := (c * x) mod p_384, assuming x reduced
+// Inputs c, x[6]; output z[6]
+extern void bignum_cmul_p384 (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
+
+// Test bignums for coprimality, gcd(x,y) = 1
+// Inputs x[m], y[n]; output function return; temporary buffer t[>=2*max(m,n)]
+extern uint64_t bignum_coprime (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y, uint64_t *t);
+
+// Copy bignum with zero-extension or truncation, z := x
+// Input x[n]; output z[k]
+extern void bignum_copy (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x);
+
+// Count trailing zero digits (64-bit words)
+// Input x[k]; output function return
+extern uint64_t bignum_ctd (uint64_t k, uint64_t *x);
+
+// Count trailing zero bits
+// Input x[k]; output function return
+extern uint64_t bignum_ctz (uint64_t k, uint64_t *x);
+
+// Convert from almost-Montgomery form, z := (x / 2^256) mod p_256
+// Input x[4]; output z[4]
+extern void bignum_deamont_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
+// Input x[6]; output z[6]
+extern void bignum_deamont_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Convert from (almost-)Montgomery form z := (x / 2^{64k}) mod m
+// Inputs x[k], m[k]; output z[k]
+extern void bignum_demont (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+
+// Convert from Montgomery form z := (x / 2^256) mod p_256, assuming x reduced
+// Input x[4]; output z[4]
+extern void bignum_demont_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+extern void bignum_demont_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Select digit x[n]
+// Inputs x[k], n; output function return
+extern uint64_t bignum_digit (uint64_t k, uint64_t *x, uint64_t n);
+
+// Return size of bignum in digits (64-bit word)
+// Input x[k]; output function return
+extern uint64_t bignum_digitsize (uint64_t k, uint64_t *x);
+
+// Double modulo p_256, z := (2 * x) mod p_256, assuming x reduced
+// Input x[4]; output z[4]
+extern void bignum_double_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Double modulo p_384, z := (2 * x) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+extern void bignum_double_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Extended Montgomery reduce, returning results in input-output buffer
+// Inputs z[2*k], m[k], w; outputs function return (extra result bit) and z[2*k]
+extern uint64_t bignum_emontredc (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w);
+
+// Extended Montgomery reduce in 8-digit blocks, results in input-output buffer
+// Inputs z[2*k], m[k], w; outputs function return (extra result bit) and z[2*k]
+extern uint64_t bignum_emontredc_8n (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w);
+
+// Test bignums for equality, x = y
+// Inputs x[m], y[n]; output function return
+extern uint64_t bignum_eq (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+
+// Test bignum for even-ness
+// Input x[k]; output function return
+extern uint64_t bignum_even (uint64_t k, uint64_t *x);
+
+// Compare bignums, x >= y
+// Inputs x[m], y[n]; output function return
+extern uint64_t bignum_ge (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+
+// Compare bignums, x > y
+// Inputs x[m], y[n]; output function return
+extern uint64_t bignum_gt (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+
+// Halve modulo p_256, z := (x / 2) mod p_256, assuming x reduced
+// Input x[4]; output z[4]
+extern void bignum_half_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Halve modulo p_384, z := (x / 2) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+extern void bignum_half_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Test bignum for zero-ness, x = 0
+// Input x[k]; output function return
+extern uint64_t bignum_iszero (uint64_t k, uint64_t *x);
+
+// Compare bignums, x <= y
+// Inputs x[m], y[n]; output function return
+extern uint64_t bignum_le (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+
+// Compare bignums, x < y
+// Inputs x[m], y[n]; output function return
+extern uint64_t bignum_lt (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+
+// Multiply-add, z := z + x * y
+// Inputs x[m], y[n]; outputs function return (carry-out) and z[k]
+extern uint64_t bignum_madd (uint64_t k, uint64_t *z, uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+
+// Reduce modulo group order, z := x mod n_256
+// Input x[k]; output z[4]
+extern void bignum_mod_n256 (uint64_t z[static 4], uint64_t k, uint64_t *x);
+
+// Reduce modulo group order, z := x mod n_256
+// Input x[4]; output z[4]
+extern void bignum_mod_n256_4 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Reduce modulo group order, z := x mod n_384
+// Input x[k]; output z[6]
+extern void bignum_mod_n384 (uint64_t z[static 6], uint64_t k, uint64_t *x);
+
+// Reduce modulo group order, z := x mod n_384
+// Input x[6]; output z[6]
+extern void bignum_mod_n384_6 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Reduce modulo field characteristic, z := x mod p_256
+// Input x[k]; output z[4]
+extern void bignum_mod_p256 (uint64_t z[static 4], uint64_t k, uint64_t *x);
+
+// Reduce modulo field characteristic, z := x mod p_256
+// Input x[4]; output z[4]
+extern void bignum_mod_p256_4 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Reduce modulo field characteristic, z := x mod p_384
+// Input x[k]; output z[6]
+extern void bignum_mod_p384 (uint64_t z[static 6], uint64_t k, uint64_t *x);
+
+// Reduce modulo field characteristic, z := x mod p_384
+// Input x[6]; output z[6]
+extern void bignum_mod_p384_6 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Add modulo m, z := (x + y) mod m, assuming x and y reduced
+// Inputs x[k], y[k], m[k]; output z[k]
+extern void bignum_modadd (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+
+// Double modulo m, z := (2 * x) mod m, assuming x reduced
+// Inputs x[k], m[k]; output z[k]
+extern void bignum_moddouble (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+
+// Compute "modification" constant z := 2^{64k} mod m
+// Input m[k]; output z[k]; temporary buffer t[>=k]
+extern void bignum_modifier (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+
+// Invert modulo m, z = (1/a) mod b, assuming b is an odd number > 1, a coprime to b
+// Inputs a[k], b[k]; output z[k]; temporary buffer t[>=3*k]
+extern void bignum_modinv (uint64_t k, uint64_t *z, uint64_t *a, uint64_t *b, uint64_t *t);
+
+// Optionally negate modulo m, z := (-x) mod m (if p nonzero) or z := x (if p zero), assuming x reduced
+// Inputs p, x[k], m[k]; output z[k]
+extern void bignum_modoptneg (uint64_t k, uint64_t *z, uint64_t p, uint64_t *x, uint64_t *m);
+
+// Subtract modulo m, z := (x - y) mod m, assuming x and y reduced
+// Inputs x[k], y[k], m[k]; output z[k]
+extern void bignum_modsub (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+
+// Compute "montification" constant z := 2^{128k} mod m
+// Input m[k]; output z[k]; temporary buffer t[>=k]
+extern void bignum_montifier (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+
+// Montgomery multiply, z := (x * y / 2^{64k}) mod m
+// Inputs x[k], y[k], m[k]; output z[k]
+extern void bignum_montmul (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+
+// Montgomery multiply, z := (x * y / 2^256) mod p_256
+// Inputs x[4], y[4]; output z[4]
+extern void bignum_montmul_p256 (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+
+// Montgomery multiply, z := (x * y / 2^384) mod p_384
+// Inputs x[6], y[6]; output z[6]
+extern void bignum_montmul_p384 (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+
+// Montgomery reduce, z := (x' / 2^{64p}) MOD m
+// Inputs x[n], m[k], p; output z[k]
+extern void bignum_montredc (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t *m, uint64_t p);
+
+// Montgomery square, z := (x^2 / 2^{64k}) mod m
+// Inputs x[k], y[k]; output z[k]
+extern void bignum_montsqr (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y);
+
+// Montgomery square, z := (x^2 / 2^256) mod p_256
+// Input x[4]; output z[4]
+extern void bignum_montsqr_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Montgomery square, z := (x^2 / 2^384) mod p_384
+// Input x[6]; output z[6]
+extern void bignum_montsqr_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Multiply z := x * y
+// Inputs x[m], y[n]; output z[k]
+extern void bignum_mul (uint64_t k, uint64_t *z, uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+
+// Multiply z := x * y
+// Inputs x[4], y[4]; output z[8]
+extern void bignum_mul_4_8 (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+
+// Multiply z := x * y
+// Inputs x[6], y[6]; output z[12]
+extern void bignum_mul_6_12 (uint64_t z[static 12], uint64_t x[static 6], uint64_t y[static 6]);
+
+// Multiply z := x * y
+// Inputs x[8], y[8]; output z[16]
+extern void bignum_mul_8_16 (uint64_t z[static 16], uint64_t x[static 8], uint64_t y[static 8]);
+
+// Multiplex/select z := x (if p nonzero) or z := y (if p zero)
+// Inputs b, x[k], y[k]; output b, z[k]
+extern void bignum_mux (uint64_t b, uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y);
+
+// Select element from 16-element table, z := xs[k*i]
+// Inputs xs[16*k], i; output z[k]
+extern void bignum_mux16 (uint64_t k, uint64_t *z, uint64_t *xs, uint64_t i);
+
+// Negate modulo p_256, z := (-x) mod p_256, assuming x reduced
+// Input x[4]; output z[4]
+extern void bignum_neg_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Negate modulo p_384, z := (-x) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+extern void bignum_neg_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Negated modular inverse, z := (-1/x) mod 2^{64k}
+// Input x[k]; output z[k]; temporary buffer t[>=k]
+extern void bignum_negmodinv (uint64_t k, uint64_t *z, uint64_t *t, uint64_t *x);
+
+// Test bignum for nonzero-ness x =/= 0
+// Input x[k]; output function return
+extern uint64_t bignum_nonzero (uint64_t k, uint64_t *x);
+
+// Normalize bignum in-place by shifting left till top bit is 1
+// Input z[k]; outputs function return (bits shifted left) and z[k]
+extern uint64_t bignum_normalize (uint64_t k, uint64_t *z);
+
+// Test bignum for odd-ness
+// Input x[k]; output function return
+extern uint64_t bignum_odd (uint64_t k, uint64_t *x);
+
+// Convert single digit to bignum, z := n
+// Input n; output z[k]
+extern void bignum_of_word (uint64_t k, uint64_t *z, uint64_t n);
+
+// Optionally add, z := x + y (if p nonzero) or z := x (if p zero)
+// Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
+extern uint64_t bignum_optadd (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+
+// Optionally negate, z := -x (if p nonzero) or z := x (if p zero)
+// Inputs p, x[k]; outputs function return (nonzero input) and z[k]
+extern uint64_t bignum_optneg (uint64_t k, uint64_t *z, uint64_t p, uint64_t *x);
+
+// Optionally negate modulo p_256, z := (-x) mod p_256 (if p nonzero) or z := x (if p zero), assuming x reduced
+// Inputs p, x[4]; output z[4]
+extern void bignum_optneg_p256 (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+
+// Optionally negate modulo p_384, z := (-x) mod p_384 (if p nonzero) or z := x (if p zero), assuming x reduced
+// Inputs p, x[6]; output z[6]
+extern void bignum_optneg_p384 (uint64_t z[static 6], uint64_t p, uint64_t x[static 6]);
+
+// Optionally subtract, z := x - y (if p nonzero) or z := x (if p zero)
+// Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
+extern uint64_t bignum_optsub (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+
+// Optionally subtract or add, z := x + sgn(p) * y interpreting p as signed
+// Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
+extern uint64_t bignum_optsubadd (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+
+// Return bignum of power of 2, z := 2^n
+// Input n; output z[k]
+extern void bignum_pow2 (uint64_t k, uint64_t *z, uint64_t n);
+
+// Shift bignum left by c < 64 bits z := x * 2^c
+// Inputs x[n], c; outputs function return (carry-out) and z[k]
+extern uint64_t bignum_shl_small (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t c);
+
+// Shift bignum right by c < 64 bits z := floor(x / 2^c)
+// Inputs x[n], c; outputs function return (bits shifted out) and z[k]
+extern uint64_t bignum_shr_small (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t c);
+
+// Square, z := x^2
+// Input x[4]; output z[8]
+extern void bignum_sqr_4_8 (uint64_t z[static 8], uint64_t x[static 4]);
+
+// Square, z := x^2
+// Input x[6]; output z[12]
+extern void bignum_sqr_6_12 (uint64_t z[static 12], uint64_t x[static 6]);
+
+// Square, z := x^2
+// Input x[8]; output z[16]
+extern void bignum_sqr_8_16 (uint64_t z[static 16], uint64_t x[static 8]);
+
+// Subtract, z := x - y
+// Inputs x[m], y[n]; outputs function return (carry-out) and z[p]
+extern uint64_t bignum_sub (uint64_t p, uint64_t *z, uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+
+// Subtract modulo p_256, z := (x - y) mod p_256
+// Inputs x[4], y[4]; output z[4]
+extern void bignum_sub_p256 (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+
+// Subtract modulo p_384, z := (x - y) mod p_384
+// Inputs x[6], y[6]; output z[6]
+extern void bignum_sub_p384 (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+
+// Convert to Montgomery form z := (2^256 * x) mod p_256
+// Input x[4]; output z[4]
+extern void bignum_tomont_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Convert to Montgomery form z := (2^256 * x) mod p_256
+// Input x[6]; output z[6]
+extern void bignum_tomont_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Triple modulo p_256, z := (3 * x) mod p_256
+// Input x[4]; output z[4]
+extern void bignum_triple_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+
+// Triple modulo p_384, z := (3 * x) mod p_384
+// Input x[6]; output z[6]
+extern void bignum_triple_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+
+// Count leading zero bits in a single word
+// Input a; output function return
+extern uint64_t word_clz (uint64_t a);
+
+// Count trailing zero bits in a single word
+// Input a; output function return
+extern uint64_t word_ctz (uint64_t a);
+
+// Single-word negated modular inverse (-1/a) mod 2^64
+// Input a; output function return
+extern uint64_t word_negmodinv (uint64_t a);

--- a/include/s2n-bignum.h
+++ b/include/s2n-bignum.h
@@ -322,8 +322,8 @@ extern void bignum_neg_p256 (uint64_t z[static 4], uint64_t x[static 4]);
 extern void bignum_neg_p384 (uint64_t z[static 6], uint64_t x[static 6]);
 
 // Negated modular inverse, z := (-1/x) mod 2^{64k}
-// Input x[k]; output z[k]; temporary buffer t[>=k]
-extern void bignum_negmodinv (uint64_t k, uint64_t *z, uint64_t *t, uint64_t *x);
+// Input x[k]; output z[k]
+extern void bignum_negmodinv (uint64_t k, uint64_t *z, uint64_t *x);
 
 // Test bignum for nonzero-ness x =/= 0
 // Input x[k]; output function return

--- a/include/s2n-bignum.h
+++ b/include/s2n-bignum.h
@@ -35,7 +35,7 @@ extern void bignum_add_p256 (uint64_t z[static 4], uint64_t x[static 4], uint64_
 
 // Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
 // Inputs x[6], y[6]; output z[6]
-extern void bignum_add_p384 (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+extern void bignum_add_p384 (uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
 
 // Compute "amontification" constant z :== 2^{128k} (congruent mod m)
 // Input m[k]; output z[k]; temporary buffer t[>=k]
@@ -271,7 +271,7 @@ extern void bignum_montmul_p256 (uint64_t z[static 4], uint64_t x[static 4], uin
 
 // Montgomery multiply, z := (x * y / 2^384) mod p_384
 // Inputs x[6], y[6]; output z[6]
-extern void bignum_montmul_p384 (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+extern void bignum_montmul_p384 (uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
 
 // Montgomery reduce, z := (x' / 2^{64p}) MOD m
 // Inputs x[n], m[k], p; output z[k]
@@ -287,7 +287,7 @@ extern void bignum_montsqr_p256 (uint64_t z[static 4], uint64_t x[static 4]);
 
 // Montgomery square, z := (x^2 / 2^384) mod p_384
 // Input x[6]; output z[6]
-extern void bignum_montsqr_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+extern void bignum_montsqr_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
 
 // Multiply z := x * y
 // Inputs x[m], y[n]; output z[k]

--- a/third_party/fiat/p384_32.h
+++ b/third_party/fiat/p384_32.h
@@ -33,7 +33,6 @@ static __inline__ uint32_t fiat_p384_value_barrier_u32(uint32_t a) {
 #endif
 
 // TODO: if we regenerate the Fiat-crypto files with only the needed functions, no need for these declarations.
-OPENSSL_UNUSED static void fiat_p384_opp(uint32_t out1[6], const uint32_t arg1[6]);
 OPENSSL_UNUSED static void fiat_p384_set_one(uint32_t out1[6]);
 OPENSSL_UNUSED static void fiat_p384_msat(uint32_t out1[7]);
 OPENSSL_UNUSED static void fiat_p384_divstep(uint32_t* out1, uint32_t out2[7], uint32_t out3[7], uint32_t out4[6], uint32_t out5[6], uint32_t arg1, const uint32_t arg2[7], const uint32_t arg3[7], const uint32_t arg4[6], const uint32_t arg5[6]);

--- a/third_party/fiat/p384_64.h
+++ b/third_party/fiat/p384_64.h
@@ -41,7 +41,6 @@ static __inline__ uint64_t fiat_p384_value_barrier_u64(uint64_t a) {
 #endif
 
 // TODO: if we regenerate the Fiat-crypto files with only the needed functions, no need for these declarations.
-OPENSSL_UNUSED static void fiat_p384_opp(uint64_t out1[6], const uint64_t arg1[6]);
 OPENSSL_UNUSED static void fiat_p384_set_one(uint64_t out1[6]);
 OPENSSL_UNUSED static void fiat_p384_msat(uint64_t out1[7]);
 OPENSSL_UNUSED static void fiat_p384_divstep(uint64_t* out1, uint64_t out2[7], uint64_t out3[7], uint64_t out4[6], uint64_t out5[6], uint64_t arg1, const uint64_t arg2[7], const uint64_t arg3[7], const uint64_t arg4[6], const uint64_t arg5[6]);


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-750

### Description of changes:
In this PR, the field arithmetic underlying P-384 operations is changed from Fiat-crypto to [s2n-bignum](https://github.com/awslabs/s2n-bignum) for Armv8 (AArch64).
Performance

### Call-outs:
* `selectznz`, `from_bytes` and `to_bytes` are not moved yet and may require their own assembly implementation.
* `nonzero` can be moved with a wrapper, but we will check if it can be implemented specifically for p-384 size.

### Testing:
`crypto_test` and `bssl speed` tests filtered on ECDH and ECDSA pass on Armv8 (Graviton 2).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
