### PR TITLE
Do not build libdecrepit if we are not buildling libssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,10 +728,10 @@ add_subdirectory(crypto)
 if(BUILD_LIBSSL)
   add_subdirectory(ssl)
   add_subdirectory(tool)
+  add_subdirectory(decrepit)
 endif()
 add_subdirectory(util/fipstools/cavp)
 add_subdirectory(util/fipstools/acvp/modulewrapper)
-add_subdirectory(decrepit)
 
 if(FUZZ)
   if(LIBFUZZER_FROM_DEPS)
@@ -842,7 +842,6 @@ if(BUILD_TESTING)
           run_minimal_tests
           COMMAND crypto_test
           COMMAND urandom_test
-          COMMAND decrepit_test
           WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
           DEPENDS all_tests
           ${MAYBE_USES_TERMINAL}

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -421,7 +421,7 @@ func main() {
 			}
 
 			if !(*sslTests) {
-				if strings.Contains(fmt.Sprint(test.Cmd), "ssl_test") {
+				if strings.Contains(fmt.Sprint(test.Cmd), "ssl_test") || strings.Contains(fmt.Sprint(test.Cmd), "decrepit_test") {
 					continue
 				}
 			}


### PR DESCRIPTION
### Description of changes: 
In #105 we added support for the `BUILD_TESTING` and `BUILD_LIBSSL` options. For `BUILD_LIBSSL`, it was missed that we link the `ssl` target when building `libdecrepit` and we should not be doing this when we disable building libssl.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
