### PR TITLE
Add 'responder' role of KAS-FFC-SSC in ACVP config.

### DIFF
--- a/util/fipstools/acvp/modulewrapper/modulewrapper.cc
+++ b/util/fipstools/acvp/modulewrapper/modulewrapper.cc
@@ -838,7 +838,8 @@ static bool GetConfig(const Span<const uint8_t> args[], ReplyCallback write_repl
         "scheme": {
           "dhEphem": {
             "kasRole": [
-              "initiator"
+              "initiator",
+              "responder"
             ]
           }
         },


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-823

### Description of changes: 
This PR is to update config of `modulewrapper.cc`. This change is to keep the config update to date. The config sometimes is used as reference to request ACVP data.

### Call-outs:
TBD

### Testing:
CryptoAlg-823 has one quip doc and test report shows this role is supported.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
