### PR TITLE
Add a broader set of compile flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ if(GCC OR CLANG)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wwrite-strings -Wformat-security -Wunused-result")
 
   if(GCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "8")
+    # GCC 8.x added a warning called -Wcast-function-type to the -Wextra umbrella.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-cast-function-type")
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,19 +175,13 @@ if(GCC OR CLANG)
   # Note clang-cl is odd and sets both CLANG and MSVC. We base our configuration
   # primarily on our normal Clang one.
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Wpedantic -Werror")
+  # TODO(CryptoAlg-759): enable '-Wpedantic' if awslc has to follow c99 spec.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Werror")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wwrite-strings -Wformat-security -Wunused-result")
 
   if(GCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "8")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-cast-function-type")
-  endif()
-
-  # TODO(CryptoAlg-759): remove '-Wno-overlength-strings' and '-Wno-c11-extensions' if awslc has to follow c99 spec.
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-overlength-strings")
-  if(CLANG)
-    # Only Clang warns error: _Alignas is a C11-specific feature [-Werror,-Wc11-extensions].
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-c11-extensions")
   endif()
 
   set(C_CXX_FLAGS "-Werror -Wformat=2 -Wsign-compare -Wmissing-field-initializers -Wwrite-strings -Wvla")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,10 @@ if(GCC OR CLANG)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wwrite-strings -Wformat-security -Wunused-result")
 
+  if(GCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "8")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-cast-function-type")
+  endif()
+
   # TODO(CryptoAlg-759): remove '-Wno-overlength-strings' and '-Wno-c11-extensions' if awslc has to follow c99 spec.
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-overlength-strings")
   if(CLANG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ if(GCC OR CLANG)
   # Note clang-cl is odd and sets both CLANG and MSVC. We base our configuration
   # primarily on our normal Clang one.
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Wpedantic -Wno-c11-extensions -Wno-overlength-strings -Werror")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Wpedantic -Werror")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wwrite-strings -Wformat-security -Wunused-result")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,17 @@ if(GCC OR CLANG)
   # Note clang-cl is odd and sets both CLANG and MSVC. We base our configuration
   # primarily on our normal Clang one.
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Wpedantic -Wno-c11-extensions -Wno-overlength-strings -Werror")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wwrite-strings -Wformat-security -Wunused-result")
+
+  # TODO(CryptoAlg-759): remove '-Wno-overlength-strings' and '-Wno-c11-extensions' if awslc has to follow c99 spec.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-overlength-strings")
+  if(CLANG)
+    # Only Clang warns error: _Alignas is a C11-specific feature [-Werror,-Wc11-extensions].
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-c11-extensions")
+  endif()
+
   set(C_CXX_FLAGS "-Werror -Wformat=2 -Wsign-compare -Wmissing-field-initializers -Wwrite-strings -Wvla")
   if(MSVC)
     # clang-cl sets different default warnings than clang. It also treats -Wall

--- a/crypto/fipsmodule/ec/p256.c
+++ b/crypto/fipsmodule/ec/p256.c
@@ -88,7 +88,7 @@ static void fiat_p256_to_generic(EC_FELEM *out, const fiat_p256_felem in) {
   // zero when rounding up to |BN_ULONG|s.
   OPENSSL_STATIC_ASSERT(
       256 / 8 == sizeof(BN_ULONG) * ((256 + BN_BITS2 - 1) / BN_BITS2),
-      fiat_p256_to_bytes_leaves_bytes_uninitialized);
+      fiat_p256_to_bytes_leaves_bytes_uninitialized)
   fiat_p256_to_bytes(out->bytes, in);
 }
 

--- a/crypto/fipsmodule/ec/simple_mul.c
+++ b/crypto/fipsmodule/ec/simple_mul.c
@@ -204,7 +204,7 @@ int ec_GFp_mont_init_precomp(const EC_GROUP *group, EC_PRECOMP *out,
   // cache pressure and makes the constant-time selects faster.)
   OPENSSL_STATIC_ASSERT(
       OPENSSL_ARRAY_SIZE(comb) == OPENSSL_ARRAY_SIZE(out->comb),
-      comb_sizes_did_not_match);
+      comb_sizes_did_not_match)
   return ec_jacobian_to_affine_batch(group, out->comb, comb,
                                      OPENSSL_ARRAY_SIZE(comb));
 }

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -81,9 +81,9 @@ struct rand_thread_state {
 // objects in the process, one per thread. This is needed because FIPS requires
 // that they be zeroed on process exit, but thread-local destructors aren't
 // called when the whole process is exiting.
-DEFINE_BSS_GET(struct rand_thread_state *, thread_states_list);
-DEFINE_STATIC_MUTEX(thread_states_list_lock);
-DEFINE_STATIC_MUTEX(state_clear_all_lock);
+DEFINE_BSS_GET(struct rand_thread_state *, thread_states_list)
+DEFINE_STATIC_MUTEX(thread_states_list_lock)
+DEFINE_STATIC_MUTEX(state_clear_all_lock)
 
 static void rand_thread_state_clear_all(void) __attribute__((destructor));
 static void rand_thread_state_clear_all(void) {

--- a/crypto/fipsmodule/rsa/rsa_impl.c
+++ b/crypto/fipsmodule/rsa/rsa_impl.c
@@ -413,7 +413,7 @@ static BN_BLINDING *rsa_blinding_get(RSA *rsa, unsigned *index_used,
 
   OPENSSL_STATIC_ASSERT(
       MAX_BLINDINGS_PER_RSA < UINT_MAX / sizeof(BN_BLINDING *),
-      MAX_BLINDINGS_PER_RSA_too_large);
+      MAX_BLINDINGS_PER_RSA_too_large)
   BN_BLINDING **new_blindings =
       OPENSSL_malloc(sizeof(BN_BLINDING *) * new_num_blindings);
   uint8_t *new_blindings_inuse = OPENSSL_malloc(new_num_blindings);

--- a/crypto/hrss/hrss.c
+++ b/crypto/hrss/hrss.c
@@ -912,14 +912,12 @@ void HRSS_poly3_invert(struct poly3 *out, const struct poly3 *in) {
 //
 // Coefficients are ordered little-endian, thus the coefficient of x^0 is the
 // first element of the array.
-struct poly {
+union poly {
 #if defined(HRSS_HAVE_VECTOR_UNIT)
-  union {
-    // N + 3 = 704, which is a multiple of 64 and thus aligns things, esp for
-    // the vector code.
-    uint16_t v[N + 3];
-    vec_t vectors[VECS_PER_POLY];
-  };
+  // N + 3 = 704, which is a multiple of 64 and thus aligns things, esp for
+  // the vector code.
+  uint16_t v[N + 3];
+  vec_t vectors[VECS_PER_POLY];
 #else
   // Even if !HRSS_HAVE_VECTOR_UNIT, external assembly may be called that
   // requires alignment.
@@ -927,7 +925,7 @@ struct poly {
 #endif
 };
 
-OPENSSL_UNUSED static void poly_print(const struct poly *p) {
+OPENSSL_UNUSED static void poly_print(const union poly *p) {
   printf("[");
   for (unsigned i = 0; i < N; i++) {
     if (i) {
@@ -1183,14 +1181,14 @@ static void poly_mul_vec_aux(vec_t *restrict out, vec_t *restrict scratch,
 }
 
 // poly_mul_vec sets |*out| to |x|×|y| mod (𝑥^n - 1).
-static void poly_mul_vec(struct poly *out, const struct poly *x,
-                         const struct poly *y) {
+static void poly_mul_vec(union poly *out, const union poly *x,
+                         const union poly *y) {
   OPENSSL_memset((uint16_t *)&x->v[N], 0, 3 * sizeof(uint16_t));
   OPENSSL_memset((uint16_t *)&y->v[N], 0, 3 * sizeof(uint16_t));
 
   OPENSSL_STATIC_ASSERT(sizeof(out->v) == sizeof(vec_t) * VECS_PER_POLY,
                         struct_poly_is_the_wrong_size)
-  OPENSSL_STATIC_ASSERT(alignof(struct poly) == alignof(vec_t),
+  OPENSSL_STATIC_ASSERT(alignof(union poly) == alignof(vec_t),
                         struct_poly_has_incorrect_alignment)
 
   vec_t prod[VECS_PER_POLY * 2];
@@ -1272,8 +1270,8 @@ static void poly_mul_novec_aux(uint16_t *out, uint16_t *scratch,
 }
 
 // poly_mul_novec sets |*out| to |x|×|y| mod (𝑥^n - 1).
-static void poly_mul_novec(struct poly *out, const struct poly *x,
-                           const struct poly *y) {
+static void poly_mul_novec(union poly *out, const union poly *x,
+                           const union poly *y) {
   uint16_t prod[2 * N];
   uint16_t scratch[1318];
   poly_mul_novec_aux(prod, scratch, x->v, y->v, N);
@@ -1284,8 +1282,8 @@ static void poly_mul_novec(struct poly *out, const struct poly *x,
   OPENSSL_memset(&out->v[N], 0, 3 * sizeof(uint16_t));
 }
 
-static void poly_mul(struct poly *r, const struct poly *a,
-                     const struct poly *b) {
+static void poly_mul(union poly *r, const union poly *a,
+                     const union poly *b) {
 #if defined(POLY_RQ_MUL_ASM)
   const int has_avx2 = (OPENSSL_ia32cap_P[2] & (1 << 5)) != 0;
   if (has_avx2) {
@@ -1306,7 +1304,7 @@ static void poly_mul(struct poly *r, const struct poly *a,
 }
 
 // poly_mul_x_minus_1 sets |p| to |p|×(𝑥 - 1) mod (𝑥^n - 1).
-static void poly_mul_x_minus_1(struct poly *p) {
+static void poly_mul_x_minus_1(union poly *p) {
   // Multiplying by (𝑥 - 1) means negating each coefficient and adding in
   // the value of the previous one.
   const uint16_t orig_final_coefficient = p->v[N - 1];
@@ -1318,7 +1316,7 @@ static void poly_mul_x_minus_1(struct poly *p) {
 }
 
 // poly_mod_phiN sets |p| to |p| mod Φ(N).
-static void poly_mod_phiN(struct poly *p) {
+static void poly_mod_phiN(union poly *p) {
   const uint16_t coeff700 = p->v[N - 1];
 
   for (unsigned i = 0; i < N; i++) {
@@ -1327,7 +1325,7 @@ static void poly_mod_phiN(struct poly *p) {
 }
 
 // poly_clamp reduces each coefficient mod Q.
-static void poly_clamp(struct poly *p) {
+static void poly_clamp(union poly *p) {
   for (unsigned i = 0; i < N; i++) {
     p->v[i] &= Q - 1;
   }
@@ -1338,7 +1336,7 @@ static void poly_clamp(struct poly *p) {
 // --------------------
 
 // poly2_from_poly sets |*out| to |in| mod 2.
-static void poly2_from_poly(struct poly2 *out, const struct poly *in) {
+static void poly2_from_poly(struct poly2 *out, const union poly *in) {
   crypto_word_t *words = out->v;
   unsigned shift = 0;
   crypto_word_t word = 0;
@@ -1370,7 +1368,7 @@ static uint16_t mod3(int16_t a) {
 }
 
 // poly3_from_poly sets |*out| to |in|.
-static void poly3_from_poly(struct poly3 *out, const struct poly *in) {
+static void poly3_from_poly(struct poly3 *out, const union poly *in) {
   crypto_word_t *words_s = out->s.v;
   crypto_word_t *words_a = out->a.v;
   crypto_word_t s = 0;
@@ -1409,7 +1407,7 @@ static void poly3_from_poly(struct poly3 *out, const struct poly *in) {
 // Q-1}. It returns a mask indicating whether all coefficients were found to be
 // in that set.
 static crypto_word_t poly3_from_poly_checked(struct poly3 *out,
-                                             const struct poly *in) {
+                                             const union poly *in) {
   crypto_word_t *words_s = out->s.v;
   crypto_word_t *words_a = out->a.v;
   crypto_word_t s = 0;
@@ -1451,7 +1449,7 @@ static crypto_word_t poly3_from_poly_checked(struct poly3 *out,
   return ok;
 }
 
-static void poly_from_poly2(struct poly *out, const struct poly2 *in) {
+static void poly_from_poly2(union poly *out, const struct poly2 *in) {
   const crypto_word_t *words = in->v;
   unsigned shift = 0;
   crypto_word_t word = *words;
@@ -1469,7 +1467,7 @@ static void poly_from_poly2(struct poly *out, const struct poly2 *in) {
   }
 }
 
-static void poly_from_poly3(struct poly *out, const struct poly3 *in) {
+static void poly_from_poly3(union poly *out, const struct poly3 *in) {
   const crypto_word_t *words_s = in->s.v;
   const crypto_word_t *words_a = in->a.v;
   crypto_word_t word_s = ~(*words_s);
@@ -1499,7 +1497,7 @@ static void poly_from_poly3(struct poly *out, const struct poly3 *in) {
 // poly_invert_mod2 sets |*out| to |in^-1| (i.e. such that |*out|×|in| = 1 mod
 // Φ(N)), all mod 2. This isn't useful in itself, but is part of doing inversion
 // mod Q.
-static void poly_invert_mod2(struct poly *out, const struct poly *in) {
+static void poly_invert_mod2(union poly *out, const union poly *in) {
   // This algorithm is taken from section 7.1 of [SAFEGCD].
   struct poly2 v, r, f, g;
 
@@ -1547,10 +1545,10 @@ static void poly_invert_mod2(struct poly *out, const struct poly *in) {
 }
 
 // poly_invert sets |*out| to |in^-1| (i.e. such that |*out|×|in| = 1 mod Φ(N)).
-static void poly_invert(struct poly *out, const struct poly *in) {
+static void poly_invert(union poly *out, const union poly *in) {
   // Inversion mod Q, which is done based on the result of inverting mod
   // 2. See [NTRUTN14] paper, bottom of page two.
-  struct poly a, *b, tmp;
+  union poly a, *b, tmp;
 
   // a = -in.
   for (unsigned i = 0; i < N; i++) {
@@ -1576,7 +1574,7 @@ static void poly_invert(struct poly *out, const struct poly *in) {
 #define POLY_BYTES 1138
 
 // poly_marshal serialises all but the final coefficient of |in| to |out|.
-static void poly_marshal(uint8_t out[POLY_BYTES], const struct poly *in) {
+static void poly_marshal(uint8_t out[POLY_BYTES], const union poly *in) {
   const uint16_t *p = in->v;
 
   for (size_t i = 0; i < N / 8; i++) {
@@ -1612,7 +1610,7 @@ static void poly_marshal(uint8_t out[POLY_BYTES], const struct poly *in) {
 // all but the final coefficients match, and the final coefficient is calculated
 // such that evaluating |out| at one results in zero. It returns one on success
 // or zero if |in| is an invalid encoding.
-static int poly_unmarshal(struct poly *out, const uint8_t in[POLY_BYTES]) {
+static int poly_unmarshal(union poly *out, const uint8_t in[POLY_BYTES]) {
   uint16_t *p = out->v;
 
   for (size_t i = 0; i < N / 8; i++) {
@@ -1672,7 +1670,7 @@ static uint16_t mod3_from_modQ(uint16_t v) {
 // all in {0, 1, Q-1, 65535} and |in| is mod Φ(N). (Note that coefficients may
 // have invalid values when processing attacker-controlled inputs.)
 static void poly_marshal_mod3(uint8_t out[HRSS_POLY3_BYTES],
-                              const struct poly *in) {
+                              const union poly *in) {
   const uint16_t *coeffs = in->v;
 
   // Only 700 coefficients are marshaled because in[700] must be zero.
@@ -1697,7 +1695,7 @@ static void poly_marshal_mod3(uint8_t out[HRSS_POLY3_BYTES],
 // with HRSS-SXY the sampling algorithm is now a private detail of the
 // implementation (previously it had to match between two parties). This
 // function uses that freedom to implement a flatter distribution of values.
-static void poly_short_sample(struct poly *out,
+static void poly_short_sample(union poly *out,
                               const uint8_t in[HRSS_SAMPLE_BYTES]) {
   OPENSSL_STATIC_ASSERT(HRSS_SAMPLE_BYTES == N - 1,
                         HRSS_SAMPLE_BYTES_incorrect)
@@ -1712,7 +1710,7 @@ static void poly_short_sample(struct poly *out,
 
 // poly_short_sample_plus performs the T+ sample as defined in [HRSSNIST],
 // section 1.8.2.
-static void poly_short_sample_plus(struct poly *out,
+static void poly_short_sample_plus(union poly *out,
                                    const uint8_t in[HRSS_SAMPLE_BYTES]) {
   poly_short_sample(out, in);
 
@@ -1733,7 +1731,7 @@ static void poly_short_sample_plus(struct poly *out,
 }
 
 // poly_lift computes the function discussed in [HRSS], appendix B.
-static void poly_lift(struct poly *out, const struct poly *a) {
+static void poly_lift(union poly *out, const union poly *a) {
   // We wish to calculate a/(𝑥-1) mod Φ(N) over GF(3), where Φ(N) is the
   // Nth cyclotomic polynomial, i.e. 1 + 𝑥 + … + 𝑥^700 (since N is prime).
 
@@ -1848,12 +1846,12 @@ static void poly_lift(struct poly *out, const struct poly *a) {
 }
 
 struct public_key {
-  struct poly ph;
+  union poly ph;
 };
 
 struct private_key {
   struct poly3 f, f_inverse;
-  struct poly ph_inverse;
+  union poly ph_inverse;
   uint8_t hmac_key[32];
 };
 
@@ -1898,23 +1896,23 @@ void HRSS_generate_key(
   OPENSSL_memcpy(priv->hmac_key, in + 2 * HRSS_SAMPLE_BYTES,
                  sizeof(priv->hmac_key));
 
-  struct poly f;
+  union poly f;
   poly_short_sample_plus(&f, in);
   poly3_from_poly(&priv->f, &f);
   HRSS_poly3_invert(&priv->f_inverse, &priv->f);
 
   // pg_phi1 is p (i.e. 3) × g × Φ(1) (i.e. 𝑥-1).
-  struct poly pg_phi1;
+  union poly pg_phi1;
   poly_short_sample_plus(&pg_phi1, in + HRSS_SAMPLE_BYTES);
   for (unsigned i = 0; i < N; i++) {
     pg_phi1.v[i] *= 3;
   }
   poly_mul_x_minus_1(&pg_phi1);
 
-  struct poly pfg_phi1;
+  union poly pfg_phi1;
   poly_mul(&pfg_phi1, &f, &pg_phi1);
 
-  struct poly pfg_phi1_inverse;
+  union poly pfg_phi1_inverse;
   poly_invert(&pfg_phi1_inverse, &pfg_phi1);
 
   poly_mul(&pub->ph, &pfg_phi1_inverse, &pg_phi1);
@@ -1934,12 +1932,12 @@ void HRSS_encap(uint8_t out_ciphertext[POLY_BYTES],
                 const uint8_t in[HRSS_SAMPLE_BYTES + HRSS_SAMPLE_BYTES]) {
   const struct public_key *pub =
       public_key_from_external((struct HRSS_public_key *)in_pub);
-  struct poly m, r, m_lifted;
+  union poly m, r, m_lifted;
   poly_short_sample(&m, in);
   poly_short_sample(&r, in + HRSS_SAMPLE_BYTES);
   poly_lift(&m_lifted, &m);
 
-  struct poly prh_plus_m;
+  union poly prh_plus_m;
   poly_mul(&prh_plus_m, &r, &pub->ph);
   for (unsigned i = 0; i < N; i++) {
     prh_plus_m.v[i] += m_lifted.v[i];
@@ -1998,7 +1996,7 @@ void HRSS_decap(uint8_t out_shared_key[HRSS_KEY_BYTES],
                         HRSS_shared_key_length_incorrect)
   SHA256_Final(out_shared_key, &hash_ctx);
 
-  struct poly c;
+  union poly c;
   // If the ciphertext is publicly invalid then a random shared key is still
   // returned to simply the logic of the caller, but this path is not constant
   // time.
@@ -2007,7 +2005,7 @@ void HRSS_decap(uint8_t out_shared_key[HRSS_KEY_BYTES],
     return;
   }
 
-  struct poly f, cf;
+  union poly f, cf;
   struct poly3 cf3, m3;
   poly_from_poly3(&f, &priv->f);
   poly_mul(&cf, &c, &f);
@@ -2015,11 +2013,11 @@ void HRSS_decap(uint8_t out_shared_key[HRSS_KEY_BYTES],
   // Note that cf3 is not reduced mod Φ(N). That reduction is deferred.
   HRSS_poly3_mul(&m3, &cf3, &priv->f_inverse);
 
-  struct poly m, m_lifted;
+  union poly m, m_lifted;
   poly_from_poly3(&m, &m3);
   poly_lift(&m_lifted, &m);
 
-  struct poly r;
+  union poly r;
   for (unsigned i = 0; i < N; i++) {
     r.v[i] = c.v[i] - m_lifted.v[i];
   }

--- a/crypto/poly1305/poly1305.c
+++ b/crypto/poly1305/poly1305.c
@@ -52,7 +52,7 @@ struct poly1305_state_st {
 
 OPENSSL_STATIC_ASSERT(
     sizeof(struct poly1305_state_st) + 63 <= sizeof(poly1305_state),
-    _poly1305_state_isn_t_large_enough_to_hold_aligned_poly1305_state_st);
+    _poly1305_state_isn_t_large_enough_to_hold_aligned_poly1305_state_st)
 
 static inline struct poly1305_state_st *poly1305_aligned_state(
     poly1305_state *state) {

--- a/crypto/poly1305/poly1305_arm.c
+++ b/crypto/poly1305/poly1305_arm.c
@@ -185,7 +185,7 @@ struct poly1305_state_st {
 
 OPENSSL_STATIC_ASSERT(
     sizeof(struct poly1305_state_st) + 63 <= sizeof(poly1305_state),
-    _poly1305_state_isn_t_large_enough_to_hold_aligned_poly1305_state_st);
+    _poly1305_state_isn_t_large_enough_to_hold_aligned_poly1305_state_st)
 
 void CRYPTO_poly1305_init_neon(poly1305_state *state, const uint8_t key[32]) {
   struct poly1305_state_st *st = (struct poly1305_state_st *)(state);

--- a/third_party/fiat/curve25519_64.h
+++ b/third_party/fiat/curve25519_64.h
@@ -11,8 +11,9 @@
 #include <stdint.h>
 typedef unsigned char fiat_25519_uint1;
 typedef signed char fiat_25519_int1;
-typedef signed __int128 fiat_25519_int128;
-typedef unsigned __int128 fiat_25519_uint128;
+// Pedantic warnings can be disabled by adding prefix __extension__.
+__extension__ typedef signed __int128 fiat_25519_int128;
+__extension__ typedef unsigned __int128 fiat_25519_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/third_party/fiat/p256_64.h
+++ b/third_party/fiat/p256_64.h
@@ -14,8 +14,9 @@
 #include <stdint.h>
 typedef unsigned char fiat_p256_uint1;
 typedef signed char fiat_p256_int1;
-typedef signed __int128 fiat_p256_int128;
-typedef unsigned __int128 fiat_p256_uint128;
+// Pedantic warnings can be disabled by adding prefix __extension__.
+__extension__ typedef signed __int128 fiat_p256_int128;
+__extension__ typedef unsigned __int128 fiat_p256_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-626

### Description of changes: 
This PR added a broader set of compile flags in `./CMakeLists.txt`.

Some compiler warnings are fixed in this PR:
* ISO C does not support ‘__int128’ types [-Werror=pedantic].
  * The error was in the header file of the third-party lib `fiat`. The warning is suppressed by `__extension__`.
  * Previous discussion: https://github.com/awslabs/aws-lc/pull/152#discussion_r633829479
* ISO C99 doesn’t support unnamed structs/unions [-Werror=pedantic].
  * Added a name to the union.
 
### Call-outs:
* `-Wpedantic` is not enabled to avoid c99 warnings.
  * One warning is `CryptoAlg-626?selectedConversation=763115b6-a861-42f9-9fa5-acea8cbcb825`. 
  * CryptoAlg-759 is created to clarify if all code need to follow c99 spec.
* `-Wno-unused-parameter` is added instead of using `OPENSSL_UNUSED` because
  * Fixing warnings using later macro will cause more merge conflicts.  
  * Some unused parameters are because not all implementations need to use all function parameters.
  * Both are just to suppress the warnings.
* `-Wcast-qual` is not enabled because it causes lots of false positive.
  * For example, the compiler warns `const ptr` is cast to `ptr` on macro `BORINGSSL_DEFINE_STACK_OF_IMPL`. 
    * The compiler does not check the macro use `const ptr` for `constptrtype`. 
    * The error message is linked in CryptoAlg-626?selectedConversation=5c2b0ef7-1f27-4f49-887f-7e298bf18b83 
*  `-Wno-cast-function-type` is added when the compiler is gcc8.
    * See explanation in https://gitlab.gnome.org/GNOME/gnome-terminal/-/issues/96 

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
