### PR TITLE
Address Docker Hub pull limit.

### DIFF
--- a/tests/ci/cdk/README.md
+++ b/tests/ci/cdk/README.md
@@ -68,10 +68,15 @@ To update AWS-LC CI, run command:
 ./run-cdk.sh --action update-ci
 ```
 
-To create/udpate Docker images, run command:
+To create/udpate Linux Docker images, run command:
 ```
 export GITHUB_ACCESS_TOKEN='xxxxx'
-./run-cdk.sh --action build-img --github-access-token ${GITHUB_ACCESS_TOKEN}
+./run-cdk.sh --action build-linux-img --github-access-token ${GITHUB_ACCESS_TOKEN}
+```
+
+To create/udpate Windows Docker images, run command:
+```
+./run-cdk.sh --action build-win-img
 ```
 
 To destroy AWS-LC CI resources created above, run command:

--- a/tests/ci/cdk/README.md
+++ b/tests/ci/cdk/README.md
@@ -10,6 +10,12 @@ AWS-LC CI uses AWS CDK to define and deploy AWS resources (e.g. AWS CodeBuild, E
 * Install [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
 * [Connect AWS CodeBuild with GitHub](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-access-tokens.html)
   * Note: This step should grant AWS CodeBuild with access to create WebHook.
+  * For team AWS account, AWS CodeBuild is connected with GitHub through GitHub OAuth.
+    * step 1: go to AWS CodeBuild console.
+    * step 2: create a CodeBuild project.
+    * step 3: change **Source provider** to **GitHub**. 
+    * step 4: click **Connect using OAuth** and **Connect to GitHub**.
+    * step 5: follow the OAuth app to grant access.
 * [Create GitHub Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)
   * Note: This token ONLY needs ['read:packages' permission](https://docs.github.com/en/packages/learn-github-packages/about-github-packages#authenticating-to-github-packages), and should be deleted from GitHub account after docker image build.
   * This token is needed when pulling images from 'docker.pkg.github.com'.

--- a/tests/ci/cdk/app.py
+++ b/tests/ci/cdk/app.py
@@ -41,7 +41,8 @@ win_x86_build_spec_file = "./cdk/codebuild/github_ci_windows_x86_omnibus.yaml"
 AwsLcGitHubCIStack(app, "aws-lc-ci-windows-x86", WINDOWS_X86_ECR_REPO, win_x86_build_spec_file, env=env)
 fuzz_build_spec_file = "cdk/codebuild/github_ci_fuzzing_omnibus.yaml"
 AwsLcGitHubFuzzCIStack(app, "aws-lc-ci-fuzzing", LINUX_X86_ECR_REPO, LINUX_AARCH_ECR_REPO, fuzz_build_spec_file, env=env)
-bm_framework_build_spec_file = "./cdk/codebuild/bm_framework_omnibus.yaml"
-BmFrameworkStack(app, "aws-lc-ci-bm-framework", LINUX_X86_ECR_REPO, bm_framework_build_spec_file, env=env)
+# TODO: re-enable 'aws-lc-ci-bm-framework' when it's ready.
+# bm_framework_build_spec_file = "./cdk/codebuild/bm_framework_omnibus.yaml"
+# BmFrameworkStack(app, "aws-lc-ci-bm-framework", LINUX_X86_ECR_REPO, bm_framework_build_spec_file, env=env)
 
 app.synth()

--- a/tests/ci/cdk/cdk/linux_docker_image_batch_build_stack.py
+++ b/tests/ci/cdk/cdk/linux_docker_image_batch_build_stack.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from aws_cdk import core, aws_codebuild as codebuild, aws_iam as iam
+from aws_cdk import core, aws_codebuild as codebuild, aws_iam as iam, aws_ec2 as ec2
 
 from util.metadata import AWS_ACCOUNT, GITHUB_REPO_OWNER, GITHUB_REPO_NAME, GITHUB_SOURCE_VERSION, LINUX_AARCH_ECR_REPO, \
     LINUX_X86_ECR_REPO, EXTERNAL_CREDENTIAL_SECRET_ARN
@@ -57,10 +57,14 @@ class LinuxDockerImageBatchBuildStack(core.Stack):
                 value=github_access_token,
                 type=codebuild.BuildEnvironmentVariableType.SECRETS_MANAGER)
 
+        # Define VPC
+        vpc = ec2.Vpc(self, id="{}-ec2-vpc".format(id))
+
         # Define CodeBuild project.
         project = codebuild.Project(
             scope=self,
             id=id,
+            vpc=vpc,
             project_name=id,
             source=git_hub_source,
             environment=codebuild.BuildEnvironment(

--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -394,7 +394,7 @@ function main() {
   build-linux-img)
     build_linux_docker_images
     ;;
-  build-linux-img)
+  build-win-img)
     build_win_docker_images
     ;;
   synth)

--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -62,6 +62,10 @@ function store_external_credential() {
 }
 
 function destroy_ci() {
+  if [[ "${CDK_DEPLOY_ACCOUNT}" == "620771051181" ]]; then
+    echo "destroy_ci should not be executed on team account."
+    exit 1
+  fi
   cdk destroy aws-lc-* --force
   # CDK stack destroy does not delete s3 bucket automatically.
   delete_s3_buckets

--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -118,7 +118,8 @@ function create_github_ci_stack() {
   aws codebuild update-webhook --project-name aws-lc-ci-linux-arm --build-type BUILD_BATCH
   aws codebuild update-webhook --project-name aws-lc-ci-windows-x86 --build-type BUILD_BATCH
   aws codebuild update-webhook --project-name aws-lc-ci-fuzzing --build-type BUILD_BATCH
-  aws codebuild update-webhook --project-name aws-lc-ci-bm-framework --build-type BUILD_BATCH
+  # TODO: re-enable 'aws-lc-ci-bm-framework' when it's ready.
+#  aws codebuild update-webhook --project-name aws-lc-ci-bm-framework --build-type BUILD_BATCH
 }
 
 function run_linux_img_build() {

--- a/tests/ci/cdk/setup.py
+++ b/tests/ci/cdk/setup.py
@@ -27,7 +27,9 @@ setuptools.setup(
         # PyYAML is a YAML parser and emitter for Python. Used to read build_spec.yaml.
         "pyyaml==5.3.1",
         # A formatter for Python code.
-        "yapf==0.30.0"
+        "yapf==0.30.0",
+        # Introduced by benchmark framework.
+        "boto3==1.18.11"
     ],
 
     python_requires=">=3.6",

--- a/tests/ci/docker_images/linux-aarch/amazonlinux-2_base/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/amazonlinux-2_base/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM arm64v8/amazonlinux:2
+# Below tag is from https://gallery.ecr.aws/amazonlinux/amazonlinux
+FROM public.ecr.aws/amazonlinux/amazonlinux:latest
 
 SHELL ["/bin/bash", "-c"]
 

--- a/tests/ci/docker_images/linux-aarch/build_images.sh
+++ b/tests/ci/docker_images/linux-aarch/build_images.sh
@@ -2,6 +2,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+####################################
+# Build images from AWS public ECR #
+# https://gallery.ecr.aws/?page=1  #
+####################################
+
 docker build -t amazonlinux-2-aarch:base amazonlinux-2_base
 docker build -t amazonlinux-2-aarch:gcc-7x amazonlinux-2_gcc-7x
 docker build -t amazonlinux-2-aarch:clang-7x amazonlinux-2_clang-7x

--- a/tests/ci/docker_images/linux-aarch/ubuntu-20.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/ubuntu-20.04_base/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM arm64v8/ubuntu:20.04
+# Below tag is from https://gallery.ecr.aws/ubuntu/ubuntu
+FROM public.ecr.aws/ubuntu/ubuntu:20.04_stable
 
 SHELL ["/bin/bash", "-c"]
 

--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_base/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM amazonlinux:2
+# Below tag is from https://gallery.ecr.aws/amazonlinux/amazonlinux
+FROM public.ecr.aws/amazonlinux/amazonlinux:latest
 
 SHELL ["/bin/bash", "-c"]
 

--- a/tests/ci/docker_images/linux-x86/build_images.sh
+++ b/tests/ci/docker_images/linux-x86/build_images.sh
@@ -2,11 +2,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-########################################
-# Build images from AWS-LC GitHub repo #
-########################################
+####################################
+# Build images from AWS public ECR #
+# https://gallery.ecr.aws/?page=1  #
+####################################
 
-docker build -t ubuntu-16.04:gcc-5x ubuntu-16.04_gcc-5x
+# Image pulled from AWS public ECR https://gallery.ecr.aws/?page=1
 docker build -t ubuntu-18.04:base ubuntu-18.04_base
 docker build -t ubuntu-18.04:gcc-7x ubuntu-18.04_gcc-7x
 docker build -t ubuntu-18.04:clang-6x ubuntu-18.04_clang-6x
@@ -24,6 +25,16 @@ docker build -t amazonlinux-2:base amazonlinux-2_base
 docker build -t amazonlinux-2:gcc-7x amazonlinux-2_gcc-7x
 docker build -t amazonlinux-2:gcc-7x-intel-sde amazonlinux-2_gcc-7x-intel-sde
 docker build -t amazonlinux-2:clang-7x amazonlinux-2_clang-7x
+
+################################
+# Build images from Docker Hub #
+################################
+
+# Log Docker hub limit https://docs.docker.com/docker-hub/download-rate-limit/#how-can-i-check-my-current-rate
+TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
+
+docker build -t ubuntu-16.04:gcc-5x ubuntu-16.04_gcc-5x
 docker build -t centos-7:gcc-4x centos-7_gcc-4x
 docker build -t fedora-31:clang-9x fedora-31_clang-9x
 

--- a/tests/ci/docker_images/linux-x86/build_images.sh
+++ b/tests/ci/docker_images/linux-x86/build_images.sh
@@ -7,6 +7,7 @@
 ########################################
 
 docker build -t ubuntu-16.04:gcc-5x ubuntu-16.04_gcc-5x
+docker build -t ubuntu-18.04:base ubuntu-18.04_base
 docker build -t ubuntu-18.04:gcc-7x ubuntu-18.04_gcc-7x
 docker build -t ubuntu-18.04:clang-6x ubuntu-18.04_clang-6x
 docker build -t ubuntu-20.04:base ubuntu-20.04_base
@@ -19,11 +20,11 @@ docker build -t ubuntu-20.04:clang-10x ubuntu-20.04_clang-10x
 docker build -t ubuntu-20.04:clang-7x-bm-framework ubuntu-20.04_clang-7x-bm-framework
 # This passes in the Dockerfile in the folder but uses the parent directory for the context so it has access to cryptofuzz_data.zip
 docker build -t ubuntu-20.04:cryptofuzz -f ubuntu-20.04_cryptofuzz/Dockerfile ../
-docker build -t centos-7:gcc-4x centos-7_gcc-4x
 docker build -t amazonlinux-2:base amazonlinux-2_base
 docker build -t amazonlinux-2:gcc-7x amazonlinux-2_gcc-7x
 docker build -t amazonlinux-2:gcc-7x-intel-sde amazonlinux-2_gcc-7x-intel-sde
 docker build -t amazonlinux-2:clang-7x amazonlinux-2_clang-7x
+docker build -t centos-7:gcc-4x centos-7_gcc-4x
 docker build -t fedora-31:clang-9x fedora-31_clang-9x
 
 ###########################################################

--- a/tests/ci/docker_images/linux-x86/ubuntu-18.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-18.04_base/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu-18.04:base
+# Below tag is from https://gallery.ecr.aws/ubuntu/ubuntu
+FROM public.ecr.aws/ubuntu/ubuntu:18.04_stable
 
 SHELL ["/bin/bash", "-c"]
 
@@ -9,15 +10,20 @@ RUN set -ex && \
     apt-get update && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install \
-    gcc-7 \
-    g++-7 && \
+    cmake \
+    ninja-build \
+    perl \
+    ca-certificates \
+    wget && \
+    cd /tmp && \
+    wget https://dl.google.com/go/go1.13.12.linux-amd64.tar.gz && \
+    tar -xvf go1.13.12.linux-amd64.tar.gz && \
+    mv go /usr/local && \
     apt-get autoremove --purge -y && \
     apt-get clean && \
     apt-get autoclean && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/*
 
-ENV CC=gcc-7
-ENV CXX=g++-7
 ENV GOROOT=/usr/local/go
 ENV PATH="$GOROOT/bin:$PATH"

--- a/tests/ci/docker_images/linux-x86/ubuntu-18.04_clang-6x/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-18.04_clang-6x/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:18.04
+FROM ubuntu-18.04:base
 
 SHELL ["/bin/bash", "-c"]
 
@@ -9,16 +9,7 @@ RUN set -ex && \
     apt-get update && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install \
-    clang \
-    cmake \
-    ninja-build \
-    perl \
-    ca-certificates \
-    wget && \
-    cd /tmp && \
-    wget https://dl.google.com/go/go1.13.12.linux-amd64.tar.gz && \
-    tar -xvf go1.13.12.linux-amd64.tar.gz && \
-    mv go /usr/local && \
+    clang && \
     apt-get autoremove --purge -y && \
     apt-get clean && \
     apt-get autoclean && \

--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_base/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+# Below tag is from https://gallery.ecr.aws/ubuntu/ubuntu
+FROM public.ecr.aws/ubuntu/ubuntu:20.04_stable
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-825

### Description of changes: 
This PR addressed the [Docker hub limit](https://docs.docker.com/docker-hub/download-rate-limit/) by attaching VPC to the AWS CodeBuild used for Linux image build. Without the VPC, it seems the IP address is shared by AWS CodeBuild and throttled heavily. Docker hub pull limit on anonymous user is 100, which is enough for AWS-LC Docker Image build(normally, it just consumes a few). Other minor changes:
* https://gallery.ecr.aws instead of Docker hub is used to pull Ubuntu and AL2 images.
* Linux and Windows images builds are separated because most time only Linux images are rebuilt. This split is also to avoid the personal AWS account(e.g. `'EIP failed Reason: Maximum number of addresses has been reached'`).
* Benchmark CI dimension is commented out.
* Added more comments.

### Call-outs:
TBD

### Testing:
TBD

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
