### PR TITLE
Workaround in ChaCha20 armv8 Perlasm for old Perl versions

### DIFF
--- a/crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl
+++ b/crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl
@@ -37,7 +37,7 @@ my ($t0,$t1,$t2,$t3) = map("x$_",(11..14));
 my ($one, $r0, $r1) = ("x15","x16","x17");
 
 # my ($t0w) = $t0 =~ s/x/w/r;
-# The above line is substitued with the two lines below because old verions of Perl
+# The above line is substituted with the two lines below because old versions of Perl
 # don't know how to evaluate the substitution regex s/x/w/r.
 my $t0w = $t0;
 $t0w =~ s/x/w/;

--- a/crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl
+++ b/crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl
@@ -35,7 +35,12 @@ my ($oup,$inp,$inl,$adp,$adl,$keyp,$itr1,$itr2) = ("x0","x1","x2","x3","x4","x5"
 my ($acc0,$acc1,$acc2) = map("x$_",(8..10));
 my ($t0,$t1,$t2,$t3) = map("x$_",(11..14));
 my ($one, $r0, $r1) = ("x15","x16","x17");
-my ($t0w) = $t0 =~ s/x/w/r;
+
+# my ($t0w) = $t0 =~ s/x/w/r;
+# The above line is substitued with the two lines below because old verions of Perl
+# don't know how to evaluate the substitution regex s/x/w/r.
+my $t0w = $t0;
+$t0w =~ s/x/w/;
 
 my ($A0,$A1,$A2,$A3,$A4,$B0,$B1,$B2,$B3,$B4,$C0,$C1,$C2,$C3,$C4,$D0,$D1,$D2,$D3,$D4) = map("v$_",(0..19));
 my ($T0,$T1,$T2,$T3) = map("v$_",(20..23));


### PR DESCRIPTION
Signed-off-by: Dusan Kostic <dkostic@amazon.com>

### Issues:
Old versions of Perl don't know how to evaluate a substitute regex with /r modifier. The commit fixes this issue.

### Description of changes: 

### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
