### PR TITLE
Create a local copy of the shared fuzzing corpus for each fuzz test

### DIFF
--- a/tests/ci/cdk/cdk/aws_lc_github_fuzz_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_fuzz_ci_stack.py
@@ -82,7 +82,10 @@ class AwsLcGitHubFuzzCIStack(core.Stack):
             encrypted=True,
             security_group=build_security_group,
             vpc=fuzz_vpc,
-            vpc_subnets=efs_subnet_selection
+            vpc_subnets=efs_subnet_selection,
+            performance_mode=efs.PerformanceMode.GENERAL_PURPOSE,
+            throughput_mode=efs.ThroughputMode.PROVISIONED,
+            provisioned_throughput_per_second=core.Size.mebibytes(100),
         )
 
         # Create build spec.

--- a/tests/ci/common_fuzz.sh
+++ b/tests/ci/common_fuzz.sh
@@ -108,7 +108,7 @@ function run_fuzz_test {
 
   # Step 2 merge any new files from the run corpus and GitHub src corpus into the shared corpus, the first folder is
   # where to merge the new corpus (SHARED_FUZZ_TEST_CORPUS), the second two are where to read new inputs from
-  # ($LOCAL_RUN_CORPU and SRC_CORPUS).
+  # (LOCAL_RUN_CORPUS and SRC_CORPUS).
   time "${FUZZ_TEST_PATH}" -merge=1 "$SHARED_FUZZ_TEST_CORPUS" "$LOCAL_RUN_CORPUS" "$SRC_CORPUS"
 
   # Calculate interesting metrics and post results to CloudWatch, this checks the shared (EFS) corpus after the new test

--- a/tests/ci/common_fuzz.sh
+++ b/tests/ci/common_fuzz.sh
@@ -20,11 +20,9 @@ echo "$BUILD_ID"
 
 PLATFORM=$(uname -m)
 DATE_NOW="$(date +%Y-%m-%d)"
-FAILURE_ROOT="${CORPUS_ROOT}/runs/${DATE_NOW}/${BUILD_ID}"
-ALL_RUN_ROOT="${BUILD_ROOT}/fuzz_run_root"
-rm -rf "$ALL_RUN_ROOT"
-
-
+SHARED_FAILURE_ROOT="${CORPUS_ROOT}/runs/${DATE_NOW}/${BUILD_ID}"
+LOCAL_RUN_ROOT="${BUILD_ROOT}/fuzz_run_root"
+rm -rf "$LOCAL_RUN_ROOT"
 
 function put_metric_count {
   put_metric --unit Count "$@"
@@ -41,64 +39,66 @@ function put_metric {
 }
 
 function run_fuzz_test {
-  SHARED_CORPUS="${CORPUS_ROOT}/shared_corpus/${FUZZ_NAME}/shared_corpus"
-  FUZZ_TEST_ROOT="${ALL_RUN_ROOT}/${FUZZ_NAME}"
-  LOCAL_SHARED_CORPUS_ROOT="${FUZZ_TEST_ROOT}/local_shared_corpus"
-  FUZZ_TEST_CORPUS="${FUZZ_TEST_ROOT}/run_corpus"
-  ARTIFACTS_FOLDER="${FUZZ_TEST_ROOT}/artifacts"
-  FUZZ_RUN_LOGS="${FUZZ_TEST_ROOT}/logs"
-  SUMMARY_LOG="${FUZZ_RUN_LOGS}/summary.log"
-  mkdir -p "$SHARED_CORPUS" "$FUZZ_TEST_ROOT" "$FUZZ_TEST_CORPUS" "$ARTIFACTS_FOLDER" "$FUZZ_RUN_LOGS"
+  SHARED_FUZZ_TEST_CORPUS="${CORPUS_ROOT}/shared_corpus/${FUZZ_NAME}/shared_corpus"
+  LOCAL_FUZZ_TEST_ROOT="${LOCAL_RUN_ROOT}/${FUZZ_NAME}"
+  LOCAL_SHARED_CORPUS="${LOCAL_FUZZ_TEST_ROOT}/local_shared_corpus"
+  LOCAL_RUN_CORPUS="${LOCAL_FUZZ_TEST_ROOT}/run_corpus"
+  LOCAL_ARTIFACTS_FOLDER="${LOCAL_FUZZ_TEST_ROOT}/artifacts"
+  LOCAL_FUZZ_RUN_LOGS="${LOCAL_FUZZ_TEST_ROOT}/logs"
+  SUMMARY_LOG="${LOCAL_FUZZ_RUN_LOGS}/summary.log"
+  mkdir -p "$SHARED_FUZZ_TEST_CORPUS" "$LOCAL_FUZZ_TEST_ROOT" "$LOCAL_RUN_CORPUS" "$LOCAL_ARTIFACTS_FOLDER" "$LOCAL_FUZZ_RUN_LOGS"
 
   # To avoid having each libfuzzer thread read from the shared corpus copy it to the local CodeBuild directory one time
-  cp -r "$SHARED_CORPUS" "$LOCAL_SHARED_CORPUS_ROOT"
+  cp -r "$SHARED_FUZZ_TEST_CORPUS" "$LOCAL_SHARED_CORPUS"
 
-  # Calculate starting metrics and post to CloudWatch
-  ORIGINAL_SHARED_CORPUS_FILE_COUNT=$(find "$LOCAL_SHARED_CORPUS_ROOT" -type f | wc -l)
-  put_metric_count --metric-name SharedCorpusFileCount --value "$ORIGINAL_SHARED_CORPUS_FILE_COUNT" --dimensions "FuzzTest=$FUZZ_NAME"
+  # Calculate starting metrics and post to CloudWatch, this counts the files in LOCAL_SHARED_CORPUS but publishes them
+  # as the SharedCorpusFileCount, which it basically everything in SHARED_FUZZ_TEST_CORPUS was just copied to
+  # LOCAL_SHARED_CORPUS
+  ORIGINAL_CORPUS_FILE_COUNT=$(find "$LOCAL_SHARED_CORPUS" -type f | wc -l)
+  put_metric_count --metric-name SharedCorpusFileCount --value "$ORIGINAL_CORPUS_FILE_COUNT" --dimensions "FuzzTest=$FUZZ_NAME"
 
   # Perform the actual fuzzing!
-  # Step 1 run each fuzz test for the determined time. This will use the existing shared corpus (in EFS) and any files
-  # checked into the GitHub corpus. This runs the fuzzer with three folders: the first folder is where new inputs will
-  # go (FUZZ_TEST_CORPUS), all other folders will be used as input ($LOCAL_SHARED_CORPUS_ROOT and SRC_CORPUS). It will
-  # write new files to the temporary run corpus.
+  # Step 1 run each fuzz test for the determined time. This will use the existing shared corpus copied from EFS to
+  # LOCAL_SHARED_CORPUS and any files checked into the GitHub SRC_CORPUS. This runs the fuzzer with three
+  # folders: the first folder is where new inputs will go (LOCAL_RUN_CORPUS), all other folders will be used as input
+  # for fuzzing (LOCAL_SHARED_CORPUS and SRC_CORPUS).
   # https://llvm.org/docs/LibFuzzer.html#options
   #
   # Run with NUM_CPU_THREADS which will be physical cores on ARM and virtualized cores on x86 with hyper threading.
   # Looking at the overall system fuzz rate running 1:1 with virtualized cores provides a noticeable speed up. This
   # is slightly different than libfuzzer's recommendation of #cores/2.
-  # This could fail and we want to capture that (+e)
+  # This could fail and we want to capture that so we can publish metrics and save logs (+e)
   set +e
   FUZZ_RUN_FAILURE=0
   time "${FUZZ_TEST_PATH}" -print_final_stats=1 -timeout="$FUZZ_TEST_TIMEOUT" -max_total_time="$TIME_FOR_EACH_FUZZ" \
     -jobs="$NUM_CPU_THREADS" -workers="$NUM_CPU_THREADS" \
-    -artifact_prefix="$ARTIFACTS_FOLDER/" \
-    "$FUZZ_TEST_CORPUS" "$LOCAL_SHARED_CORPUS_ROOT" "$SRC_CORPUS" 2>&1 | tee "$SUMMARY_LOG"
+    -artifact_prefix="$LOCAL_ARTIFACTS_FOLDER/" \
+    "$LOCAL_RUN_CORPUS" "$LOCAL_SHARED_CORPUS" "$SRC_CORPUS" 2>&1 | tee "$SUMMARY_LOG"
   # This gets the status of the fuzz run which determines if we want to fail the build or not, otherwise we'd get the results of tee
   if [ "${PIPESTATUS[0]}" == 1 ]; then
     FUZZ_RUN_FAILURE=1
   fi
 
   # The libfuzzer logs are written to the current working directory and need to be moved after the test is done
-  mv ./*.log  "${FUZZ_RUN_LOGS}/."
+  mv ./*.log  "${LOCAL_FUZZ_RUN_LOGS}/."
 
   if [ "$FUZZ_RUN_FAILURE" == 1 ]; then
-    FUZZ_TEST_FAILURE_ROOT="${FAILURE_ROOT}/${FUZZ_NAME}"
+    FUZZ_TEST_FAILURE_ROOT="${SHARED_FAILURE_ROOT}/${FUZZ_NAME}"
     mkdir -p "$FUZZ_TEST_FAILURE_ROOT"
 
     if [[ "$FUZZ_NAME" == "cryptofuzz" ]]; then
-      for ARTIFACT in "$ARTIFACTS_FOLDER"/*; do
+      for ARTIFACT in "$LOCAL_ARTIFACTS_FOLDER"/*; do
         ARTIFACT_NAME=$(basename "$ARTIFACT")
-        "${FUZZ_TEST_PATH}" --debug "$ARTIFACT" | tee "${FUZZ_RUN_LOGS}/${ARTIFACT_NAME}.log"
+        "${FUZZ_TEST_PATH}" --debug "$ARTIFACT" | tee "${LOCAL_FUZZ_RUN_LOGS}/${ARTIFACT_NAME}.log"
       done
     fi
 
-    cp -r "$FUZZ_TEST_ROOT" "$FAILURE_ROOT"
+    cp -r "$LOCAL_FUZZ_TEST_ROOT" "$SHARED_FAILURE_ROOT"
     cp "$FUZZ_TEST_PATH" "${FUZZ_TEST_FAILURE_ROOT}/${FUZZ_NAME}"
 
-    # If this fuzz run has failed the below metrics wont make a lot of sense, it could fail on the first input and
+    # If this fuzz run has failed the below metrics won't make a lot of sense, it could fail on the first input and
     # publish a TestCount of 1 which makes all the metrics look weird
-    echo "${FUZZ_NAME} failed, see the above output for details. For all the logs see ${FAILURE_ROOT} in EFS"
+    echo "${FUZZ_NAME} failed, see the above output for details. For all the logs see ${SHARED_FAILURE_ROOT} in EFS"
     exit 1
   else
     echo "Fuzz test ${FUZZ_NAME} finished successfully, not copying run logs and run corpus"
@@ -106,16 +106,18 @@ function run_fuzz_test {
 
   set -e
 
-  # Step 2 merge any new files from the run corpus and GitHub src corpus into the shared corpus (EFS)
-  time "${FUZZ_TEST_PATH}" -merge=1 "$SHARED_CORPUS" "$FUZZ_TEST_CORPUS" "$SRC_CORPUS"
+  # Step 2 merge any new files from the run corpus and GitHub src corpus into the shared corpus, the first folder is
+  # where to merge the new corpus (SHARED_FUZZ_TEST_CORPUS), the second two are where to read new inputs from
+  # ($LOCAL_RUN_CORPU and SRC_CORPUS).
+  time "${FUZZ_TEST_PATH}" -merge=1 "$SHARED_FUZZ_TEST_CORPUS" "$LOCAL_RUN_CORPUS" "$SRC_CORPUS"
 
-  # Calculate interesting metrics and post results to CloudWatch, this checks the shared EFS corpus after the new test
+  # Calculate interesting metrics and post results to CloudWatch, this checks the shared (EFS) corpus after the new test
   # run corpus has been merged in
-  FINAL_SHARED_CORPUS_FILE_COUNT=$(find "$SHARED_CORPUS" -type f | wc -l)
+  FINAL_SHARED_CORPUS_FILE_COUNT=$(find "$SHARED_FUZZ_TEST_CORPUS" -type f | wc -l)
   put_metric_count --metric-name SharedCorpusFileCount --value "$FINAL_SHARED_CORPUS_FILE_COUNT" --dimensions "FuzzTest=$FUZZ_NAME"
 
-  NEW_FUZZ_FILES=$(find "$FUZZ_TEST_CORPUS" -type f | wc -l)
-  put_metric_count --metric-name RunCorpusFileCount --value "$NEW_FUZZ_FILES" --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
+  RUN_CORPUS_FILE_COUNT=$(find "$LOCAL_RUN_CORPUS" -type f | wc -l)
+  put_metric_count --metric-name RunCorpusFileCount --value "$RUN_CORPUS_FILE_COUNT" --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
 
   TEST_COUNT=$(grep -o "stat::number_of_executed_units: [0-9]*" "$SUMMARY_LOG" | awk '{test_count += $2} END {print test_count}')
   put_metric_count --metric-name TestCount --value "$TEST_COUNT" --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
@@ -129,5 +131,5 @@ function run_fuzz_test {
   BLOCK_COVERAGE=$(grep -o "cov: [0-9]*" "$SUMMARY_LOG" | awk '{print $2}' | sort -n | tail -1)
   put_metric_count --metric-name BlockCoverage --value "$BLOCK_COVERAGE" --dimensions "FuzzTest=$FUZZ_NAME,Platform=$PLATFORM"
 
-  echo "${FUZZ_NAME} starting shared ${ORIGINAL_SHARED_CORPUS_FILE_COUNT} final shared ${FINAL_SHARED_CORPUS_FILE_COUNT} new files ${NEW_FUZZ_FILES} total test count ${TEST_COUNT} test rate ${TESTS_PER_SECOND} code coverage ${BLOCK_COVERAGE} feature coverage ${FEATURE_COVERAGE}"
+  echo "${FUZZ_NAME} starting shared ${ORIGINAL_CORPUS_FILE_COUNT} final shared ${FINAL_SHARED_CORPUS_FILE_COUNT} new files ${RUN_CORPUS_FILE_COUNT} total test count ${TEST_COUNT} test rate ${TESTS_PER_SECOND} code coverage ${BLOCK_COVERAGE} feature coverage ${FEATURE_COVERAGE}"
 }


### PR DESCRIPTION
### Description of changes: 
Previously all shared corpus operations required reading from EFS including each thread of libfuzzer. This results in a lot of EFS capacity utilization and possible some slow downs. This change copies the shared corpus to each CodeBuild job host one time, uses the local copy and then merges back to the shared EFS corpus.

### Call-outs:
This is a draft PR and I want to collect data on average build runtime before and after this change. The question is how does the extra copy time compare to the advantage of local file reads, and how does that impact EFS utilization? 

### Testing:
I tested the change by running the script in local mode and checking the contents of `mock_efs` and `fuzz_run_root`.

Copying the Cryptofuzz corpus (the largest one) to CodeBuild takes 28 seconds, but it saves 10 seconds to count the files for the before metric, about 10 seconds to load each thread for libfuzzer (8 in total) and overall speeds up the build from ~90 minutes down to ~80 minutes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
