### PR TITLE
Split AES-GCM formal verification with smaller parameter range.

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -244,7 +244,9 @@ batch:
           HMAC_SELECTCHECK: 1
 
     # When 'AES_GCM_SELECTCHECK' is defined, AES-GCM formal verification is executed against more parameters.
-    - identifier: ubuntu2004_clang10x_formal_verification_aes_gcm_selectcheck
+    # This dimension only checks |evp_cipher_update_len| from 1 to 128.
+    # https://github.com/awslabs/aws-lc-verification/blob/master/SAW/proof/AES/verify-AES-GCM-selectcheck-template.txt
+    - identifier: ubuntu2004_clang10x_formal_verification_aes_gcm_selectcheck_1_128
       buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-20.04_clang-10x_formal-verification.yml
       env:
         type: LINUX_CONTAINER
@@ -253,6 +255,38 @@ batch:
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_formal-verification_latest
         variables:
           AES_GCM_SELECTCHECK: 1
+          AES_GCM_SELECTCHECK_START: 1
+          AES_GCM_SELECTCHECK_END: 128
+
+    # When 'AES_GCM_SELECTCHECK' is defined, AES-GCM formal verification is executed against more parameters.
+    # This dimension only checks |evp_cipher_update_len| from 129 to 258.
+    # https://github.com/awslabs/aws-lc-verification/blob/master/SAW/proof/AES/verify-AES-GCM-selectcheck-template.txt
+    - identifier: ubuntu2004_clang10x_formal_verification_aes_gcm_selectcheck_129_258
+      buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-20.04_clang-10x_formal-verification.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_2XLARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_formal-verification_latest
+        variables:
+          AES_GCM_SELECTCHECK: 1
+          AES_GCM_SELECTCHECK_START: 129
+          AES_GCM_SELECTCHECK_END: 258
+
+    # When 'AES_GCM_SELECTCHECK' is defined, AES-GCM formal verification is executed against more parameters.
+    # This dimension only checks |evp_cipher_update_len| from 259 to 384.
+    # https://github.com/awslabs/aws-lc-verification/blob/master/SAW/proof/AES/verify-AES-GCM-selectcheck-template.txt
+    - identifier: ubuntu2004_clang10x_formal_verification_aes_gcm_selectcheck_259_384
+      buildspec: ./tests/ci/codebuild/linux-x86/ubuntu-20.04_clang-10x_formal-verification.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_2XLARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_formal-verification_latest
+        variables:
+          AES_GCM_SELECTCHECK: 1
+          AES_GCM_SELECTCHECK_START: 259
+          AES_GCM_SELECTCHECK_END: 384
 
     # Build and test aws-lc without Perl/Go.
     # aws-c-cal uses Docker images maintained in aws crt repo.


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-847

### Description of changes: 
https://github.com/awslabs/aws-lc-verification/pull/54 added a pair of env var to make the the parameter range configurable. This PR used the env variable to reduce the total time of AES-GCM select check.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
* CryptoAlg-847?selectedConversation=a20c9db4-403b-4184-b0d1-1acf7c663e34

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
