### PR TITLE
Add third_party/jitterentropy license to the top level LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -184,6 +184,26 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+The code in third_party/jitterentropy is distributed under the 3-Clause BSD
+License. Amazon expressly elects to distribute the package under the 3-Clause
+BSD License and NOT under GNU General Public License Version 2:
+
+Copyright (C) 2017 - 2021, Stephan Mueller <smueller@chronox.de>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, and the entire permission notice in its entirety,
+   including the disclaimer of warranties.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote
+   products derived from this software without specific prior
+   written permission.
+
 Licenses for support code
 -------------------------
  


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-863 

### Description of changes: 
Update our top level license with information from Jitter's license file.

### Call-outs:
Approval was granted in V438103860.

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
