### PR TITLE
Downstream fips pre-compilation flag

### DIFF
--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -79,3 +79,13 @@ TEST(CryptoTest, FIPSCountersEVP) {
   }
 }
 #endif  // BORINGSSL_FIPS_COUNTERS
+
+#if defined(BORINGSSL_FIPS)
+TEST(CryptoTest, FIPSdownstreamPrecompilationFlag) {
+#if defined(AWSLC_FIPS)
+  ASSERT_TRUE(1);
+#else
+  ASSERT_TRUE(0);
+#endif
+}
+#endif // defined(BORINGSSL_FIPS)

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -83,6 +83,9 @@
 extern "C" {
 #endif
 
+#if defined(BORINGSSL_FIPS)
+#define AWSLC_FIPS
+#endif
 
 #if defined(__x86_64) || defined(_M_AMD64) || defined(_M_X64)
 #define OPENSSL_64_BIT


### PR DESCRIPTION
### Issues:

### Description of changes: 

Define downstream consumable directive that can be used during pre-compilation to branch depending on whether AWS-LC is build in FIPS mode or not.

### Call-outs:

### Testing:

Simple unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
