### PR TITLE
Fix FIPS gcc shared release build on x86.

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -267,6 +267,7 @@ elseif(FIPS_SHARED)
   set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/fips_shared.lds")
   if (GCC)
     # gcc puts some code in sections named ".text.unlikely", ".text.exit" and ".text.startup".
+    # so we have a separate linker script for gcc.
     set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/gcc_fips_shared.lds")
   endif()
 

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -263,10 +263,16 @@ elseif(FIPS_SHARED)
   )
 
   add_dependencies(bcm_library global_target)
+  # fips_shared.lds does not have 'clang' prefix because we want to keep merging any changes from upstream.
+  set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/fips_shared.lds")
+  if (GCC)
+    # gcc puts some code in sections named ".text.unlikely", ".text.exit" and ".text.startup".
+    set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/gcc_fips_shared.lds")
+  endif()
 
   add_custom_command(
     OUTPUT bcm.o
-    COMMAND ${CMAKE_LINKER} -r -T ${CMAKE_CURRENT_SOURCE_DIR}/fips_shared.lds -o bcm.o --whole-archive $<TARGET_FILE:bcm_library>
+    COMMAND ${CMAKE_LINKER} -r -T ${FIPS_CUSTOM_LINKER_SCRIPT} -o bcm.o --whole-archive $<TARGET_FILE:bcm_library>
     DEPENDS bcm_library fips_shared.lds
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )

--- a/crypto/fipsmodule/gcc_fips_shared.lds
+++ b/crypto/fipsmodule/gcc_fips_shared.lds
@@ -1,0 +1,28 @@
+SECTIONS
+{
+  .text : {
+    BORINGSSL_bcm_text_start = .;
+    *(.text)
+    /* gcc puts some code in sections named ".text.unlikely", ".text.exit" and ".text.startup". */
+    *(.text.unlikely)
+    *(.text.exit)
+    *(.text.startup)
+    BORINGSSL_bcm_text_end = .;
+  }
+  .rodata : {
+    BORINGSSL_bcm_rodata_start = .;
+    *(.rodata)
+    *(.rodata.*)
+    BORINGSSL_bcm_rodata_end = .;
+  }
+
+  /DISCARD/ : {
+    /* These sections shouldn't exist. In order to catch any slip-ups, direct
+     * the linker to discard them. */
+    *(.rela.dyn)
+    *(.data)
+    *(.rel.ro)
+    *(*.text.*)
+    *(*.data.*)
+  }
+}

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -13,11 +13,8 @@ fips_build_and_test -DCMAKE_BUILD_TYPE=Release
 echo "Testing shared AWS-LC in FIPS debug mode."
 fips_build_and_test -DBUILD_SHARED_LIBS=1
 
-# FIPS build in release mode is disabled for GCC due to some build issues relating to '-O3'.
-if [[ "${CC}" == 'clang'*  ]]; then
-  echo "Testing shared AWS-LC in FIPS release mode."
-  fips_build_and_test -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
-fi
+echo "Testing shared AWS-LC in FIPS release mode."
+fips_build_and_test -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
 
 if [[  "${AWSLC_NO_ASM_FIPS}" == "1" ]]; then
   # This dimension corresponds to boringssl CI 'linux_fips_noasm_asan'.


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-723?selectedConversation=5bbdd8be-635b-434f-934f-ea9dfa6ac67a

### Description of changes: 
This PR fixed FIPS gcc shared release build on x86.

### Call-outs:
* Next PR will include related CI change.
* `crypto/fipsmodule/gcc_fips_shared.lds` is copy from `crypto/fipsmodule/fips_shared.lds` because the gcc specific change is not needed by clang generated code.

### Testing:
```sh
./tests/ci/run_fips_tests.sh
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
