### PR TITLE
Correctly check Jitter read_entropy return value

### DIFF
--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -183,8 +183,8 @@ static void CRYPTO_get_fips_seed(uint8_t *out_entropy, size_t out_entropy_len,
   }
 
   // Generate the required number of bytes with Jitter.
-  if (jent_read_entropy_safe(&state->jitter_ec,
-                             (char *) out_entropy, out_entropy_len) < 0) {
+  if (jent_read_entropy_safe(&state->jitter_ec, (char *) out_entropy,
+                             out_entropy_len) != (ssize_t) out_entropy_len) {
     abort();
   }
 
@@ -233,7 +233,7 @@ static void rand_get_seed(struct rand_thread_state *state,
   OPENSSL_memcpy(seed, entropy, CTR_DRBG_ENTROPY_LEN);
 }
 
-#else
+#else // BORINGSSL_FIPS
 
 // rand_get_seed fills |seed| with entropy and sets |*out_used_cpu| to one if
 // that entropy came directly from the CPU and zero otherwise.
@@ -246,7 +246,7 @@ static void rand_get_seed(struct rand_thread_state *state,
   *out_used_cpu = 0;
 }
 
-#endif
+#endif // BORINGSSL_FIPS
 
 void RAND_bytes_with_additional_data(uint8_t *out, size_t out_len,
                                      const uint8_t user_additional_data[32]) {


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Documentation for Jitter read_entropy functions states that the functions return either a negative integer which signifies an error, or the number of generated bytes of entropy. The implementation of the functions however checks if it the requested and the generated number of bytes is the same and returns an error if it's not. Nevertheless, to be on the safe side we now check that Jitter function returns the expected value.

### Call-outs:
N/A

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
