### PR TITLE
Remove redundant call

### DIFF
--- a/crypto/rand_extra/rand_test.cc
+++ b/crypto/rand_extra/rand_test.cc
@@ -215,8 +215,6 @@ TEST(RandTest, RdrandABI) {
     return;
   }
 
-  maybe_disable_some_fork_detect_mechanisms();
-
   uint8_t buf[32];
   CHECK_ABI_SEH(CRYPTO_rdrand, buf);
   CHECK_ABI_SEH(CRYPTO_rdrand_multiple8_buf, nullptr, 0);


### PR DESCRIPTION
### Issues:

### Description of changes: 
This test suite doesn't pass through any of the fork detection stuff. Removing that redundant call.

### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
