### PR TITLE
Add back removed static assert

### DIFF
--- a/crypto/hrss/hrss.c
+++ b/crypto/hrss/hrss.c
@@ -1200,6 +1200,8 @@ static void poly_mul_vec(struct poly *out, const struct poly *x,
 
   OPENSSL_STATIC_ASSERT(sizeof(out->v) == sizeof(vec_t) * VECS_PER_POLY,
                         struct_poly_is_the_wrong_size)
+  OPENSSL_STATIC_ASSERT(alignof(struct poly) == alignof(vec_t),
+                        struct_poly_has_incorrect_alignment)
 
   struct poly_vec x_vec = {{{0}}};
   struct poly_vec y_vec = {{{0}}};


### PR DESCRIPTION
### Description of changes: 
This adds back an `OPENSSL_STATIC_ASSERT` that was previously removed in #165. 

### Testing:
Tests pass locally. Also run in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
