### PR TITLE
Fix 'gcc: error: MAKE_ASM_FLAGS: No such file or directory'.

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -138,7 +138,7 @@ function(cpreprocess dest src)
 
   add_custom_command(
     OUTPUT ${dest}
-    COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} $CMAKE_ASM_FLAGS -E ${src} -I${PROJECT_SOURCE_DIR}/include > ${dest}
+    COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -E ${src} -I${PROJECT_SOURCE_DIR}/include > ${dest}
     DEPENDS
     ${src}
     ${PROJECT_SOURCE_DIR}/include/openssl/arm_arch.h


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-806?selectedConversation=09a87eb5-628e-4138-8e65-70f7c88d8d1d

### Description of changes: 
Fix 'gcc: error: MAKE_ASM_FLAGS: No such file or directory'. This issue happens when some CLFAGS(passed by android tool chain or some other build tool) can be duplicate to the CLFAG enabled inside awslc CMakeList.txt. Then gcc cannot parse the syntax.

### Call-outs:
TBD

### Testing:
See CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
