### PR TITLE
Integrate s2n-bignum into ARMv8 for P-384

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -148,6 +148,13 @@ if(${ARCH} STREQUAL "aarch64")
 
     chacha/chacha-armv8.${ASM_EXT}
     test/trampoline-armv8.${ASM_EXT}
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_add_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_montmul_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_montsqr_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_sub_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_neg_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_tomont_p384.S
+    ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/Arm/bignum_demont_p384.S
   )
 endif()
 

--- a/third_party/s2n-bignum/Arm/bignum_add_p384.S
+++ b/third_party/s2n-bignum/Arm/bignum_add_p384.S
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
+// Inputs x[6], y[6]; output z[6]
+//
+//    extern void bignum_add_p384
+//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define x x1
+#define y x2
+#define c x3
+#define l x4
+#define d0 x5
+#define d1 x6
+#define d2 x7
+#define d3 x8
+#define d4 x9
+#define d5 x10
+
+.text
+.globl bignum_add_p384
+
+bignum_add_p384:
+
+// First just add the numbers as c + [d5; d4; d3; d2; d1; d0]
+
+                ldp     d0, d1, [x]
+                ldp     l, c, [y]
+                adds    d0, d0, l
+                adcs    d1, d1, c
+                ldp     d2, d3, [x, #16]
+                ldp     l, c, [y, #16]
+                adcs    d2, d2, l
+                adcs    d3, d3, c
+                ldp     d4, d5, [x, #32]
+                ldp     l, c, [y, #32]
+                adcs    d4, d4, l
+                adcs    d5, d5, c
+                adc     c, xzr, xzr
+
+// Now compare [d5; d4; d3; d2; d1; d0] with p_384
+
+                mov     l, 0x00000000ffffffff
+                subs    xzr, d0, l
+                mov     l, 0xffffffff00000000
+                sbcs    xzr, d1, l
+                mov     l, 0xfffffffffffffffe
+                sbcs    xzr, d2, l
+                adcs    xzr, d3, xzr
+                adcs    xzr, d4, xzr
+                adcs    xzr, d5, xzr
+
+// Now CF is set (because of inversion) if (x + y) % 2^384 >= p_384
+// Thus we want to correct if either this is set or the original carry c was
+
+                adcs    c, c, xzr
+                csetm   c, ne
+
+// Now correct by subtracting masked p_384
+
+                mov     l, 0x00000000ffffffff
+                and     l, l, c
+                subs    d0, d0, l
+                eor     l, l, c
+                sbcs    d1, d1, l
+                mov     l, 0xfffffffffffffffe
+                and     l, l, c
+                sbcs    d2, d2, l
+                sbcs    d3, d3, c
+                sbcs    d4, d4, c
+                sbc     d5, d5, c
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+
+                ret

--- a/third_party/s2n-bignum/Arm/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/Arm/bignum_demont_p384.S
@@ -1,0 +1,117 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+//
+//    extern void bignum_demont_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// This assumes the input is < p_384 for correctness. If this is not the case,
+// use the variant "bignum_deamont_p384" instead.
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+.globl   bignum_demont_p384
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+.macro          montreds d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+// Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+// Recycle d0 (which we know gets implicitly cancelled) to store it
+                lsl     \t1, \d0, 32
+                add     \d0, \t1, \d0
+// Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)
+// We need to subtract 2^32 * this, and we can ignore its lower 32
+// bits since by design it will cancel anyway; we only need the w_hi
+// part to get the carry propagation going.
+                lsr     \t1, \d0, 32
+                subs    \t1, \t1, \d0
+                sbc     \t2, \d0, xzr
+// Now select in t1 the field to subtract from d1
+                extr    \t1, \t2, \t1, 32
+// And now get the terms to subtract from d2 and d3
+                lsr     \t2, \t2, 32
+                adds    \t2, \t2, \d0
+                adc     \t3, xzr, xzr
+// Do the subtraction of that portion
+                subs    \d1, \d1, \t1
+                sbcs    \d2, \d2, \t2
+                sbcs    \d3, \d3, \t3
+                sbcs    \d4, \d4, xzr
+                sbcs    \d5, \d5, xzr
+// Now effectively add 2^384 * w by taking d0 as the input for the last sbc
+                sbc     \d6, \d0, xzr
+.endm
+
+// Input parameters
+
+#define z x0
+#define x x1
+
+// Rotating registers for the intermediate windows
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+
+// Other temporaries
+
+#define u x8
+#define v x9
+#define w x10
+
+bignum_demont_p384:
+
+// Set up an initial window with the input x and an extra leading zero
+
+                ldp     d0, d1, [x]
+                ldp     d2, d3, [x, 16]
+                ldp     d4, d5, [x, 32]
+
+// Systematically scroll left doing 1-step reductions
+
+                montreds d0,d5,d4,d3,d2,d1,d0, u,v,w
+
+                montreds d1,d0,d5,d4,d3,d2,d1, u,v,w
+
+                montreds d2,d1,d0,d5,d4,d3,d2, u,v,w
+
+                montreds d3,d2,d1,d0,d5,d4,d3, u,v,w
+
+                montreds d4,d3,d2,d1,d0,d5,d4, u,v,w
+
+                montreds d5,d4,d3,d2,d1,d0,d5, u,v,w
+
+// This is already our answer with no correction needed
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, 16]
+                stp     d4, d5, [z, 32]
+
+                ret

--- a/third_party/s2n-bignum/Arm/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/Arm/bignum_montmul_p384.S
@@ -1,0 +1,423 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^384) mod p_384
+// Inputs x[6], y[6]; output z[6]
+//
+//    extern void bignum_montmul_p384
+//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//
+// Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
+// satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in
+// the "usual" case x < p_384 and y < p_384).
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+.globl   bignum_montmul_p384
+
+// ---------------------------------------------------------------------------
+// Macro returning (c,h,l) = 3-word 1s complement (x - y) * (w - z)
+// c,h,l,t should all be different
+// t,h should not overlap w,z
+// ---------------------------------------------------------------------------
+
+.macro muldiffn c,h,l, t, x,y, w,z
+        subs    \t, \x, \y
+        cneg    \t, \t, cc
+        csetm   \c, cc
+        subs    \h, \w, \z
+        cneg    \h, \h, cc
+        mul     \l, \t, \h
+        umulh   \h, \t, \h
+        cinv    \c, \c, cc
+        eor     \l, \l, \c
+        eor     \h, \h, \c
+.endm
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+.macro          montreds d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+// Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+// Recycle d0 (which we know gets implicitly cancelled) to store it
+                lsl     \t1, \d0, 32
+                add     \d0, \t1, \d0
+// Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)
+// We need to subtract 2^32 * this, and we can ignore its lower 32
+// bits since by design it will cancel anyway; we only need the w_hi
+// part to get the carry propagation going.
+                lsr     \t1, \d0, 32
+                subs    \t1, \t1, \d0
+                sbc     \t2, \d0, xzr
+// Now select in t1 the field to subtract from d1
+                extr    \t1, \t2, \t1, 32
+// And now get the terms to subtract from d2 and d3
+                lsr     \t2, \t2, 32
+                adds    \t2, \t2, \d0
+                adc     \t3, xzr, xzr
+// Do the subtraction of that portion
+                subs    \d1, \d1, \t1
+                sbcs    \d2, \d2, \t2
+                sbcs    \d3, \d3, \t3
+                sbcs    \d4, \d4, xzr
+                sbcs    \d5, \d5, xzr
+// Now effectively add 2^384 * w by taking d0 as the input for the last sbc
+                sbc     \d6, \d0, xzr
+.endm
+
+#define a0 x3
+#define a1 x4
+#define a2 x5
+#define a3 x6
+#define a4 x7
+#define a5 x8
+#define b0 x9
+#define b1 x10
+#define b2 x11
+#define b3 x12
+#define b4 x13
+#define b5 x14
+
+#define s0 x15
+#define s1 x16
+#define s2 x17
+#define s3 x19
+#define s4 x20
+#define s5 x1
+#define s6 x2
+
+#define t1 x21
+#define t2 x22
+#define t3 x23
+#define t4 x24
+
+bignum_montmul_p384:
+
+// Save some registers
+
+                stp     x19, x20, [sp, -16]!
+                stp     x21, x22, [sp, -16]!
+                stp     x23, x24, [sp, -16]!
+
+// Load in all words of both inputs
+
+                ldp     a0, a1, [x1]
+                ldp     a2, a3, [x1, 16]
+                ldp     a4, a5, [x1, 32]
+                ldp     b0, b1, [x2]
+                ldp     b2, b3, [x2, 16]
+                ldp     b4, b5, [x2, 32]
+
+// Multiply low halves with a 3x3->6 ADK multiplier as [s5;s4;s3;s2;s1;s0]
+
+                mul     s0, a0, b0
+                mul     t1, a1, b1
+                mul     t2, a2, b2
+                umulh   t3, a0, b0
+                umulh   t4, a1, b1
+                umulh   s5, a2, b2
+
+                adds    t3, t3, t1
+                adcs    t4, t4, t2
+                adc     s5, s5, xzr
+
+                adds    s1, t3, s0
+                adcs    s2, t4, t3
+                adcs    s3, s5, t4
+                adc     s4, s5, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, t3
+                adcs    s4, s4, t4
+                adc     s5, s5, xzr
+
+                muldiffn t3,t2,t1, t4, a0,a1, b1,b0
+                adds    xzr, t3, 1
+                adcs    s1, s1, t1
+                adcs    s2, s2, t2
+                adcs    s3, s3, t3
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a0,a2, b2,b0
+                adds    xzr, t3, 1
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a1,a2, b2,b1
+                adds    xzr, t3, 1
+                adcs    s3, s3, t1
+                adcs    s4, s4, t2
+                adc     s5, s5, t3
+
+// Perform three "short" Montgomery steps on the low product
+// This shifts it to an offset compatible with middle terms
+// Stash the result temporarily in the output buffer
+// We could keep this in registers by directly adding to it in the next
+// ADK block, but if anything that seems to be slightly slower
+
+                montreds s0,s5,s4,s3,s2,s1,s0, t1,t2,t3
+
+                montreds s1,s0,s5,s4,s3,s2,s1, t1,t2,t3
+
+                montreds s2,s1,s0,s5,s4,s3,s2, t1,t2,t3
+
+                stp     s3, s4, [x0]
+                stp     s5, s0, [x0, 16]
+                stp     s1, s2, [x0, 32]
+
+// Multiply high halves with a 3x3->6 ADK multiplier as [s5;s4;s3;s2;s1;s0]
+
+                mul     s0, a3, b3
+                mul     t1, a4, b4
+                mul     t2, a5, b5
+                umulh   t3, a3, b3
+                umulh   t4, a4, b4
+                umulh   s5, a5, b5
+
+                adds    t3, t3, t1
+                adcs    t4, t4, t2
+                adc     s5, s5, xzr
+
+                adds    s1, t3, s0
+                adcs    s2, t4, t3
+                adcs    s3, s5, t4
+                adc     s4, s5, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, t3
+                adcs    s4, s4, t4
+                adc     s5, s5, xzr
+
+                muldiffn t3,t2,t1, t4, a3,a4, b4,b3
+                adds    xzr, t3, 1
+                adcs    s1, s1, t1
+                adcs    s2, s2, t2
+                adcs    s3, s3, t3
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a3,a5, b5,b3
+                adds    xzr, t3, 1
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a4,a5, b5,b4
+                adds    xzr, t3, 1
+                adcs    s3, s3, t1
+                adcs    s4, s4, t2
+                adc     s5, s5, t3
+
+// Compute sign-magnitude a0,[a5,a4,a3] = x_hi - x_lo
+
+                subs    a3, a3, a0
+                sbcs    a4, a4, a1
+                sbcs    a5, a5, a2
+                sbc     a0, xzr, xzr
+                adds    xzr, a0, 1
+                eor     a3, a3, a0
+                adcs    a3, a3, xzr
+                eor     a4, a4, a0
+                adcs    a4, a4, xzr
+                eor     a5, a5, a0
+                adc     a5, a5, xzr
+
+// Compute sign-magnitude b5,[b2,b1,b0] = y_lo - y_hi
+
+                subs    b0, b0, b3
+                sbcs    b1, b1, b4
+                sbcs    b2, b2, b5
+                sbc     b5, xzr, xzr
+
+                adds    xzr, b5, 1
+                eor     b0, b0, b5
+                adcs    b0, b0, xzr
+                eor     b1, b1, b5
+                adcs    b1, b1, xzr
+                eor     b2, b2, b5
+                adc     b2, b2, xzr
+
+// Save the correct sign for the sub-product in b5
+
+                eor     b5, a0, b5
+
+// Add the high H to the modified low term L' and re-stash 6 words,
+// keeping top word in s6
+
+                ldp     t1, t2, [x0]
+                adds    s0, s0, t1
+                adcs    s1, s1, t2
+                ldp     t1, t2, [x0, 16]
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                ldp     t1, t2, [x0, 32]
+                adcs    s4, s4, t1
+                adcs    s5, s5, t2
+                adc     s6, xzr, xzr
+                stp     s0, s1, [x0]
+                stp     s2, s3, [x0, 16]
+                stp     s4, s5, [x0, 32]
+
+// Multiply with yet a third 3x3 ADK for the complex mid-term
+
+                mul     s0, a3, b0
+                mul     t1, a4, b1
+                mul     t2, a5, b2
+                umulh   t3, a3, b0
+                umulh   t4, a4, b1
+                umulh   s5, a5, b2
+
+                adds    t3, t3, t1
+                adcs    t4, t4, t2
+                adc     s5, s5, xzr
+
+                adds    s1, t3, s0
+                adcs    s2, t4, t3
+                adcs    s3, s5, t4
+                adc     s4, s5, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, t3
+                adcs    s4, s4, t4
+                adc     s5, s5, xzr
+
+                muldiffn t3,t2,t1, t4, a3,a4, b1,b0
+                adds    xzr, t3, 1
+                adcs    s1, s1, t1
+                adcs    s2, s2, t2
+                adcs    s3, s3, t3
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a3,a5, b2,b0
+                adds    xzr, t3, 1
+                adcs    s2, s2, t1
+                adcs    s3, s3, t2
+                adcs    s4, s4, t3
+                adc     s5, s5, t3
+
+                muldiffn t3,t2,t1, t4, a4,a5, b2,b1
+                adds    xzr, t3, 1
+                adcs    s3, s3, t1
+                adcs    s4, s4, t2
+                adc     s5, s5, t3
+
+// Unstash the H + L' sum to add in twice
+
+                ldp     a0, a1, [x0]
+                ldp     a2, a3, [x0, 16]
+                ldp     a4, a5, [x0, 32]
+
+// Set up a sign-modified version of the mid-product in a long accumulator
+// as [b3;b2;b1;b0;s5;s4;s3;s2;s1;s0], adding in the H + L' term once with
+// zero offset as this signed value is created
+
+                adds    xzr, b5, 1
+                eor     s0, s0, b5
+                adcs    s0, s0, a0
+                eor     s1, s1, b5
+                adcs    s1, s1, a1
+                eor     s2, s2, b5
+                adcs    s2, s2, a2
+                eor     s3, s3, b5
+                adcs    s3, s3, a3
+                eor     s4, s4, b5
+                adcs    s4, s4, a4
+                eor     s5, s5, b5
+                adcs    s5, s5, a5
+                adcs    b0, b5, s6
+                adcs    b1, b5, xzr
+                adcs    b2, b5, xzr
+                adc     b3, b5, xzr
+
+// Add in the stashed H + L' term an offset of 3 words as well
+
+                adds    s3, s3, a0
+                adcs    s4, s4, a1
+                adcs    s5, s5, a2
+                adcs    b0, b0, a3
+                adcs    b1, b1, a4
+                adcs    b2, b2, a5
+                adc     b3, b3, s6
+
+// Do three more Montgomery steps on the composed term
+
+                montreds s0,s5,s4,s3,s2,s1,s0, t1,t2,t3
+                montreds s1,s0,s5,s4,s3,s2,s1, t1,t2,t3
+                montreds s2,s1,s0,s5,s4,s3,s2, t1,t2,t3
+
+                adds    b0, b0, s0
+                adcs    b1, b1, s1
+                adcs    b2, b2, s2
+                adc     b3, b3, xzr
+
+// Because of the way we added L' in two places, we can overspill by
+// more than usual in Montgomery, with the result being only known to
+// be < 3 * p_384, not the usual < 2 * p_384. So now we do a more
+// elaborate final correction in the style of bignum_cmul_p384, just
+// a little bit simpler because we know q is small.
+
+                add     t2, b3, 1
+                lsl     t1, t2, 32
+                subs    t4, t2, t1
+                sbc     t1, t1, xzr
+
+                adds    s3, s3, t4
+                adcs    s4, s4, t1
+                adcs    s5, s5, t2
+                adcs    b0, b0, xzr
+                adcs    b1, b1, xzr
+                adcs    b2, b2, xzr
+
+                csetm   t2, cc
+
+                mov     t3, 0x00000000ffffffff
+                and     t3, t3, t2
+                adds    s3, s3, t3
+                eor     t3, t3, t2
+                adcs    s4, s4, t3
+                mov     t3, 0xfffffffffffffffe
+                and     t3, t3, t2
+                adcs    s5, s5, t3
+                adcs    b0, b0, t2
+                adcs    b1, b1, t2
+                adc     b2, b2, t2
+
+// Write back the result
+
+                stp     s3, s4, [x0]
+                stp     s5, b0, [x0, 16]
+                stp     b1, b2, [x0, 32]
+
+// Restore registers and return
+
+                ldp     x23, x24, [sp], 16
+                ldp     x21, x22, [sp], 16
+                ldp     x19, x20, [sp], 16
+
+                ret

--- a/third_party/s2n-bignum/Arm/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/Arm/bignum_montsqr_p384.S
@@ -1,0 +1,380 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^384) mod p_384
+// Input x[6]; output z[6]
+//
+//    extern void bignum_montsqr_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
+// guaranteed in particular if x < p_384 initially (the "intended" case).
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+.globl   bignum_montsqr_p384
+
+// ---------------------------------------------------------------------------
+// Macro returning (c,h,l) = 3-word 1s complement (x - y) * (w - z)
+// c,h,l,t should all be different
+// t,h should not overlap w,z
+// ---------------------------------------------------------------------------
+
+.macro muldiffn c,h,l, t, x,y, w,z
+        subs    \t, \x, \y
+        cneg    \t, \t, cc
+        csetm   \c, cc
+        subs    \h, \w, \z
+        cneg    \h, \h, cc
+        mul     \l, \t, \h
+        umulh   \h, \t, \h
+        cinv    \c, \c, cc
+        eor     \l, \l, \c
+        eor     \h, \h, \c
+.endm
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+.macro          montreds d6,d5,d4,d3,d2,d1,d0, t3,t2,t1
+// Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64
+// Recycle d0 (which we know gets implicitly cancelled) to store it
+                lsl     \t1, \d0, 32
+                add     \d0, \t1, \d0
+// Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)
+// We need to subtract 2^32 * this, and we can ignore its lower 32
+// bits since by design it will cancel anyway; we only need the w_hi
+// part to get the carry propagation going.
+                lsr     \t1, \d0, 32
+                subs    \t1, \t1, \d0
+                sbc     \t2, \d0, xzr
+// Now select in t1 the field to subtract from d1
+                extr    \t1, \t2, \t1, 32
+// And now get the terms to subtract from d2 and d3
+                lsr     \t2, \t2, 32
+                adds    \t2, \t2, \d0
+                adc     \t3, xzr, xzr
+// Do the subtraction of that portion
+                subs    \d1, \d1, \t1
+                sbcs    \d2, \d2, \t2
+                sbcs    \d3, \d3, \t3
+                sbcs    \d4, \d4, xzr
+                sbcs    \d5, \d5, xzr
+// Now effectively add 2^384 * w by taking d0 as the input for the last sbc
+                sbc     \d6, \d0, xzr
+.endm
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define a4 x6
+#define a5 x7
+
+#define c0 x8
+#define c1 x9
+#define c2 x10
+#define c3 x11
+#define c4 x12
+#define c5 x13
+#define d1 x14
+#define d2 x15
+#define d3 x16
+#define d4 x17
+
+bignum_montsqr_p384:
+
+// Load in all words of the input
+
+                ldp     a0, a1, [x1]
+                ldp     a2, a3, [x1, 16]
+                ldp     a4, a5, [x1, 32]
+
+// Square the low half getting a result in [c5;c4;c3;c2;c1;c0]
+
+                mul     d1, a0, a1
+                mul     d2, a0, a2
+                mul     d3, a1, a2
+                mul     c0, a0, a0
+                mul     c2, a1, a1
+                mul     c4, a2, a2
+
+                umulh   d4, a0, a1
+                adds    d2, d2, d4
+                umulh   d4, a0, a2
+                adcs    d3, d3, d4
+                umulh   d4, a1, a2
+                adcs    d4, d4, xzr
+
+                umulh   c1, a0, a0
+                umulh   c3, a1, a1
+                umulh   c5, a2, a2
+
+                adds    d1, d1, d1
+                adcs    d2, d2, d2
+                adcs    d3, d3, d3
+                adcs    d4, d4, d4
+                adc     c5, c5, xzr
+
+                adds    c1, c1, d1
+                adcs    c2, c2, d2
+                adcs    c3, c3, d3
+                adcs    c4, c4, d4
+                adc     c5, c5, xzr
+
+// Perform three "short" Montgomery steps on the low square
+// This shifts it to an offset compatible with middle product
+// Stash the result temporarily in the output buffer (to avoid more registers)
+
+                montreds c0,c5,c4,c3,c2,c1,c0, d1,d2,d3
+
+                montreds c1,c0,c5,c4,c3,c2,c1, d1,d2,d3
+
+                montreds c2,c1,c0,c5,c4,c3,c2, d1,d2,d3
+
+                stp     c3, c4, [x0]
+                stp     c5, c0, [x0, 16]
+                stp     c1, c2, [x0, 32]
+
+// Compute product of the cross-term with ADK 3x3->6 multiplier
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define a4 x6
+#define a5 x7
+#define s0 x8
+#define s1 x9
+#define s2 x10
+#define s3 x11
+#define s4 x12
+#define s5 x13
+
+#define l1 x14
+#define l2 x15
+#define h0 x16
+#define h1 x17
+#define h2 x1
+
+#define s6 h1
+#define c  l1
+#define h  l2
+#define l  h0
+#define t  h1
+
+                mul     s0, a0, a3
+                mul     l1, a1, a4
+                mul     l2, a2, a5
+                umulh   h0, a0, a3
+                umulh   h1, a1, a4
+                umulh   h2, a2, a5
+
+                adds    h0, h0, l1
+                adcs    h1, h1, l2
+                adc     h2, h2, xzr
+
+                adds    s1, h0, s0
+                adcs    s2, h1, h0
+                adcs    s3, h2, h1
+                adc     s4, h2, xzr
+
+                adds    s2, s2, s0
+                adcs    s3, s3, h0
+                adcs    s4, s4, h1
+                adc     s5, h2, xzr
+
+                muldiffn c,h,l, t, a0,a1, a4,a3
+                adds    xzr, c, 1
+                adcs    s1, s1, l
+                adcs    s2, s2, h
+                adcs    s3, s3, c
+                adcs    s4, s4, c
+                adc     s5, s5, c
+
+                muldiffn c,h,l, t, a0,a2, a5,a3
+                adds    xzr, c, 1
+                adcs    s2, s2, l
+                adcs    s3, s3, h
+                adcs    s4, s4, c
+                adc     s5, s5, c
+
+                muldiffn c,h,l, t, a1,a2, a5,a4
+                adds    xzr, c, 1
+                adcs    s3, s3, l
+                adcs    s4, s4, h
+                adc     s5, s5, c
+
+// Double it and add the stashed Montgomerified low square
+
+                adds    s0, s0, s0
+                adcs    s1, s1, s1
+                adcs    s2, s2, s2
+                adcs    s3, s3, s3
+                adcs    s4, s4, s4
+                adcs    s5, s5, s5
+                adc     s6, xzr, xzr
+
+                ldp     a0, a1, [x0]
+                adds    s0, s0, a0
+                adcs    s1, s1, a1
+                ldp     a0, a1, [x0, 16]
+                adcs    s2, s2, a0
+                adcs    s3, s3, a1
+                ldp     a0, a1, [x0, 32]
+                adcs    s4, s4, a0
+                adcs    s5, s5, a1
+                adc     s6, s6, xzr
+
+// Montgomery-reduce the combined low and middle term another thrice
+
+                montreds s0,s5,s4,s3,s2,s1,s0, a0,a1,a2
+
+                montreds s1,s0,s5,s4,s3,s2,s1, a0,a1,a2
+
+                montreds s2,s1,s0,s5,s4,s3,s2, a0,a1,a2
+
+                adds    s6, s6, s0
+                adcs    s0, s1, xzr
+                adcs    s1, s2, xzr
+                adcs    s2, xzr, xzr
+
+// Our sum so far is in [s2;s1;s0;s6;s5;s4;s3]
+// Choose more intuitive names
+
+#define r0 x11
+#define r1 x12
+#define r2 x13
+#define r3 x17
+#define r4 x8
+#define r5 x9
+#define r6 x10
+
+// Remind ourselves what else we can't destroy
+
+#define a3 x5
+#define a4 x6
+#define a5 x7
+
+// So we can have these as temps
+
+#define t1 x1
+#define t2 x14
+#define t3 x15
+#define t4 x16
+
+// Add in all the pure squares 33 + 44 + 55
+
+                mul     t1, a3, a3
+                adds    r0, r0, t1
+                mul     t2, a4, a4
+                mul     t3, a5, a5
+                umulh   t1, a3, a3
+                adcs    r1, r1, t1
+                umulh   t1, a4, a4
+                adcs    r2, r2, t2
+                adcs    r3, r3, t1
+                umulh   t1, a5, a5
+                adcs    r4, r4, t3
+                adcs    r5, r5, t1
+                adc     r6, r6, xzr
+
+// Now compose the 34 + 35 + 45 terms, which need doubling
+
+                mul     t1, a3, a4
+                mul     t2, a3, a5
+                mul     t3, a4, a5
+                umulh   t4, a3, a4
+                adds    t2, t2, t4
+                umulh   t4, a3, a5
+                adcs    t3, t3, t4
+                umulh   t4, a4, a5
+                adc     t4, t4, xzr
+
+// Double and add. Recycle one of the no-longer-needed inputs as a temp
+
+#define t5 x5
+
+                adds    t1, t1, t1
+                adcs    t2, t2, t2
+                adcs    t3, t3, t3
+                adcs    t4, t4, t4
+                adc     t5, xzr, xzr
+
+                adds    r1, r1, t1
+                adcs    r2, r2, t2
+                adcs    r3, r3, t3
+                adcs    r4, r4, t4
+                adcs    r5, r5, t5
+                adc     r6, r6, xzr
+
+// We know, writing B = 2^{6*64} that the full implicit result is
+// B^2 c <= z + (B - 1) * p < B * p + (B - 1) * p < 2 * B * p,
+// so the top half is certainly < 2 * p. If c = 1 already, we know
+// subtracting p will give the reduced modulus. But now we do a
+// comparison to catch cases where the residue is >= p.
+// First set [0;0;0;t3;t2;t1] = 2^384 - p_384
+
+                mov     t1, 0xffffffff00000001
+                mov     t2, 0x00000000ffffffff
+                mov     t3, 0x0000000000000001
+
+// Let dd = [] be the 6-word intermediate result.
+// Set CF if the addition dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384.
+
+                adds    xzr, r0, t1
+                adcs    xzr, r1, t2
+                adcs    xzr, r2, t3
+                adcs    xzr, r3, xzr
+                adcs    xzr, r4, xzr
+                adcs    xzr, r5, xzr
+
+// Now just add this new carry into the existing r6. It's easy to see they
+// can't both be 1 by our range assumptions, so this gives us a {0,1} flag
+
+                adc     r6, r6, xzr
+
+// Now convert it into a bitmask
+
+                sub     r6, xzr, r6
+
+// Masked addition of 2^384 - p_384, hence subtraction of p_384
+
+                and     t1, t1, r6
+                adds    r0, r0, t1
+                and     t2, t2, r6
+                adcs    r1, r1, t2
+                and     t3, t3, r6
+                adcs    r2, r2, t3
+                adcs    r3, r3, xzr
+                adcs    r4, r4, xzr
+                adc     r5, r5, xzr
+
+// Store it back
+
+                stp     r0, r1, [x0]
+                stp     r2, r3, [x0, 16]
+                stp     r4, r5, [x0, 32]
+
+                ret

--- a/third_party/s2n-bignum/Arm/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/Arm/bignum_neg_p384.S
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Negate modulo p_384, z := (-x) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+//
+//    extern void bignum_neg_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define x x1
+
+#define p x2
+#define t x3
+
+#define d0 x4
+#define d1 x5
+#define d2 x6
+#define d3 x7
+#define d4 x8
+#define d5 x9
+
+.text
+.globl bignum_neg_p384
+
+bignum_neg_p384:
+
+// Load the 6 digits of x
+
+                ldp     d0, d1, [x]
+                ldp     d2, d3, [x, 16]
+                ldp     d4, d5, [x, 32]
+
+// Set a bitmask p for the input being nonzero, so that we avoid doing
+// -0 = p_384 and hence maintain strict modular reduction
+
+                orr     p, d0, d1
+                orr     t, d2, d3
+                orr     p, p, t
+                orr     t, d4, d5
+                orr     p, p, t
+                cmp     p, 0
+                csetm   p, ne
+
+// Load and mask the complicated lower three words of
+// p_384 = [-1;-1;-1;n2;n1;n0] and subtract, using mask itself for upper digits
+
+                mov     t, 0x00000000ffffffff
+                and     t, t, p
+                subs    d0, t, d0
+
+                mov     t, 0xffffffff00000000
+                and     t, t, p
+                sbcs    d1, t, d1
+
+                mov     t, 0xfffffffffffffffe
+                and     t, t, p
+                sbcs    d2, t, d2
+
+                sbcs    d3, p, d3
+                sbcs    d4, p, d4
+                sbc     d5, p, d5
+
+// Write back the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, 16]
+                stp     d4, d5, [z, 32]
+
+// Return
+
+                ret

--- a/third_party/s2n-bignum/Arm/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/Arm/bignum_sub_p384.S
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Subtract modulo p_384, z := (x - y) mod p_384
+// Inputs x[6], y[6]; output z[6]
+//
+//    extern void bignum_sub_p384
+//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+#define z x0
+#define x x1
+#define y x2
+
+#define c x3
+#define l x4
+#define d0 x5
+#define d1 x6
+#define d2 x7
+#define d3 x8
+#define d4 x9
+#define d5 x10
+
+.text
+.globl bignum_sub_p384
+
+bignum_sub_p384:
+
+// First just subtract the numbers as [d5; d4; d3; d2; d1; d0]
+// Set a mask based on (inverted) carry indicating x < y = correction is needed
+
+                ldp     d0, d1, [x]
+                ldp     l, c, [y]
+                subs    d0, d0, l
+                sbcs    d1, d1, c
+                ldp     d2, d3, [x, #16]
+                ldp     l, c, [y, #16]
+                sbcs    d2, d2, l
+                sbcs    d3, d3, c
+                ldp     d4, d5, [x, #32]
+                ldp     l, c, [y, #32]
+                sbcs    d4, d4, l
+                sbcs    d5, d5, c
+
+// Create a mask for the condition x < y, when we need to correct
+
+                csetm   c, cc
+
+// Now correct by adding masked p_384
+
+                mov     l, 0x00000000ffffffff
+                and     l, l, c
+                adds    d0, d0, l
+                eor     l, l, c
+                adcs    d1, d1, l
+                mov     l, 0xfffffffffffffffe
+                and     l, l, c
+                adcs    d2, d2, l
+                adcs    d3, d3, c
+                adcs    d4, d4, c
+                adc     d5, d5, c
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+
+                ret

--- a/third_party/s2n-bignum/Arm/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/Arm/bignum_tomont_p384.S
@@ -1,0 +1,133 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert to Montgomery form z := (2^256 * x) mod p_256
+// Input x[6]; output z[6]
+//
+//    extern void bignum_tomont_p384
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+.globl   bignum_tomont_p384
+
+// ----------------------------------------------------------------------------
+// Core "x |-> (2^64 * x) mod p_384" macro, with x assumed to be < p_384.
+// Input is in [d6;d5;d4;d3;d2;d1] and output in [d5;d4;d3;d2;d1;d0]
+// using d6 as well as t1, t2, t3 as temporaries.
+// ----------------------------------------------------------------------------
+
+.macro modstep_p384 d6,d5,d4,d3,d2,d1,d0, t1,t2,t3
+// Initial quotient approximation q = min (h + 1) (2^64 - 1)
+                adds    \d6, \d6, 1
+                csetm   \t3, cs
+                add     \d6, \d6, \t3
+                orn     \t3, xzr, \t3
+                sub     \t2, \d6, 1
+                sub     \t1, xzr, \d6
+// Correction term [d6;t2;t1;d0] = q * (2^384 - p_384)
+                lsl     \d0, \t1, 32
+                extr    \t1, \t2, \t1, 32
+                lsr     \t2, \t2, 32
+                adds    \d0, \d0, \d6
+                adcs    \t1, \t1, xzr
+                adcs    \t2, \t2, \d6
+                adc     \d6, xzr, xzr
+// Addition to the initial value
+                adds    \d1, \d1, \t1
+                adcs    \d2, \d2, \t2
+                adcs    \d3, \d3, \d6
+                adcs    \d4, \d4, xzr
+                adcs    \d5, \d5, xzr
+                adc     \t3, \t3, xzr
+// Use net top of the 7-word answer in t3 for masked correction
+                mov     \t1, 0x00000000ffffffff
+                and     \t1, \t1, \t3
+                adds    \d0, \d0, \t1
+                eor     \t1, \t1, \t3
+                adcs    \d1, \d1, \t1
+                mov     \t1, 0xfffffffffffffffe
+                and     \t1, \t1, \t3
+                adcs    \d2, \d2, \t1
+                adcs    \d3, \d3, \t3
+                adcs    \d4, \d4, \t3
+                adc     \d5, \d5, \t3
+.endm
+
+bignum_tomont_p384:
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+#define d6 x8
+
+#define t1 x9
+#define t2 x10
+#define t3 x11
+
+#define n0 x8
+#define n1 x9
+#define n2 x10
+#define n3 x11
+#define n4 x12
+#define n5 x1
+
+// Load the inputs
+
+                ldp     d0, d1, [x1]
+                ldp     d2, d3, [x1, 16]
+                ldp     d4, d5, [x1, 32]
+
+// Do an initial reduction to make sure this is < p_384, using just
+// a copy of the bignum_mod_p384 code. This is needed to set up the
+// invariant "input < p_384" for the main modular reduction steps.
+
+                mov     n0, 0x00000000ffffffff
+                mov     n1, 0xffffffff00000000
+                mov     n2, 0xfffffffffffffffe
+                subs    n0, d0, n0
+                sbcs    n1, d1, n1
+                sbcs    n2, d2, n2
+                adcs    n3, d3, xzr
+                adcs    n4, d4, xzr
+                adcs    n5, d5, xzr
+                csel    d0, d0, n0, cc
+                csel    d1, d1, n1, cc
+                csel    d2, d2, n2, cc
+                csel    d3, d3, n3, cc
+                csel    d4, d4, n4, cc
+                csel    d5, d5, n5, cc
+
+// Successively multiply by 2^64 and reduce
+
+                modstep_p384 d5,d4,d3,d2,d1,d0,d6, t1,t2,t3
+                modstep_p384 d4,d3,d2,d1,d0,d6,d5, t1,t2,t3
+                modstep_p384 d3,d2,d1,d0,d6,d5,d4, t1,t2,t3
+                modstep_p384 d2,d1,d0,d6,d5,d4,d3, t1,t2,t3
+                modstep_p384 d1,d0,d6,d5,d4,d3,d2, t1,t2,t3
+                modstep_p384 d0,d6,d5,d4,d3,d2,d1, t1,t2,t3
+
+// Store the result and return
+
+                stp     d1, d2, [x0]
+                stp     d3, d4, [x0, #16]
+                stp     d5, d6, [x0, #32]
+
+                ret

--- a/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
+++ b/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// C prototypes for s2n-bignum functions used in AWS-LC
+// ----------------------------------------------------------------------------
+
+// Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
+// Inputs x[6], y[6]; output z[6]
+extern void bignum_add_p384 (uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
+
+// Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+extern void bignum_demont_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
+
+// Montgomery multiply, z := (x * y / 2^384) mod p_384
+// Inputs x[6], y[6]; output z[6]
+extern void bignum_montmul_p384 (uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
+
+// Montgomery square, z := (x^2 / 2^384) mod p_384
+// Input x[6]; output z[6]
+extern void bignum_montsqr_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
+
+// Negate modulo p_384, z := (-x) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+extern void bignum_neg_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
+
+// Subtract modulo p_384, z := (x - y) mod p_384
+// Inputs x[6], y[6]; output z[6]
+extern void bignum_sub_p384 (uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
+
+// Convert to Montgomery form z := (2^384 * x) mod p_384
+// Input x[6]; output z[6]
+extern void bignum_tomont_p384 (uint64_t z[static 6], const uint64_t x[static 6]);


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-750

### Description of changes:
In this PR, the field arithmetic underlying P-384 operations is changed from Fiat-crypto to [s2n-bignum](https://github.com/awslabs/s2n-bignum) for Armv8 (AArch64).
Performance

#### Steps of merging files from s2n-bignum
```
git remote add s2n-bignum git@github.com:awslabs/s2n-bignum.git

git fetch s2n-bignum
git branch s2n-bignum-main s2n-bignum/main

git checkout s2n-bignum-main
git checkout -b s2n-bignum-arm

PATHS_TO_KEEP=" \
Arm/bignum_add_p384.S \
Arm/bignum_montmul_p384.S \
Arm/bignum_montsqr_p384.S \
Arm/bignum_sub_p384.S \
Arm/bignum_neg_p384.S \
Arm/bignum_tomont_p384.S \
Arm/bignum_demont_p384.S \
"
git filter-branch -f --index-filter "git rm --ignore-unmatch --cached -qr -- . && git reset -q \$GIT_COMMIT -- $PATHS_TO_KEEP" --prune-empty -- HEAD

git checkout p384-asm
git checkout -b p384-asm-arm-2
git subtree add --prefix=third_party/s2n-bignum s2n-bignum-arm
```

### Call-outs:
* commit hashes of commits from s2n-bignum are changed when using `git filter-branch` to filter on the used files only. (Note: `git filter-repo` would also [change the commit hashes](https://stackoverflow.com/questions/63125810/how-to-keep-commit-hashs-not-change-when-use-git-filter-repo-rewrite-the-history)).
* `selectznz`, `from_bytes` and `to_bytes` are not moved yet and would require their own assembly implementation.
* `nonzero` can be moved with a wrapper, but we will wait till it's implemented specifically for p-384 size.

### Testing:
`crypto_test` test and `bssl speed` test filtered on ECDH and ECDSA pass on Armv8 (Graviton 2).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
