### PR TITLE
Add memcmp invalid strip check to CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,21 +34,6 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
   set(GCC 1)
 endif()
 
-# Fail CMake build when some vulnerable gcc versions are used.
-set(VUL_GCC_VERSIONS "")
-# These versions are disabled due to a bug reported in memcmp, which means we can't trust them.
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
-list(APPEND VUL_GCC_VERSIONS "9.2" "9.3" "10.1")
-if(GCC)
-  foreach(vul_gcc_version ${VUL_GCC_VERSIONS})
-    if("${vul_gcc_version}" VERSION_EQUAL CMAKE_C_COMPILER_VERSION)
-      message(WARNING "Currently, GCC ${CMAKE_C_COMPILER_VERSION} is not supported due to a memcmp related bug reported in "
-                      "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.\n"
-                      "We strongly recommend against using the GCC ${CMAKE_C_COMPILER_VERSION} compiler.")
-    endif()
-  endforeach()
-endif()
-
 # This is a dummy target which all other targets depend on (manually - see other
 # CMakeLists.txt files). This gives us a hook to add any targets which need to
 # run before all other targets.
@@ -188,6 +173,41 @@ macro(check_compiler file_to_test flag_to_set)
     message(STATUS "    ${ERROR_MESSAGE}")
   endif()
 endmacro()
+
+macro(check_run file_to_test flag_to_set compile_flags)
+  message(STATUS "Run check_run file_to_test '${file_to_test}', "
+          "flag_to_set '${flag_to_set}', "
+          "and compile_flags '${compile_flags}'.")
+  try_run(
+          ${flag_to_set}
+          COMPILE_RESULT
+          "${CMAKE_CURRENT_BINARY_DIR}"
+          "${CMAKE_CURRENT_LIST_DIR}/tests/compiler_features_tests/${file_to_test}"
+          COMPILE_DEFINITIONS "${compile_flags}"
+          OUTPUT_VARIABLE COMPILE_AND_RUN_OUTPUT)
+  if (NOT COMPILE_RESULT)
+    message(WARNING "COMPILE_AND_RUN_OUTPUT ${COMPILE_AND_RUN_OUTPUT}")
+  endif()
+endmacro()
+
+# Detect if memcmp is wrongly stripped like strcmp.
+# If exists, let CMake generate a warning.
+# memcmp bug link https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.
+if (GCC)
+  if (CMAKE_BUILD_TYPE_LOWER MATCHES "release")
+    # CMAKE_C_FLAGS_RELEASE enables `-O3`.
+    check_run(memcmp_invalid_stripped_check.c MEMCMP_INVALID_STRIPPED "${CMAKE_C_FLAGS_RELEASE}")
+  elseif(CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo")
+    # CMAKE_C_FLAGS_RELEASE enables `-O2`.
+    check_run(memcmp_invalid_stripped_check.c MEMCMP_INVALID_STRIPPED "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+  endif()
+
+  if (MEMCMP_INVALID_STRIPPED)
+    message(WARNING "Currently, GCC ${CMAKE_C_COMPILER_VERSION} is not supported due to a memcmp related bug reported in "
+            "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.\n"
+            "We strongly recommend against using the GCC ${CMAKE_C_COMPILER_VERSION} compiler.")
+  endif ()
+endif ()
 
 if(GCC OR CLANG)
   check_compiler("stdalign_check.c" AWS_LC_STDALIGN_AVAILABLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,10 @@ endmacro()
 # If exists, let CMake generate a warning.
 # memcmp bug link https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.
 if (GCC)
+  # CMake try_run requires these variables must be preset.
+  # https://cmake.org/cmake/help/latest/command/try_run.html
+  set(MEMCMP_INVALID_STRIPPED "")
+  set(MEMCMP_INVALID_STRIPPED__TRYRUN_OUTPUT "")
   if (CMAKE_BUILD_TYPE_LOWER MATCHES "release")
     # CMAKE_C_FLAGS_RELEASE enables `-O3`.
     check_run(memcmp_invalid_stripped_check.c MEMCMP_INVALID_STRIPPED "${CMAKE_C_FLAGS_RELEASE}")

--- a/crypto/compiler_test.cc
+++ b/crypto/compiler_test.cc
@@ -174,14 +174,3 @@ TEST(CompilerTest, PointerRepresentation) {
   EXPECT_EQ(Bytes(bytes),
             Bytes(reinterpret_cast<uint8_t *>(&null), sizeof(null)));
 }
-
-TEST(CompilerTest, MemcmpInvalidStripped) {
-  // A bug of 'memcmp' is reported in gcc (9.2, 9.3, 10.1). See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
-  // AWS-LC disables the build when the gcc with reported versions is used.
-  // This test is added to help detect the bug on some gcc versions that are not reported.
-  // Below test case is equivalent to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189#c7
-  const size_t array_size = 2;
-  static const uint8_t array_0[array_size] = {0x00, 0x00};
-  uint8_t array_1[array_size] = {0x00, 0x01};
-  ASSERT_NE(0, memcmp(array_1, array_0, array_size));
-}

--- a/tests/compiler_features_tests/memcmp_invalid_stripped_check.c
+++ b/tests/compiler_features_tests/memcmp_invalid_stripped_check.c
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+  // A bug of 'memcmp' is reported in gcc (9.2, 9.3, 10.1). See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
+  // AWS-LC warns the build when detecting the unexpected 'memcmp' behavior.
+  // Below test case is equivalent to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189#c7
+  char a[] = "\0abc";
+  int res = memcmp(a, "\0\0\0\0", 4);
+  printf("memcmp result %d\n", res);
+  // If the 'memcmp' bug exists, below will return 1.
+  return (res == 0);
+}


### PR DESCRIPTION
### Issues:
Addresses V378887705

### Description of changes: 
This PR added `memcmp invalid strip check` to CMakeLists.txt.

### Call-outs:
TBD

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
