### PR TITLE
Document that macOS CI dimension is disabled

### DIFF
--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -65,7 +65,9 @@ CodeBuild|clang 9.0.1|aarch64|Ubuntu 20.04
 CodeBuild|clang 10.0.0|x86-64|Ubuntu 20.04
 CodeBuild|clang 10.0.0|aarch64|Ubuntu 20.04
 CodeBuild|Visual Studio 2015|x86-64|Windows Server 10
-Travis|Xcode 11*|x86-64|macOS 10.14
+~~Travis~~|~~Xcode 11*~~|~~x86-64~~|~~macOS 10.14~~
+
+(macOS CI dimension is currently disabled)
 
 \* Apple Xcode 11 supplies what Apple calls clang 11 which is equivalent to llvm
 clang 8.0.0


### PR DESCRIPTION
### Issues:

### Description of changes: 

We moved off Travis, which hosted our macOS CI dimension. Document that.

### Call-outs:

### Testing:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
