### PR TITLE
Fix a read buffer overrun in X509_CERT_AUX_print()

### DIFF
--- a/crypto/x509/t_x509a.c
+++ b/crypto/x509/t_x509a.c
@@ -103,7 +103,7 @@ int X509_CERT_AUX_print(BIO *out, X509_CERT_AUX *aux, int indent)
     } else
         BIO_printf(out, "%*sNo Rejected Uses.\n", indent, "");
     if (aux->alias)
-        BIO_printf(out, "%*sAlias: %s\n", indent, "", aux->alias->data);
+        BIO_printf(out, "%*sAlias: %.*s\n", indent, "", aux->alias->length, aux->alias->data);
     if (aux->keyid) {
         BIO_printf(out, "%*sKey Id: ", indent, "");
         for (j = 0; j < aux->keyid->length; j++)


### PR DESCRIPTION
### Issues:
Resolves AWS-LC-1

### Description of changes: 
This fix is picked from https://github.com/openssl/openssl/commit/ccb0a11145ee72b042d10593a64eaf9e8a55ec12 to address [CVE-2021-3712](https://cve.report/CVE-2021-3712).

### Call-outs:
N/A

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
