### PR TITLE
Fix __builtin_bswap* GCC version checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,14 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
 endif()
 
 if(GCC OR CLANG)
+  try_compile(
+          AWS_LC_BUILTIN_SWAP_SUPPORTED
+          ${CMAKE_BINARY_DIR}
+          SOURCES "${CMAKE_CURRENT_LIST_DIR}/tests/compiler_features_tests/builtin_swap_check.c"
+          COMPILE_DEFINITIONS "-Werror")
+  if(AWS_LC_BUILTIN_SWAP_SUPPORTED)
+    set(C_CXX_FLAGS "${C_CXX_FLAGS} -DAWS_LC_BUILTIN_SWAP_SUPPORTED")
+  endif()
   # Note clang-cl is odd and sets both CLANG and MSVC. We base our configuration
   # primarily on our normal Clang one.
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
@@ -182,7 +190,7 @@ if(GCC OR CLANG)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Werror")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wwrite-strings -Wformat-security -Wunused-result")
-    set(C_CXX_FLAGS "-Wvla")
+    set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wvla")
   endif()
 
   if(GCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "8")

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -696,7 +696,7 @@ OPENSSL_EXPORT void CRYPTO_free_ex_data(CRYPTO_EX_DATA_CLASS *ex_data_class,
 
 // Endianness conversions.
 
-#if defined(__GNUC__) && __GNUC__ >= 2
+#if defined(AWS_LC_BUILTIN_SWAP_SUPPORTED)
 static inline uint16_t CRYPTO_bswap2(uint16_t x) {
   return __builtin_bswap16(x);
 }

--- a/tests/compiler_features_tests/builtin_swap_check.c
+++ b/tests/compiler_features_tests/builtin_swap_check.c
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+// Builtin swap was added in GCC 4.8 https://gcc.gnu.org/gcc-4.8/changes.html. Recent versions of Clang pretend to be
+// 4.2 but they do support the builtin swap functions.
+
+int main() {
+    uint16_t test16 = 0;
+    test16 = __builtin_bswap16(test16);
+
+    uint32_t test32 = 0;
+    test32 = __builtin_bswap32(test32);
+
+    uint64_t test64 = 0;
+    test64 = __builtin_bswap64(test64);
+}


### PR DESCRIPTION
Issues:
Addresses CryptoAlg-762

### Description of changes: 
I think this check has been wrong for a while but went unnoticed. Testing on GCC 4.1.2 fails and the GCC 4.8 release notes imply it was added then https://gcc.gnu.org/gcc-4.8/changes.html.

### Testing:
Manually tested with GCC 4.1.2 waiting to fix all issues before adding a build to our CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
