### PR TITLE
Sort the output of libfuzzer's cov as a number

### DIFF
--- a/tests/ci/common_fuzz.sh
+++ b/tests/ci/common_fuzz.sh
@@ -118,10 +118,10 @@ function run_fuzz_test {
   TESTS_PER_SECOND=$((TEST_COUNT/TIME_FOR_EACH_FUZZ))
   put_metric --metric-name TestRate --value "$TESTS_PER_SECOND" --unit Count/Second --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
 
-  FEATURE_COVERAGE=$(grep -o "ft: [0-9]*" "$SUMMARY_LOG" | awk '{print $2}' | sort | tail -1)
+  FEATURE_COVERAGE=$(grep -o "ft: [0-9]*" "$SUMMARY_LOG" | awk '{print $2}' | sort -n | tail -1)
   put_metric_count --metric-name FeatureCoverage --value "$FEATURE_COVERAGE" --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
 
-  BLOCK_COVERAGE=$(grep -o "cov: [0-9]*" "$SUMMARY_LOG" | awk '{print $2}' | sort | tail -1)
+  BLOCK_COVERAGE=$(grep -o "cov: [0-9]*" "$SUMMARY_LOG" | awk '{print $2}' | sort -n | tail -1)
   put_metric_count --metric-name BlockCoverage --value "$BLOCK_COVERAGE" --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
 
   echo "${FUZZ_NAME} starting shared ${ORIGINAL_SHARED_CORPUS_FILE_COUNT} final shared ${FINAL_SHARED_CORPUS_FILE_COUNT} new files ${NEW_FUZZ_FILES} total test count ${TEST_COUNT} test rate ${TESTS_PER_SECOND} code coverage ${BLOCK_COVERAGE} feature coverage ${FEATURE_COVERAGE}"


### PR DESCRIPTION
### Issues:
Resolves P50460092

### Description of changes: 
Previously the `cov` output of libfuzzer was sorted as a string which puts `999` ahead of `8000` which creates confusing reports. This will fix the dashboard for future data only. Past reports can be cleaned up manually if needed.

### Testing:
Tested locally sorting things.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
