### PR TITLE
Don't use Intel-specific intrinsic on the Arm path and force alignment of Arm vector type

### DIFF
--- a/crypto/hrss/hrss.c
+++ b/crypto/hrss/hrss.c
@@ -192,6 +192,10 @@ static inline vec_t vec_broadcast_bit(vec_t a) {
     (defined(__ARM_NEON__) || defined(__ARM_NEON))
 
 #define HRSS_HAVE_VECTOR_UNIT
+// The Intel vector type |__m128i| is automatically aligned to a 16-byte
+// boundary. But, I can't find anything information about |uint16x8_t| should
+// necessarily be aligned to a 16-byte boundary. We verify 16-byte alignment in
+// |poly_mul_vec()|, so try to force alignment here.
 typedef uint16x8_t vec_t __attribute__ ((aligned (16)));
 
 // These functions perform the same actions as the SSE2 function of the same
@@ -818,7 +822,8 @@ static void poly3_invert_vec(struct poly3 *out, const struct poly3 *in) {
     const vec_t c_a = vec_broadcast_bit(f_a[0] & g_a[0]);
     const vec_t c_s = vec_broadcast_bit((f_s[0] ^ g_s[0]) & c_a);
 
-
+    // SSE2 is an Intel thing. So, checking for |OPENSSL_SSE2| should avoid
+    // hitting the Arm specific path under the #else. 
 #if defined(OPENSSL_SSE2)
     // This is necessary because older versions of GCC, such as version 4.1.2,
     // do not support accessing individual elements of the __m128i type

--- a/crypto/hrss/hrss.c
+++ b/crypto/hrss/hrss.c
@@ -852,7 +852,7 @@ static void poly3_invert_vec(struct poly3 *out, const struct poly3 *in) {
 void HRSS_poly3_invert(struct poly3 *out, const struct poly3 *in) {
   // The vector version of this function seems slightly slower on AArch64, but
   // is useful on ARMv7 and x86-64.
-#if defined(HRSS_HAVE_VECTOR_UNIT) && !defined(OPENSSL_AARCH64
+#if defined(HRSS_HAVE_VECTOR_UNIT) && !defined(OPENSSL_AARCH64)
   if (vec_capable()) {
     poly3_invert_vec(out, in);
     return;

--- a/crypto/hrss/hrss.c
+++ b/crypto/hrss/hrss.c
@@ -193,7 +193,7 @@ static inline vec_t vec_broadcast_bit(vec_t a) {
 
 #define HRSS_HAVE_VECTOR_UNIT
 // The Intel vector type |__m128i| is automatically aligned to a 16-byte
-// boundary. But, I can't find anything information about |uint16x8_t| should
+// boundary. But, I can't find any information about |uint16x8_t| should
 // necessarily be aligned to a 16-byte boundary. We verify 16-byte alignment in
 // |poly_mul_vec()|, so try to force alignment here.
 typedef uint16x8_t vec_t __attribute__ ((aligned (16)));

--- a/crypto/hrss/hrss.c
+++ b/crypto/hrss/hrss.c
@@ -192,7 +192,7 @@ static inline vec_t vec_broadcast_bit(vec_t a) {
     (defined(__ARM_NEON__) || defined(__ARM_NEON))
 
 #define HRSS_HAVE_VECTOR_UNIT
-typedef uint16x8_t vec_t;
+typedef uint16x8_t vec_t __attribute__ ((aligned (16)));
 
 // These functions perform the same actions as the SSE2 function of the same
 // name, above.
@@ -737,7 +737,7 @@ void HRSS_poly3_mul(struct poly3 *out, const struct poly3 *x,
   poly3_mod_phiN(out);
 }
 
-#if defined(HRSS_HAVE_VECTOR_UNIT) && !defined(OPENSSL_AARCH64)
+#if defined(HRSS_HAVE_VECTOR_UNIT) && !(defined(OPENSSL_AARCH64) || defined(OPENSSL_ARM))
 
 // poly3_vec_cswap swaps (|a_s|, |a_a|) and (|b_s|, |b_a|) if |swap| is
 // |0xff..ff|. Otherwise, |swap| must be zero.
@@ -847,7 +847,7 @@ static void poly3_invert_vec(struct poly3 *out, const struct poly3 *in) {
 void HRSS_poly3_invert(struct poly3 *out, const struct poly3 *in) {
   // The vector version of this function seems slightly slower on AArch64, but
   // is useful on ARMv7 and x86-64.
-#if defined(HRSS_HAVE_VECTOR_UNIT) && !defined(OPENSSL_AARCH64)
+#if defined(HRSS_HAVE_VECTOR_UNIT) && !(defined(OPENSSL_AARCH64) || defined(OPENSSL_ARM))
   if (vec_capable()) {
     poly3_invert_vec(out, in);
     return;


### PR DESCRIPTION
### Issues:

### Description of changes: 

**Intel-specific intrinsic**

~~`OPENSSL_AARCH64` is used at compile-time to branch away from non-arm supported code. However, this is only enabled for Arm 64-bit platforms:
https://github.com/awslabs/aws-lc/blob/main/include/openssl/base.h#L96~~

~~The 32-bit Arm platform we are looking at makes the compiler define `__ARMEL__`, making us defining `OPENSSL_ARM`:
https://github.com/awslabs/aws-lc/blob/main/include/openssl/base.h#L99.~~

~~Fixed two instances of this.~~

https://github.com/awslabs/aws-lc/pull/165 introduced a breaking change. The CI didn't exercise this code path because it doesn't have an Arm 32-bit w/ Neon dimension. So it didn't pick up that it now uses Intel specific intrinsics.

Revert back to the original implementation for the Arm code path but use the fix in the PR for the x86 code path.


**alignment**

`struct poly` is aligned to 16-byte boundary:
https://github.com/awslabs/aws-lc/blob/main/crypto/hrss/hrss.c#L921

For SSE2 `vec_t` is automatically 16-byte boundary aligned because `__m128i` is automatically 16-byte aligned.

However, for Arm `vec_t` is typedef'ed to `uint16x8_t`, which I can't find any information about is automatically 16-byte aligned.

I can't say if this is required, but we statically assert that `vec_t` and `struct poly` should have the same alignment:
https://github.com/awslabs/aws-lc/blob/main/crypto/hrss/hrss.c#L1232

Force this alignment.

### Call-outs:

### Testing:
Tested manually that this builds on a Arm 32-bit system that has Arm NEON support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
