### PR TITLE
Revert "Disable HRSS AVX2 optimisation on X86_64. Valgrind is trippin…

### DIFF
--- a/crypto/hrss/internal.h
+++ b/crypto/hrss/internal.h
@@ -41,17 +41,11 @@ OPENSSL_EXPORT void HRSS_poly3_mul(struct poly3 *out, const struct poly3 *x,
 OPENSSL_EXPORT void HRSS_poly3_invert(struct poly3 *out,
                                       const struct poly3 *in);
 
-// Disable AVX2 optimisation for HRSS because of memory over read.
-// |a| parameter passed in is of size |N+3| = 1408. But the ASM code reads
-// past this e.g. https://github.com/awslabs/aws-lc/blob/52de7a54c5971419bd465eb6d52e3ecd2a8a11fd/crypto/hrss/asm/poly_rq_mul.S#L743
-#define DISABLE_HRSS_X86_64_AVX2
-
 // On x86-64, we can use the AVX2 code from [HRSS]. (The authors have given
 // explicit permission for this and signed a CLA.) However it's 57KB of object
 // code, so it's not used if |OPENSSL_SMALL| is defined.
 #if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && \
-    defined(OPENSSL_X86_64) && defined(OPENSSL_LINUX) && \
-    !defined(DISABLE_HRSS_X86_64_AVX2)
+    defined(OPENSSL_X86_64) && defined(OPENSSL_LINUX)
 #define POLY_RQ_MUL_ASM
 // POLY_MUL_RQ_SCRATCH_SPACE is the number of bytes of scratch space needed
 // by the assembly function poly_Rq_mul.


### PR DESCRIPTION
…g on a potential memory error."

This reverts commit 22ff8b801a790238544384ffdbfeb945f9b3cd30.
We have already merged
https://boringssl.googlesource.com/boringssl/+/f1d153dc3619eaea7fac176716c53824f5584830
which fixes the underlying issue so we should be able to enable HRSS
AVX2 optimizations on X86_64 again

### Issues:
None

### Description of changes: 
This re-enables the AVX2 optimizations on X86_64. Previously these optimizations were disabled because of a bug that caused us to access memory out of bounds, but since that bug has been addressed already in a merge from BoringSSL we can enable this again

### Call-outs:
This should be fairly straightforward, I'd recommend double checking that the BoringSSL merge actually addressed this problem if you are skeptical.

### Testing:
I ran the tests on my own Amazon Linux 2 host with an x86_64 processor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
