### PR TITLE
Defend against RDRAND triggery

### DIFF
--- a/crypto/fipsmodule/rand/asm/rdrand-x86_64.pl
+++ b/crypto/fipsmodule/rand/asm/rdrand-x86_64.pl
@@ -48,9 +48,9 @@ CRYPTO_rdrand:
 .cfi_startproc
 	xorq %rax, %rax
 	rdrand $tmp1
-	test $tmp1, $tmp1
+	test $tmp1, $tmp1 # OLD cpu's: can us all 0s in output as error signal
 	jz .Lerr
-	cmp \$-1, $tmp1
+	cmp \$-1, $tmp1 # AMD bug: check if all returned bits by RDRAND is stuck on 1
 	je .Lerr
 	# An add-with-carry of zero effectively sets %rax to the carry flag.
 	adcq %rax, %rax
@@ -77,9 +77,9 @@ CRYPTO_rdrand_multiple8_buf:
 .Lloop:
 	rdrand $tmp2
 	jnc .Lerr_multiple
-	test $tmp2, $tmp2 # OLD cpu's: use all 0s as an error condition
+	test $tmp2, $tmp2 # OLD cpu's: can us all 0s in output as error signal
 	jz .Lerr_multiple
-	cmp \$-1, $tmp2 # AMD bug: check if all returned by bits by RDRAND is stuck on 1
+	cmp \$-1, $tmp2 # AMD bug: check if all returned bits by RDRAND is stuck on 1
 	je .Lerr_multiple
 	movq $tmp2, 0($out)
 	addq $tmp1, $out

--- a/crypto/fipsmodule/rand/asm/rdrand-x86_64.pl
+++ b/crypto/fipsmodule/rand/asm/rdrand-x86_64.pl
@@ -48,9 +48,16 @@ CRYPTO_rdrand:
 .cfi_startproc
 	xorq %rax, %rax
 	rdrand $tmp1
+	test $tmp1, $tmp1
+	jz .Lerr
+	cmp \$-1, $tmp1
+	je .Lerr
 	# An add-with-carry of zero effectively sets %rax to the carry flag.
 	adcq %rax, %rax
 	movq $tmp1, 0($out)
+	retq
+.Lerr:
+	xorq %rax, %rax
 	retq
 .cfi_endproc
 .size CRYPTO_rdrand,.-CRYPTO_rdrand
@@ -69,7 +76,11 @@ CRYPTO_rdrand_multiple8_buf:
 	movq \$8, $tmp1
 .Lloop:
 	rdrand $tmp2
-	jnc .Lerr
+	jnc .Lerr_multiple
+	test $tmp2, $tmp2 # OLD cpu's: use all 0s as an error condition
+	jz .Lerr_multiple
+	cmp \$-1, $tmp2 # AMD bug: check if all returned by bits by RDRAND is stuck on 1
+	je .Lerr_multiple
 	movq $tmp2, 0($out)
 	addq $tmp1, $out
 	subq $tmp1, $len
@@ -77,7 +88,7 @@ CRYPTO_rdrand_multiple8_buf:
 .Lout:
 	movq \$1, %rax
 	retq
-.Lerr:
+.Lerr_multiple:
 	xorq %rax, %rax
 	retq
 .cfi_endproc

--- a/crypto/fipsmodule/rand/asm/rdrand-x86_64.pl
+++ b/crypto/fipsmodule/rand/asm/rdrand-x86_64.pl
@@ -48,7 +48,7 @@ CRYPTO_rdrand:
 .cfi_startproc
 	xorq %rax, %rax
 	rdrand $tmp1
-	test $tmp1, $tmp1 # OLD cpu's: can us all 0s in output as error signal
+	test $tmp1, $tmp1 # OLD cpu's: can use all 0s in output as error signal
 	jz .Lerr
 	cmp \$-1, $tmp1 # AMD bug: check if all returned bits by RDRAND is stuck on 1
 	je .Lerr
@@ -77,7 +77,7 @@ CRYPTO_rdrand_multiple8_buf:
 .Lloop:
 	rdrand $tmp2
 	jnc .Lerr_multiple
-	test $tmp2, $tmp2 # OLD cpu's: can us all 0s in output as error signal
+	test $tmp2, $tmp2 # OLD cpu's: can use all 0s in output as error signal
 	jz .Lerr_multiple
 	cmp \$-1, $tmp2 # AMD bug: check if all returned bits by RDRAND is stuck on 1
 	je .Lerr_multiple

--- a/generated-src/linux-x86_64/crypto/fipsmodule/rdrand-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/rdrand-x86_64.S
@@ -24,9 +24,16 @@ CRYPTO_rdrand:
 .cfi_startproc	
 	xorq	%rax,%rax
 .byte	72,15,199,242
+	testq	%rdx,%rdx
+	jz	.Lerr
+	cmpq	$-1,%rdx
+	je	.Lerr
 
 	adcq	%rax,%rax
 	movq	%rdx,0(%rdi)
+	.byte	0xf3,0xc3
+.Lerr:
+	xorq	%rax,%rax
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	CRYPTO_rdrand,.-CRYPTO_rdrand
@@ -46,7 +53,11 @@ CRYPTO_rdrand_multiple8_buf:
 	movq	$8,%rdx
 .Lloop:
 .byte	72,15,199,241
-	jnc	.Lerr
+	jnc	.Lerr_multiple
+	testq	%rcx,%rcx
+	jz	.Lerr_multiple
+	cmpq	$-1,%rcx
+	je	.Lerr_multiple
 	movq	%rcx,0(%rdi)
 	addq	%rdx,%rdi
 	subq	%rdx,%rsi
@@ -54,7 +65,7 @@ CRYPTO_rdrand_multiple8_buf:
 .Lout:
 	movq	$1,%rax
 	.byte	0xf3,0xc3
-.Lerr:
+.Lerr_multiple:
 	xorq	%rax,%rax
 	.byte	0xf3,0xc3
 .cfi_endproc	

--- a/generated-src/mac-x86_64/crypto/fipsmodule/rdrand-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/rdrand-x86_64.S
@@ -24,9 +24,16 @@ _CRYPTO_rdrand:
 
 	xorq	%rax,%rax
 .byte	72,15,199,242
+	testq	%rdx,%rdx
+	jz	L$err
+	cmpq	$-1,%rdx
+	je	L$err
 
 	adcq	%rax,%rax
 	movq	%rdx,0(%rdi)
+	.byte	0xf3,0xc3
+L$err:
+	xorq	%rax,%rax
 	.byte	0xf3,0xc3
 
 
@@ -46,7 +53,11 @@ _CRYPTO_rdrand_multiple8_buf:
 	movq	$8,%rdx
 L$loop:
 .byte	72,15,199,241
-	jnc	L$err
+	jnc	L$err_multiple
+	testq	%rcx,%rcx
+	jz	L$err_multiple
+	cmpq	$-1,%rcx
+	je	L$err_multiple
 	movq	%rcx,0(%rdi)
 	addq	%rdx,%rdi
 	subq	%rdx,%rsi
@@ -54,7 +65,7 @@ L$loop:
 L$out:
 	movq	$1,%rax
 	.byte	0xf3,0xc3
-L$err:
+L$err_multiple:
 	xorq	%rax,%rax
 	.byte	0xf3,0xc3
 

--- a/generated-src/win-x86_64/crypto/fipsmodule/rdrand-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/rdrand-x86_64.asm
@@ -22,9 +22,16 @@ CRYPTO_rdrand:
 
 	xor	rax,rax
 DB	73,15,199,240
+	test	r8,r8
+	jz	NEAR $L$err
+	cmp	r8,-1
+	je	NEAR $L$err
 
 	adc	rax,rax
 	mov	QWORD[rcx],r8
+	DB	0F3h,0C3h		;repret
+$L$err:
+	xor	rax,rax
 	DB	0F3h,0C3h		;repret
 
 
@@ -43,7 +50,11 @@ CRYPTO_rdrand_multiple8_buf:
 	mov	r8,8
 $L$loop:
 DB	73,15,199,241
-	jnc	NEAR $L$err
+	jnc	NEAR $L$err_multiple
+	test	r9,r9
+	jz	NEAR $L$err_multiple
+	cmp	r9,-1
+	je	NEAR $L$err_multiple
 	mov	QWORD[rcx],r9
 	add	rcx,r8
 	sub	rdx,r8
@@ -51,7 +62,7 @@ DB	73,15,199,241
 $L$out:
 	mov	rax,1
 	DB	0F3h,0C3h		;repret
-$L$err:
+$L$err_multiple:
 	xor	rax,rax
 	DB	0F3h,0C3h		;repret
 


### PR DESCRIPTION
### Issues:

### Description of changes:

Port s2n's `rdrand` defense-in-depth https://github.com/aws/s2n-tls/blob/main/utils/s2n_random.c#L520 but do it at the asm level.

**All 0s as error code:** `test` performs a bit-wise `and` and discards the result. `ZF` is set if the result is 0. Hence, `ZF = 1` iff `tmp1` contains all 0s.

**AMD CPU "sticky on 1" bug:** The immediate `-1` is 2-compliment interpreted and sign-extended to 64 bits with no cleared bits. `ZF` is set if the two operands for the `cmp` instruction are equal. Hence, `ZF = 1` iff `tmp1` has all bits set.

### Call-outs:

### Testing:

Flipping branches to `jnz`/`jne`, produces errors when calling `CRYPTO_rdrand` or `CRYPTO_rdrand_multiple8_buf` as expected.

Some standalone perfs - nothing egregious observed.

w/ changes
```
Platform: Linux x86_64
CPU model name: Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz

Method: 10 requests of 64 bytes in 1 threads concurrently

##### AWS-LC RAND_bytes #####
average:         65251.000000 nsecs
50th percentile: 0.000000 nsecs
90th percentile: 0.000000 nsecs
95th percentile: 0.000000 nsecs

Method: 10 requests of 64 bytes in 32 threads concurrently

##### AWS-LC RAND_bytes #####
average:         28847.250000 nsecs
50th percentile: 10887.000000 nsecs
90th percentile: 17159.000000 nsecs
95th percentile: 129219.000000 nsecs
```

w/o changes

```
Platform: Linux x86_64
CPU model name: Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz

Method: 10 requests of 64 bytes in 1 threads concurrently

##### AWS-LC RAND_bytes #####
average:         65497.000000 nsecs
50th percentile: 0.000000 nsecs
90th percentile: 0.000000 nsecs
95th percentile: 0.000000 nsecs

Method: 10 requests of 64 bytes in 32 threads concurrently

##### AWS-LC RAND_bytes #####
average:         27646.406250 nsecs
50th percentile: 11184.000000 nsecs
90th percentile: 20817.000000 nsecs
95th percentile: 125782.000000 nsecs
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
