### PR TITLE
Fix Fiat crypto 128 bit int type definitions to support older compilers

### DIFF
--- a/third_party/fiat/curve25519_64.h
+++ b/third_party/fiat/curve25519_64.h
@@ -12,8 +12,8 @@
 typedef unsigned char fiat_25519_uint1;
 typedef signed char fiat_25519_int1;
 // Pedantic warnings can be disabled by adding prefix __extension__.
-__extension__ typedef signed __int128 fiat_25519_int128;
-__extension__ typedef unsigned __int128 fiat_25519_uint128;
+__extension__ typedef __int128_t fiat_25519_int128;
+__extension__ typedef __uint128_t fiat_25519_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/third_party/fiat/p256_64.h
+++ b/third_party/fiat/p256_64.h
@@ -15,8 +15,8 @@
 typedef unsigned char fiat_p256_uint1;
 typedef signed char fiat_p256_int1;
 // Pedantic warnings can be disabled by adding prefix __extension__.
-__extension__ typedef signed __int128 fiat_p256_int128;
-__extension__ typedef unsigned __int128 fiat_p256_uint128;
+__extension__ typedef __int128_t fiat_p256_int128;
+__extension__ typedef __uint128_t fiat_p256_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-762

### Description of changes: 
This fixes an issue with GCC 4.1.2 which has __int128_t and not __int128 which function the same. 

### Testing:
Manually tested with GCC 4.1.2 waiting to fix all issues before adding a build to our CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
