### PR TITLE
Entropy read retries

### DIFF
--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -219,7 +219,11 @@ OPENSSL_INLINE int have_fast_rdrand(void) {
 
 #endif  // OPENSSL_X86_64 && !OPENSSL_NO_ASM
 
-#define INJECTED_URANDOM_ERROR_ITERATIONS_FOR_TESTING 9
+// Don't retry forever. There is no science in picking this number and can be
+// adjusted in the future if need be. We do not backoff forever, because we
+// believe that it is easier to detect failing calls than detecting infinite
+// spinning loops.
+#define MAX_BACKOFF_RETRIES 9
 OPENSSL_EXPORT void HAZMAT_set_urandom_test_mode_for_testing(void);
 
 #if defined(__cplusplus)

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -219,6 +219,8 @@ OPENSSL_INLINE int have_fast_rdrand(void) {
 
 #endif  // OPENSSL_X86_64 && !OPENSSL_NO_ASM
 
+#define INJECTED_URANDOM_ERROR_ITERATIONS_FOR_TESTING 9
+OPENSSL_EXPORT void HAZMAT_set_urandom_test_mode_for_testing(void);
 
 #if defined(__cplusplus)
 }  // extern C

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -172,22 +172,36 @@ static void rand_thread_state_free(void *state_in) {
 
 #if defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM) && \
     !defined(BORINGSSL_UNSAFE_DETERMINISTIC_MODE)
+
+// rdrand maximum retries as suggested by:
+// Intel® Digital Random Number Generator (DRNG) Software Implementation Guide
+// Revision 2.1
+// https://software.intel.com/content/www/us/en/develop/articles/intel-digital-random-number-generator-drng-software-implementation-guide.html
+#define RDRAND_MAX_RETRIES 10
+
+OPENSSL_STATIC_ASSERT(RDRAND_MAX_RETRIES > 0, rdrand_max_retries_must_be_positive)
+#define CALL_RDRAND_WITH_RETRY(rdrand_func, fail_ret_value)       \
+    for (size_t tries = 0; tries < RDRAND_MAX_RETRIES; tries++) { \
+      if ((rdrand_func) == 1) {                                   \
+        break;                                                    \
+      }                                                           \
+      else if (tries == RDRAND_MAX_RETRIES - 1) {                 \
+        return fail_ret_value;                                    \
+      }                                                           \
+    }
+
 // rdrand should only be called if either |have_rdrand| or |have_fast_rdrand|
 // returned true.
 static int rdrand(uint8_t *buf, const size_t len) {
   const size_t len_multiple8 = len & ~7;
-  if (!CRYPTO_rdrand_multiple8_buf(buf, len_multiple8)) {
-    return 0;
-  }
+  CALL_RDRAND_WITH_RETRY(CRYPTO_rdrand_multiple8_buf(buf, len_multiple8), 0)
   const size_t remainder = len - len_multiple8;
 
   if (remainder != 0) {
     assert(remainder < 8);
 
     uint8_t rand_buf[8];
-    if (!CRYPTO_rdrand(rand_buf)) {
-      return 0;
-    }
+    CALL_RDRAND_WITH_RETRY(CRYPTO_rdrand(rand_buf), 0)
     OPENSSL_memcpy(buf + len_multiple8, rand_buf, remainder);
   }
 

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -88,7 +88,6 @@ static size_t ctr_drbg_get_entropy_length(ctr_drbg_key_len_t ctr_drbg_key_len) {
   switch (ctr_drbg_key_len) {
     case CTR_DRBG_AES_128:
       return CTR_DRBG_AES_128_ENTROPY_LEN;
-      break;
     case CTR_DRBG_AES_256:
       return CTR_DRBG_AES_256_ENTROPY_LEN;
     default:
@@ -109,7 +108,6 @@ static size_t ctr_drbg_get_key_length(ctr_drbg_key_len_t ctr_drbg_key_len) {
   switch (ctr_drbg_key_len) {
     case CTR_DRBG_AES_128:
       return CTR_DRBG_AES_128_KEY_LEN;
-      break;
     case CTR_DRBG_AES_256:
       return CTR_DRBG_AES_256_KEY_LEN;
     default:

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -113,7 +113,6 @@ static void handle_rare_urandom_error(long *backoff) {
   //    9         99,999,999  nsec
   //    ...
 
-  int r = 0;
   struct timespec sleep_time = {.tv_sec = 0, .tv_nsec = 0 };
 
   // Cap backoff at 99,999,999  nsec, which is the maximum value the nanoseconds
@@ -122,10 +121,7 @@ static void handle_rare_urandom_error(long *backoff) {
   // |nanosleep| can mutate |sleep_time|. Hence, we use |backoff| for state.
   sleep_time.tv_nsec = *backoff;
 
-  do {
-      r = nanosleep(&sleep_time, &sleep_time);
-  }
-  while (r != 0);
+  nanosleep(&sleep_time, &sleep_time);
 }
 
 #if defined(USE_NR_getrandom)
@@ -357,13 +353,8 @@ static void wait_for_entropy(void) {
       break;
     }
 
-    int r;
     struct timespec sleep_time = {.tv_sec = 0, .tv_nsec = MILLISECONDS_250 };
-
-    do {
-        r = nanosleep(&sleep_time, &sleep_time);
-    }
-    while (r != 0);
+    nanosleep(&sleep_time, &sleep_time);
   }
 #endif  // BORINGSSL_FIPS && !URANDOM_BLOCKS_FOR_ENTROPY
 }

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -91,7 +91,8 @@ DEFINE_BSS_GET(int, g_exponential_backoff_counter_for_testing)
 
 // One second in nanoseconds.
 #define ONE_SECOND INT64_C(1000000000)
-#define MILLISECOND_250 INT64_C(250000000)
+// 250 milliseconds in nanoseconds.
+#define MILLISECONDS_250 INT64_C(250000000)
 #define INITIAL_BACKOFF_DELAY 1
 
 // Exponential backoff. |backoff| holds the previous backoff delay. Initial
@@ -380,7 +381,7 @@ static void wait_for_entropy(void) {
     }
 
     int r;
-    struct timespec sleep_time = {.tv_sec = 0, .tv_nsec = MILLISECOND_250 };
+    struct timespec sleep_time = {.tv_sec = 0, .tv_nsec = MILLISECONDS_250 };
 
     do {
         r = nanosleep(&sleep_time, &sleep_time);

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -85,6 +85,7 @@ DEFINE_BSS_GET(int, g_exponential_backoff_counter_for_testing)
 
 // One second in nanoseconds.
 #define ONE_SECOND INT64_C(1000000000)
+#define MILLISECOND_250 INT64_C(250000000)
 #define INITIAL_BACKOFF_DELAY 1
 
 // Exponential backoff. |backoff| holds the previous backoff delay. Initial
@@ -372,7 +373,13 @@ static void wait_for_entropy(void) {
       break;
     }
 
-    usleep(250000);
+    int r;
+    struct timespec sleep_time = {.tv_sec = 0, .tv_nsec = MILLISECOND_250 };
+
+    do {
+        r = nanosleep(&sleep_time, &sleep_time);
+    }
+    while (r != 0);
   }
 #endif  // BORINGSSL_FIPS && !URANDOM_BLOCKS_FOR_ENTROPY
 }

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -80,6 +80,12 @@
 #include "../delocate.h"
 #include "../../internal.h"
 
+#ifndef MIN
+#define AWSLC_MIN(X,Y) (((X) < (Y)) ? (X) : (Y))
+#else
+#define AWSLC_MIN(X,Y) MIN(X,Y)
+#endif
+
 DEFINE_BSS_GET(int, g_urandom_test_mode_for_testing)
 DEFINE_BSS_GET(int, g_exponential_backoff_counter_for_testing)
 
@@ -112,7 +118,7 @@ static void exponential_backoff(long *backoff) {
 
   // Cap backoff at 99,999,999  nsec, which is the maximum value the nanoseconds
   // field in |timespec| can hold.
-  *backoff = MIN((*backoff) * 10, ONE_SECOND - 1);
+  *backoff = AWSLC_MIN((*backoff) * 10, ONE_SECOND - 1);
   // |nanosleep| can mutate |sleep_time|. Hence, we use |backoff| for state.
   sleep_time.tv_nsec = *backoff;
 

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -86,8 +86,6 @@
 #define AWSLC_MIN(X,Y) MIN(X,Y)
 #endif
 
-DEFINE_BSS_GET(int, g_urandom_test_mode_for_testing)
-
 // One second in nanoseconds.
 #define ONE_SECOND INT64_C(1000000000)
 // 250 milliseconds in nanoseconds.
@@ -489,14 +487,6 @@ int CRYPTO_sysrand_if_available(uint8_t *out, size_t requested) {
   }
 }
 
-void HAZMAT_set_urandom_test_mode_for_testing(void) {
-  *g_urandom_test_mode_for_testing_bss_get() = 1;
-}
-
 #else  // OPENSSL_URANDOM
-
-void HAZMAT_set_urandom_test_mode_for_testing(void) {
-  return;
-}
 
 #endif

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -478,6 +478,4 @@ int CRYPTO_sysrand_if_available(uint8_t *out, size_t requested) {
   }
 }
 
-#else  // OPENSSL_URANDOM
-
 #endif

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -92,7 +92,7 @@
 #define MILLISECONDS_250 INT64_C(250000000)
 #define INITIAL_BACKOFF_DELAY 1
 
-// handle_rare_urandom_error initiates exponential backoff |backoff| holds the
+// handle_rare_urandom_error initiates exponential backoff. |backoff| holds the
 // previous backoff delay. Initial backoff delay is |INITIAL_BACKOFF_DELAY|.
 // This function will be called so rarely (if ever), that we keep it as a
 // function call and don't care about attempting to inline it.

--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -561,8 +561,6 @@ int main(int argc, char **argv) {
     CRYPTO_fork_detect_ignore_pthread_atfork_for_testing();
   }
 
-  HAZMAT_set_urandom_test_mode_for_testing();
-
   return RUN_ALL_TESTS();
 }
 

--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -288,7 +288,8 @@ static void GetTrace(std::vector<Event> *out_trace, unsigned flags,
       // Alias for |__NR_nanosleep| on, at least, Ubuntu 20.04.
       case __NR_clock_nanosleep: {
         if (urandom_not_ready_was_cleared ||
-            ((flags & URANDOM_ERROR) && (previous_syscall != __NR_nanosleep))) {
+            ((flags & URANDOM_ERROR) &&
+             (previous_syscall != __NR_clock_nanosleep))) {
           out_trace->push_back(Event::NanoSleep());
         }
         break;

--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -430,7 +430,7 @@ static std::vector<Event> TestFunctionPRNGModel(unsigned flags) {
       }
       ret.push_back(Event::UrandomRead(len));
       if (flags & URANDOM_ERROR) {
-        for (size_t i = 0; i < INJECTED_URANDOM_ERROR_ITERATIONS_FOR_TESTING; i++) {
+        for (size_t i = 0; i < MAX_BACKOFF_RETRIES; i++) {
           ret.push_back(Event::NanoSleep());
           ret.push_back(Event::UrandomRead(len));
         }


### PR DESCRIPTION
### Issues:

CryptoAlg-812

### Description of changes: 

Implement recommended retries for entropy read functions: `rdrand`, `/dev/[u]random`, and `getrandom`.

`rdrand`: Retry 10 times in case of failure in the accumulator function.
`/dev/[u]random`/`getrandom`: Exponential backoff in case of certain failures based on observed behaviour in practice.

### Call-outs:

Sneaked in removing two redundant `break`s.

Replaced `usleep` with `nanosleep` to avoid having to cater for any potential aliasing of the former.

### Testing:

Modified testing in the following way:
* Capture system calls: `__NR_nanosleep` and `__NR_clock_nanosleep` (the latter is an alias for `nanosleep()` in at least Ubuntu 20.04.
* Modified the PRNG model to account for the extra system calls resulting from exponential backoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
