### PR TITLE
Add support for a counter lock for the service indicator along with service indicator checks and tests for sha, cmac, and hmac.

### DIFF
--- a/crypto/fipsmodule/service_indicator/internal.h
+++ b/crypto/fipsmodule/service_indicator/internal.h
@@ -9,6 +9,7 @@
 #if defined(AWSLC_FIPS)
 
 struct fips_service_indicator_state {
+  uint64_t lock_state;
   uint64_t counter;
 };
 
@@ -17,11 +18,31 @@ struct fips_service_indicator_state {
 // service is deemed to be approved.
 void FIPS_service_indicator_update_state(void);
 
+// Only to be used internally. Certain approved algorithms call upon other
+// approved algorithms, and some services provide one-shot functions that call
+// upon multiple functions that are approved themselves.
+// These functions lock/unlock the counter state, so that nested calls of
+// |FIPS_service_indicator_update_state| within don't update the counter
+// unintentionally. The lock is implemented as a counter, as one-shot functions
+// may call upon approved nested functions which have approved nested algorithms
+// within them as well. The counter state can only be updated when the
+// |lock_state| has a value of 0.
+// For the approval checks to work correctly, whenever
+// |FIPS_service_indicator_lock_state| is called,
+// |FIPS_service_indicator_unlock_state| must be called before exiting the
+// function. This ensures that the counter is only updated when the most
+// high level function that initially locked the state first, unlocks the
+// |lock_state| back to 0.
+void FIPS_service_indicator_lock_state(void);
+void FIPS_service_indicator_unlock_state(void);
+
 #else
 
 // Service indicator functions are not intended for use during non-FIPS mode.
 // If these functions are run during non-FIPS mode, they will return nothing.
 OPENSSL_INLINE void FIPS_service_indicator_update_state(void) { }
+OPENSSL_INLINE void FIPS_service_indicator_lock_state(void) { }
+OPENSSL_INLINE void FIPS_service_indicator_unlock_state(void) { }
 
 #endif // AWSLC_FIPS
 
@@ -36,5 +57,11 @@ void AES_verify_service_indicator(unsigned key_rounds);
 // those of other AES modes. AES-GCM is approved only with an internal IV, see
 // SP 800-38D Sec 8.2.2.
 void AEAD_verify_service_indicator(size_t key_length);
+
+// Only 128 and 256 bit keys are approved for AES-CMAC.
+void AES_CMAC_verify_service_indicator(const CMAC_CTX *ctx);
+
+// HMAC with SHA1, SHA224, SHA256, SHA384, and SHA512 are approved.
+void HMAC_verify_service_indicator(const EVP_MD *evp_md);
 
 #endif  // AWSLC_HEADER_SERVICE_INDICATOR_INTERNAL_H

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -9,12 +9,16 @@
 #include <openssl/aead.h>
 #include <openssl/aes.h>
 #include <openssl/bn.h>
+#include <openssl/cipher.h>
+#include <openssl/cmac.h>
 #include <openssl/des.h>
 #include <openssl/dh.h>
 #include <openssl/digest.h>
 #include <openssl/ec.h>
-#include <openssl/ecdsa.h>
 #include <openssl/ec_key.h>
+#include <openssl/ecdsa.h>
+#include <openssl/hmac.h>
+#include <openssl/md5.h>
 #include <openssl/nid.h>
 #include <openssl/rsa.h>
 #include <openssl/sha.h>
@@ -62,6 +66,273 @@ static const uint8_t kAESCBCCiphertext[64] = {
     0x18, 0xdb, 0xc1, 0x52, 0x8c, 0x23, 0x66, 0x11, 0x0d, 0xa8, 0xe9,
     0xb8, 0x08, 0x8b, 0xaa, 0x81, 0x47, 0x01, 0xa4, 0x4f
 };
+
+static const uint8_t kAESCMACOutput[16] = {
+    0xe7, 0x32, 0x43, 0xb4, 0xae, 0x79, 0x08, 0x86, 0xe7, 0x9f, 0x0d,
+    0x3f, 0x88, 0x3f, 0x1a, 0xfd
+};
+
+const uint8_t kOutput_sha1[SHA_DIGEST_LENGTH] = {
+    0x5b, 0xed, 0x47, 0xcc, 0xc8, 0x8d, 0x6a, 0xf8, 0x91, 0xc1, 0x85,
+    0x84, 0xe9, 0xd1, 0x31, 0xe6, 0x3e, 0x62, 0x61, 0xd9
+};
+
+const uint8_t kOutput_sha224[SHA224_DIGEST_LENGTH] = {
+    0xef, 0xad, 0x36, 0x20, 0xc6, 0x16, 0x17, 0x24, 0x49, 0x80, 0x53,
+    0x7a, 0x46, 0x5b, 0xed, 0xde, 0x59, 0x9d, 0xa9, 0x19, 0xb0, 0xb8,
+    0x1f, 0xbe, 0x4b, 0xa7, 0xc0, 0xea
+};
+
+const uint8_t kOutput_sha256[SHA256_DIGEST_LENGTH] = {
+    0x03, 0x19, 0x41, 0x4c, 0x62, 0x51, 0x83, 0xe5, 0x2b, 0x73, 0xf0,
+    0x55, 0x51, 0x5e, 0x8e, 0x7d, 0x6f, 0x3a, 0x91, 0xf1, 0xac, 0xe0,
+    0x7b, 0xb2, 0xac, 0x13, 0x65, 0x18, 0x55, 0x2c, 0x98, 0x0f
+};
+
+const uint8_t kOutput_sha384[SHA384_DIGEST_LENGTH] = {
+    0x0b, 0xbf, 0xc2, 0x06, 0x7a, 0x1e, 0xeb, 0x4a, 0x11, 0x57, 0x41,
+    0x20, 0x7b, 0xfb, 0xf7, 0x2c, 0x22, 0x6b, 0x96, 0xcb, 0xc6, 0x00,
+    0x81, 0xe3, 0x19, 0xf2, 0x0e, 0xcc, 0xb9, 0x5d, 0xee, 0x71, 0xda,
+    0x34, 0x10, 0xae, 0x02, 0x64, 0x31, 0x07, 0x13, 0xff, 0x47, 0xf2,
+    0xdf, 0xb0, 0x05, 0x03
+};
+
+const uint8_t kOutput_sha512[SHA512_DIGEST_LENGTH] = {
+    0x9d, 0xa3, 0xfa, 0xaf, 0xae, 0x0a, 0xf4, 0xe4, 0x2e, 0x68, 0xcb,
+    0x7c, 0x65, 0x04, 0x76, 0x26, 0x91, 0x2a, 0x52, 0xb6, 0xb0, 0xa9,
+    0x40, 0xa7, 0xf7, 0xcb, 0xc8, 0x8d, 0x4b, 0x55, 0x1b, 0x44, 0xe2,
+    0x13, 0xcb, 0x6a, 0x28, 0x89, 0xa3, 0x15, 0x94, 0xc6, 0xbb, 0xcb,
+    0x5d, 0xf5, 0xb3, 0x4f, 0x47, 0x8f, 0x1a, 0x44, 0x39, 0x51, 0xd2,
+    0x63, 0xb1, 0x0c, 0xe1, 0x2c, 0x8d, 0x07, 0x08, 0x2f
+};
+
+const uint8_t kOutput_sha512_256[SHA512_256_DIGEST_LENGTH] = {
+    0x4f, 0x8a, 0x34, 0x49, 0xfd, 0xc8, 0x42, 0xb7, 0xc1, 0x2b, 0x6d,
+    0x2a, 0x89, 0xb8, 0x10, 0x73, 0xde, 0x4a, 0x33, 0x7d, 0x3c, 0x8c,
+    0xa5, 0xff, 0xee, 0xc9, 0xbb, 0x92, 0x3d, 0x47, 0x60, 0x34
+};
+
+const uint8_t kHMACOutput_sha1[SHA_DIGEST_LENGTH] = {
+    0x22, 0xbe, 0xf1, 0x4e, 0x72, 0xec, 0xfd, 0x34, 0xd9, 0x57, 0xec,
+    0xf6, 0x08, 0xeb, 0x37, 0xff, 0xf9, 0x3b, 0x9f, 0xf3
+};
+
+const uint8_t kHMACOutput_sha224[SHA224_DIGEST_LENGTH] = {
+    0x5f, 0x85, 0xbd, 0xb9, 0xf9, 0x00, 0xdf, 0x81, 0xef, 0x65, 0xd3,
+    0x8e, 0x7a, 0xb6, 0xd8, 0x5b, 0xf9, 0xd8, 0x62, 0x1c, 0xc5, 0x11,
+    0x68, 0xb4, 0xf4, 0xd8, 0x57, 0x46
+};
+
+const uint8_t kHMACOutput_sha256[SHA256_DIGEST_LENGTH] = {
+    0x4b, 0xe9, 0x34, 0xa9, 0x37, 0x53, 0x2a, 0xb1, 0x63, 0x5d, 0x8c,
+    0x22, 0x9a, 0x02, 0x37, 0x44, 0x75, 0xe1, 0x21, 0x9e, 0xf1, 0xe3,
+    0x2c, 0xd0, 0x7d, 0x79, 0x03, 0x87, 0xd9, 0x69, 0x36, 0xb5
+};
+
+const uint8_t kHMACOutput_sha384[SHA384_DIGEST_LENGTH] = {
+    0x26, 0x5f, 0x4e, 0x13, 0x99, 0x04, 0xa1, 0xf4, 0xd2, 0x01, 0xd9,
+    0xba, 0xe0, 0xe6, 0xa2, 0xbd, 0x50, 0x76, 0x2b, 0xc3, 0x90, 0x11,
+    0x50, 0xe7, 0x26, 0xdf, 0x39, 0xf9, 0xd6, 0x8f, 0x83, 0xa5, 0xe6,
+    0x8c, 0x16, 0x77, 0xbf, 0xfc, 0x77, 0x66, 0x9a, 0xe5, 0xa0, 0xb7,
+    0xfe, 0xfb, 0x09, 0x5e
+};
+
+const uint8_t kHMACOutput_sha512[SHA512_DIGEST_LENGTH] = {
+    0x70, 0xf3, 0xf2, 0x82, 0xba, 0xc8, 0x14, 0xe4, 0x00, 0x9b, 0x72,
+    0x8a, 0xe6, 0x07, 0xc8, 0xaf, 0x4f, 0x23, 0x0a, 0x5b, 0x16, 0xa8,
+    0x9b, 0x68, 0x4f, 0x75, 0x21, 0xac, 0xb4, 0x20, 0x3d, 0x97, 0x77,
+    0x21, 0x00, 0x74, 0xfa, 0xb2, 0x79, 0x28, 0x47, 0x8c, 0xa6, 0x11,
+    0x85, 0xa5, 0x1e, 0x2f, 0x4a, 0x25, 0xd4, 0xf8, 0x13, 0x64, 0xd1,
+    0x30, 0xd8, 0x45, 0x2c, 0x87, 0x44, 0x62, 0xc5, 0xe3
+};
+
+struct MD {
+  // name is the name of the digest.
+  const char* name;
+  // md_func is the digest to test.
+  const EVP_MD *(*func)(void);
+  // one_shot_func is the convenience one-shot version of the digest.
+  uint8_t *(*one_shot_func)(const uint8_t *, size_t, uint8_t *);
+};
+
+static const MD md5 = { "MD5", &EVP_md5, &MD5 };
+static const MD sha1 = { "KAT for SHA1", &EVP_sha1, &SHA1 };
+static const MD sha224 = { "KAT for SHA224", &EVP_sha224, &SHA224 };
+static const MD sha256 = { "KAT for SHA256", &EVP_sha256, &SHA256 };
+static const MD sha384 = { "KAT for SHA384", &EVP_sha384, &SHA384 };
+static const MD sha512 = { "KAT for SHA512", &EVP_sha512, &SHA512 };
+static const MD sha512_256 = { "KAT for SHA512-256", &EVP_sha512_256, &SHA512_256 };
+
+struct DigestTestVector {
+  // md is the digest to test.
+  const MD &md;
+  // input is a NUL-terminated string to hash.
+  const uint8_t *input;
+  // expected_hex is the expected digest.
+  const uint8_t *expected_digest;
+  // expected to be approved or not.
+  const bool expect_approved;
+} kDigestTestVectors[] = {
+    { md5, kPlaintext, nullptr, false },
+    { sha1, kPlaintext, kOutput_sha1, true },
+    { sha224, kPlaintext, kOutput_sha224,true },
+    { sha256, kPlaintext, kOutput_sha256,true },
+    { sha384, kPlaintext, kOutput_sha384,true },
+    { sha512, kPlaintext, kOutput_sha512,true },
+    { sha512_256, kPlaintext, kOutput_sha512_256,true }
+};
+
+class EVP_MD_ServiceIndicatorTest : public testing::TestWithParam<DigestTestVector> {};
+
+INSTANTIATE_TEST_SUITE_P(All, EVP_MD_ServiceIndicatorTest, testing::ValuesIn(kDigestTestVectors));
+
+TEST_P(EVP_MD_ServiceIndicatorTest, EVP_Ciphers) {
+  const DigestTestVector &t = GetParam();
+
+  int approved = AWSLC_NOT_APPROVED;
+  bssl::ScopedEVP_MD_CTX ctx;
+  std::unique_ptr<uint8_t[]> digest(new uint8_t[EVP_MD_size(t.md.func())]);
+  unsigned digest_len;
+
+  // Test the EVP_Digest interfaces for approval one by one directly.
+  CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(EVP_DigestInit_ex(ctx.get(), t.md.func(), nullptr)));
+  if (t.expect_approved) {
+    ASSERT_TRUE(approved);
+  } else {
+    ASSERT_FALSE(approved);
+  }
+  CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(EVP_DigestUpdate(ctx.get(), t.input, sizeof(t.input))));
+  if (t.expect_approved) {
+    ASSERT_TRUE(approved);
+  } else {
+    ASSERT_FALSE(approved);
+  }
+  CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(EVP_DigestFinal_ex(ctx.get(), digest.get(), &digest_len)));
+  if (t.expect_approved) {
+    ASSERT_TRUE(check_test(t.expected_digest, digest.get(), digest_len, t.md.name));
+    ASSERT_TRUE(approved);
+  } else {
+    ASSERT_FALSE(approved);
+  }
+
+  // Test using the one-shot API for approval.
+  CALL_SERVICE_AND_CHECK_APPROVED(approved, t.md.one_shot_func(t.input, sizeof(t.input), digest.get()));
+  if (t.expect_approved) {
+    ASSERT_TRUE(check_test(t.expected_digest, digest.get(), EVP_MD_size(t.md.func()), t.md.name));
+    ASSERT_TRUE(approved);
+  } else {
+    ASSERT_FALSE(approved);
+  }
+}
+
+struct HMACTestVector {
+  // func is the hash function for HMAC to test.
+  const EVP_MD *(*func)(void);
+  // input is a NUL-terminated string to hash.
+  const uint8_t *input;
+  // expected_hex is the expected digest.
+  const uint8_t *expected_digest;
+  // expected to be approved or not.
+  const bool expect_approved;
+} kHMACTestVectors[] = {
+    { EVP_sha1, kPlaintext, kHMACOutput_sha1, true },
+    { EVP_sha224, kPlaintext, kHMACOutput_sha224, true },
+    { EVP_sha256, kPlaintext, kHMACOutput_sha256,true },
+    { EVP_sha384, kPlaintext, kHMACOutput_sha384,true },
+    { EVP_sha512, kPlaintext, kHMACOutput_sha512,true },
+    { EVP_sha512_256, kPlaintext, nullptr, false }
+};
+
+class HMAC_ServiceIndicatorTest : public testing::TestWithParam<HMACTestVector> {};
+
+INSTANTIATE_TEST_SUITE_P(All, HMAC_ServiceIndicatorTest, testing::ValuesIn(kHMACTestVectors));
+
+TEST_P(HMAC_ServiceIndicatorTest, HMACTest) {
+  const HMACTestVector &t = GetParam();
+
+  int approved = AWSLC_NOT_APPROVED;
+  const uint8_t kHMACKey[64] = {0};
+  std::string digest_str;
+  const EVP_MD *digest = t.func();
+  std::vector<uint8_t> key(kHMACKey, kHMACKey + sizeof(kHMACKey));
+  std::vector<uint8_t> input(t.input, t.input + sizeof(t.input));
+
+
+  unsigned expected_mac_len = EVP_MD_size(digest);
+  std::unique_ptr<uint8_t[]> mac(new uint8_t[expected_mac_len]);
+  unsigned mac_len;
+
+  // Test using HMAC_CTX for approval one by one directly.
+  bssl::ScopedHMAC_CTX ctx;
+  CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(HMAC_Init_ex(ctx.get(), key.data(), key.size(), digest, nullptr)));
+  if (t.expect_approved) {
+    ASSERT_TRUE(approved);
+  } else {
+    ASSERT_FALSE(approved);
+  }
+  CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(HMAC_Update(ctx.get(), t.input, input.size())));
+  if (t.expect_approved) {
+    ASSERT_TRUE(approved);
+  } else {
+    ASSERT_FALSE(approved);
+  }
+  CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(HMAC_Final(ctx.get(), mac.get(), &mac_len)));
+  if (t.expect_approved) {
+    ASSERT_TRUE(check_test(t.expected_digest, mac.get(), mac_len, "HMAC KAT"));
+    ASSERT_TRUE(approved);
+  } else {
+    ASSERT_FALSE(approved);
+  }
+
+  // Test using the one-shot API for approval.
+  CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(HMAC(digest, key.data(), key.size(), input.data(), input.size(),
+                                                             mac.get(), &mac_len)));
+  if (t.expect_approved) {
+    ASSERT_TRUE(check_test(t.expected_digest, mac.get(), mac_len, "HMAC KAT"));
+    ASSERT_TRUE(approved);
+  } else {
+    ASSERT_FALSE(approved);
+  }
+}
+
+TEST(ServiceIndicatorTest, CMAC) {
+  int approved = AWSLC_NOT_APPROVED;
+
+  uint8_t mac[16];
+  bssl::UniquePtr<CMAC_CTX> ctx(CMAC_CTX_new());
+  ASSERT_TRUE(ctx);
+
+
+  CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(CMAC_Init(ctx.get(),
+                        kAESKey, sizeof(kAESKey), EVP_aes_128_cbc(), nullptr)));
+  ASSERT_TRUE(approved);
+  for (unsigned chunk_size = 1; chunk_size <= sizeof(kPlaintext); chunk_size++) {
+    SCOPED_TRACE(chunk_size);
+
+    ASSERT_TRUE(CMAC_Reset(ctx.get()));
+
+    size_t done = 0;
+    while (done < sizeof(kPlaintext)) {
+      size_t todo = std::min(sizeof(kPlaintext) - done, static_cast<size_t>(chunk_size));
+      CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(CMAC_Update(ctx.get(), kPlaintext + done, todo)));
+      ASSERT_TRUE(approved);
+      done += todo;
+    }
+
+    size_t out_len;
+    CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(CMAC_Final(ctx.get(), mac, &out_len)));
+    ASSERT_TRUE(approved);
+    ASSERT_TRUE(check_test(kAESCMACOutput, mac, sizeof(kAESCMACOutput),
+                           "AES-CMAC KAT"));
+  }
+
+  // Test using the one-shot API for approval.
+  CALL_SERVICE_AND_CHECK_APPROVED(approved,AES_CMAC(mac, kAESKey, sizeof(kAESKey),
+                                                    kPlaintext, sizeof(kPlaintext)));
+  ASSERT_TRUE(check_test(kAESCMACOutput, mac, sizeof(kAESCMACOutput),
+                         "AES-CMAC KAT"));
+  ASSERT_TRUE(approved);
+}
 
 TEST(ServiceIndicatorTest, BasicTest) {
   int approved = AWSLC_NOT_APPROVED;

--- a/crypto/fipsmodule/sha/sha256.c
+++ b/crypto/fipsmodule/sha/sha256.c
@@ -76,6 +76,7 @@ int SHA224_Init(SHA256_CTX *sha) {
   sha->h[6] = 0x64f98fa7UL;
   sha->h[7] = 0xbefa4fa4UL;
   sha->md_len = SHA224_DIGEST_LENGTH;
+  FIPS_service_indicator_update_state();
   return 1;
 }
 
@@ -90,14 +91,20 @@ int SHA256_Init(SHA256_CTX *sha) {
   sha->h[6] = 0x1f83d9abUL;
   sha->h[7] = 0x5be0cd19UL;
   sha->md_len = SHA256_DIGEST_LENGTH;
+  FIPS_service_indicator_update_state();
   return 1;
 }
 
 uint8_t *SHA224(const uint8_t *data, size_t len,
                 uint8_t out[SHA224_DIGEST_LENGTH]) {
+  FIPS_service_indicator_lock_state();
   SHA256_CTX ctx;
   SHA224_Init(&ctx);
   SHA224_Update(&ctx, data, len);
+
+  // Unlock service indicator state here, to let |SHA224_Final| decide if
+  // |SHA224| has succeeded or not.
+  FIPS_service_indicator_unlock_state();
   SHA224_Final(out, &ctx);
   OPENSSL_cleanse(&ctx, sizeof(ctx));
   return out;
@@ -105,9 +112,14 @@ uint8_t *SHA224(const uint8_t *data, size_t len,
 
 uint8_t *SHA256(const uint8_t *data, size_t len,
                 uint8_t out[SHA256_DIGEST_LENGTH]) {
+  FIPS_service_indicator_lock_state();
   SHA256_CTX ctx;
   SHA256_Init(&ctx);
   SHA256_Update(&ctx, data, len);
+
+  // Unlock service indicator state here, to let |SHA256_Final| decide if
+  // |SHA256| has succeeded or not.
+  FIPS_service_indicator_unlock_state();
   SHA256_Final(out, &ctx);
   OPENSSL_cleanse(&ctx, sizeof(ctx));
   return out;
@@ -125,6 +137,7 @@ void SHA256_Transform(SHA256_CTX *c, const uint8_t data[SHA256_CBLOCK]) {
 int SHA256_Update(SHA256_CTX *c, const void *data, size_t len) {
   crypto_md32_update(&sha256_block_data_order, c->h, c->data, SHA256_CBLOCK,
                      &c->num, &c->Nh, &c->Nl, data, len);
+  FIPS_service_indicator_update_state();
   return 1;
 }
 
@@ -150,6 +163,7 @@ static int sha256_final_impl(uint8_t *out, SHA256_CTX *c) {
     CRYPTO_store_u32_be(out, c->h[i]);
     out += 4;
   }
+  FIPS_service_indicator_update_state();
   return 1;
 }
 


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-835`

### Description of changes: 
1. Implements new internal state locking/unlocking functions. Certain approved algorithms call upon other approved algorithms, and some services provide one-shot functions that call upon multiple functions that are approved themselves. These functions lock/unlock the counter state, so that nested calls of `FIPS_service_indicator_update_state` within don't update the counter unintentionally. The lock is implemented as a counter, as one-shot functions may call upon approved nested functions which have approved nested algorithms within them as well. The counter state can now only be updated when the `lock_state` has a value of `0`.
For the approval checks to work correctly, whenever `FIPS_service_indicator_lock_state` is called, `FIPS_service_indicator_unlock_state` must be called before exiting the function. This ensures that the counter is only updated when the most high level function that initially locked the state first, unlocks the `lock_state` back to 0.

2. This PR also includes service indicator checks and tests for:
    * `SHA1`, `SHA224`, `SHA256`, `SHA384`, `SHA512`, `SHA512-256`:
      * `EVP_Digest*` Interface functions
      * One-shot functions
    * `CMAC`:
      * `CMAC_Init`, `CMAC_Update`, `CMAC_Final` functions
      * One-shot function: `AES_CMAC`
    * `HMAC`:
      * `HMAC_Init_ex`, `HMAC_Update`, `HMAC_Final` functions
      * One-shot function: `HMAC`

### Call-outs:
* This new locking functionality is being used currently by `HMAC` and `CMAC`. 
    * `HMAC` has a one-shot function which calls upon `HMAC_Init_ex`, `HMAC_Update`, `HMAC_Final` (which are approved themselves as well). The underlying `SHA` crypto used in `HMAC_Init_ex`, `HMAC_Update`, `HMAC_Final` are also approved themselves. 
    * `CMAC` has a one-shot function which calls upon `CMAC_Init`, `CMAC_Update`, `CMAC_Final` (which are approved themselves as well). The underlying `AES-CBC` crypto used in `CMAC_Init`, `CMAC_Update`, `CMAC_Final` are also approved themselves. 
    
* EVP_Digest configuration functions: https://commondatastorage.googleapis.com/chromium-boringssl-docs/digest.h.html#Digest-operations
   * These are covered by updating the corresponding `SHA*_Init`,  `SHA*_Update`, `SHA*_Final` functions, as the EVP_Digest functions point towards the corresponding ones to be used.
### Testing:
New tests in `service_indicator_test.cc` testing dimension.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
