### PR TITLE
Add ASN1_STRING_clear_free.

### DIFF
--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -404,6 +404,11 @@ void ASN1_STRING_free(ASN1_STRING *str)
     OPENSSL_free(str);
 }
 
+void ASN1_STRING_clear_free(ASN1_STRING *str)
+{
+    ASN1_STRING_free(str);
+}
+
 int ASN1_STRING_cmp(const ASN1_STRING *a, const ASN1_STRING *b)
 {
     int i;

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -261,6 +261,9 @@ OPENSSL_EXPORT ASN1_STRING *ASN1_STRING_new(void);
 // ASN1_STRING_free releases memory associated with |str|.
 OPENSSL_EXPORT void ASN1_STRING_free(ASN1_STRING *str);
 
+// ASN1_STRING_free releases memory associated with |str|.
+OPENSSL_EXPORT void ASN1_STRING_clear_free(ASN1_STRING *str);
+
 // ASN1_STRING_copy sets |dst| to a copy of |str|. It returns one on success and
 // zero on error.
 OPENSSL_EXPORT int ASN1_STRING_copy(ASN1_STRING *dst, const ASN1_STRING *str);

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -261,7 +261,7 @@ OPENSSL_EXPORT ASN1_STRING *ASN1_STRING_new(void);
 // ASN1_STRING_free releases memory associated with |str|.
 OPENSSL_EXPORT void ASN1_STRING_free(ASN1_STRING *str);
 
-// ASN1_STRING_free releases memory associated with |str|.
+// ASN1_STRING_clear_free releases memory associated with |str|.
 OPENSSL_EXPORT void ASN1_STRING_clear_free(ASN1_STRING *str);
 
 // ASN1_STRING_copy sets |dst| to a copy of |str|. It returns one on success and


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-760

### Description of changes: 
This PR added `ASN1_STRING_clear_free`, which is [used by `aws-encryption-sdk-c` to free ASN1_INTEGERS](https://github.com/aws/aws-encryption-sdk-c/blame/f98243bd364fcea3e17dc07644275c7f22a0f433/source/cipher_openssl.c#L621-L622). 


### Call-outs:
* [OpenSSL 1.1.1 ASN1_STRING_clear_free has special treatment based on the macros(`ASN1_STRING_FLAG_NDEF` and `ASN1_STRING_FLAG_EMBED`)](https://github.com/openssl/openssl/blame/7fc0b9376135e9e5db76c713122a6e319c0b9768/crypto/asn1/asn1_lib.c#L336-L360). These macros are only set in `PKCS7_stream` and `asn1_primitive_new1`. These macro related features are not used by `aws-encryption-sdk-c` and not supported by awslc. Accordingly, https://github.com/awslabs/aws-lc/commit/9bdec296adba5e3891151ab4bcb8f7ebfcd1fc37 is not reverted.
* awslc `OPENSSL_free` internally calls `OPENSSL_cleanse`.
### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
