### PR TITLE
Ensure self tests execute before we calculate hash and remove BORINGSSL_FIPS_SELF_TEST_FLAG_FILE  

### DIFF
--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -208,6 +208,13 @@ BORINGSSL_bcm_power_on_self_test(void) {
   assert_within(rodata_start, kP256Params, rodata_end);
   assert_within(rodata_start, kPKCS1SigPrefixes, rodata_end);
 
+  // Per FIPS 140-3 we have to perform the CAST of the HMAC used for integrity
+  // check before the integrity check itself. So we first call the self-test
+  // before we calculate the hash of the module.
+  if (!boringssl_fips_self_test()) {
+    goto err;
+  }
+
   uint8_t result[SHA256_DIGEST_LENGTH];
   const EVP_MD *const kHashFunction = EVP_sha256();
 
@@ -244,19 +251,12 @@ BORINGSSL_bcm_power_on_self_test(void) {
 
   const uint8_t *expected = BORINGSSL_bcm_text_hash;
 
-  // Per FIPS 140-3 we have to perform the CAST of the HMAC used for integrity
-  // check before the integrity check itself. So we first call the self-test
-  // function and only after that we check the integrity of the module.
-  if (!boringssl_fips_self_test(BORINGSSL_bcm_text_hash, sizeof(result))) {
-    goto err;
-  }
-
   if (!check_test(expected, result, sizeof(result), "FIPS integrity test")) {
     goto err;
   }
 
 #else
-  if (!BORINGSSL_self_test()) {
+  if (!boringssl_fips_self_test()) {
     goto err;
   }
 #endif  // OPENSSL_ASAN

--- a/crypto/fipsmodule/self_check/self_check.c
+++ b/crypto/fipsmodule/self_check/self_check.c
@@ -48,19 +48,6 @@ int BORINGSSL_self_test(void) {
 #else
 
 #if defined(BORINGSSL_FIPS) && defined(OPENSSL_ANDROID)
-// FIPS builds on Android will test for flag files, named after the module hash,
-// in /dev/boringssl/selftest/. If such a flag file exists, it's assumed that
-// self-tests have already passed and thus do not need to be repeated. (The
-// integrity tests always run, however.)
-//
-// If self-tests complete successfully and the environment variable named in
-// |kFlagWriteEnableEnvVar| is present, then the flag file will be created. The
-// flag file isn't written without the environment variable being set in order
-// to avoid SELinux violations on Android.
-#define BORINGSSL_FIPS_SELF_TEST_FLAG_FILE
-static const char kFlagPrefix[] = "/dev/boringssl/selftest/";
-static const char kFlagWriteEnableEnvVar[] = "BORINGSSL_SELF_TEST_CREATE_FLAG";
-#endif
 
 static void hexdump(const uint8_t *in, size_t len) {
   for (size_t i = 0; i < len; i++) {
@@ -404,35 +391,7 @@ err:
 
 static const size_t kModuleDigestSize = SHA256_DIGEST_LENGTH;
 
-int boringssl_fips_self_test(
-    const uint8_t *module_hash, size_t module_hash_len) {
-#if defined(BORINGSSL_FIPS_SELF_TEST_FLAG_FILE)
-  char flag_path[sizeof(kFlagPrefix) + 2*kModuleDigestSize];
-  if (module_hash_len != 0) {
-    if (module_hash_len != kModuleDigestSize) {
-      fprintf(stderr,
-              "module hash of length %zu does not match expected length %zu\n",
-              module_hash_len, kModuleDigestSize);
-      BORINGSSL_FIPS_abort();
-    }
-
-    // Test whether the flag file exists.
-    memcpy(flag_path, kFlagPrefix, sizeof(kFlagPrefix) - 1);
-    static const char kHexTable[17] = "0123456789abcdef";
-    for (size_t i = 0; i < kModuleDigestSize; i++) {
-      flag_path[sizeof(kFlagPrefix) - 1 + 2 * i] =
-          kHexTable[module_hash[i] >> 4];
-      flag_path[sizeof(kFlagPrefix) - 1 + 2 * i + 1] =
-          kHexTable[module_hash[i] & 15];
-    }
-    flag_path[sizeof(flag_path) - 1] = 0;
-
-    if (access(flag_path, F_OK) == 0) {
-      // Flag file found. Skip self-tests.
-      return 1;
-    }
-  }
-#endif // BORINGSSL_FIPS_SELF_TEST_FLAG_FILE
+int boringssl_fips_self_test() {
 
   static const uint8_t kAESKey[16] = "BoringCrypto Key";
   static const uint8_t kAESIV[16] = {0};
@@ -1029,16 +988,6 @@ int boringssl_fips_self_test(
 
   ret = 1;
 
-#if defined(BORINGSSL_FIPS_SELF_TEST_FLAG_FILE)
-  // Tests were successful. Write flag file if requested.
-  if (module_hash_len != 0 && getenv(kFlagWriteEnableEnvVar) != NULL) {
-    const int fd = open(flag_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-    if (fd >= 0) {
-      close(fd);
-    }
-  }
-#endif  // BORINGSSL_FIPS_SELF_TEST_FLAG_FILE
-
 err:
   EVP_AEAD_CTX_cleanup(&aead_ctx);
   RSA_free(rsa_key);
@@ -1050,10 +999,6 @@ err:
   ECDSA_SIG_free(sig);
 
   return ret;
-}
-
-int BORINGSSL_self_test(void) {
-  return boringssl_fips_self_test(NULL, 0);
 }
 
 #endif  // !_MSC_VER

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -905,12 +905,8 @@ void BORINGSSL_FIPS_abort(void) __attribute__((noreturn));
 #endif
 
 // boringssl_fips_self_test runs the FIPS KAT-based self tests. It returns one
-// on success and zero on error. The argument is the integrity hash of the FIPS
-// module and may be used to check and write flag files to suppress duplicate
-// self-tests. If |module_hash_len| is zero then no flag file will be checked
-// nor written and tests will always be run.
-int boringssl_fips_self_test(const uint8_t *module_hash,
-                             size_t module_hash_len);
+// on success and zero on error.
+int boringssl_fips_self_test(void);
 
 #if defined(BORINGSSL_FIPS_COUNTERS)
 void boringssl_fips_inc_counter(enum fips_counter_t counter);


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-885

### Description of changes: 
This change fixes two issues with our self tests
1) The self tests need to occur before the hash is calculated for the integrity tests
2) We need to remove the BORINGSSL_FIPS_SELF_TEST_FLAG_FILE feature, which allows us to persist the results of a previous health check to disk so we can bypass it in the future.  This feature was added based on FIPS 140-2 IG 9.11, which was not carry forward into 140-3. 

### Call-outs:
N/A

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
