### PR TITLE
Remove unused macro check in urandom_test

### DIFF
--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -21,8 +21,7 @@
 #include "getrandom_fillin.h"
 
 #if defined(OPENSSL_X86_64) && !defined(BORINGSSL_SHARED_LIBRARY) && \
-    !defined(BORINGSSL_UNSAFE_DETERMINISTIC_MODE) && \
-    defined(USE_NR_getrandom) && !defined(JITTER_ENTROPY)
+    !defined(BORINGSSL_UNSAFE_DETERMINISTIC_MODE) && defined(USE_NR_getrandom)
 
 #include <linux/types.h>
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Remove unused macro check in urandom_test (leftover from when `JITTER_ENTROPY` flag was defined).

### Call-outs:
N/A

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
