### PR TITLE
Fix compiler error: unknown type name '__u32'.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,9 @@ endif ()
 if(GCC OR CLANG)
   check_compiler("stdalign_check.c" AWS_LC_STDALIGN_AVAILABLE)
   check_compiler("builtin_swap_check.c" AWS_LC_BUILTIN_SWAP_SUPPORTED)
+  if(FIPS)
+    check_compiler("linux_u32.c" AWS_LC_URANDOM_U32)
+  endif()
   # Note clang-cl is odd and sets both CLANG and MSVC. We base our configuration
   # primarily on our normal Clang one.
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -31,6 +31,11 @@
 
 #if defined(OPENSSL_LINUX)
 #if defined(BORINGSSL_FIPS)
+#if !defined(AWS_LC_URANDOM_U32)
+  // On old Linux OS: unknown type name '__u32' when include <linux/random.h>.
+  // If '__u32' is predefined, redefine will cause compiler error.
+  typedef unsigned int __u32;
+#endif
 #include <linux/random.h>
 #include <sys/ioctl.h>
 #endif

--- a/tests/compiler_features_tests/linux_u32.c
+++ b/tests/compiler_features_tests/linux_u32.c
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is to check if <linux/random.h> can be included.
+// Currently, I assume the compiler error is caused by '__u32' is not defined.
+// Background:
+// crypto/fipsmodule/rand/urandom.c includes below Linux header file for FIPS.
+// Some old Linux OS does not define '__u32', and then reports below error.
+// /usr/include/linux/random.h:38:2: error: unknown type name '__u32'
+// __u32 buf[0];
+// ^
+#include <linux/random.h>
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-829?selectedConversation=71347c06-0be3-4d5f-ade8-274ddeee05af

### Description of changes: 

This PR is to fix compiler error: unknown type name '__u32'.

Background:
crypto/fipsmodule/rand/urandom.c includes below Linux header file for FIPS.
Some old Linux OS does not define '__u32', and then reports below error.
```
/usr/include/linux/random.h:38:2: error: unknown type name '__u32'
__u32 buf[0];
^
```
Currently, I assume the compiler error is caused by '__u32' is not defined. If not, the redefine the same type will trigger compiler error.


### Call-outs:
* A quip doc has more details and is included in `CryptoAlg-829?selectedConversation=71347c06-0be3-4d5f-ade8-274ddeee05af`.
* `/usr/include/asm-x86_64/types.h` uses the same code to define `__u32`. The header file is not included because I plan to keep the change in scope.

### Testing:
* Internal build on old Linux OS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
