### PR TITLE
Change __int128 to __int128_t in fiat/p384_64.h

### DIFF
--- a/third_party/fiat/p384_64.h
+++ b/third_party/fiat/p384_64.h
@@ -18,14 +18,9 @@
 #include <stdint.h>
 typedef unsigned char fiat_p384_uint1;
 typedef signed char fiat_p384_int1;
-#ifdef __GNUC__
-#  define FIAT_P384_FIAT_EXTENSION __extension__
-#else
-#  define FIAT_P384_FIAT_EXTENSION
-#endif
-
-FIAT_P384_FIAT_EXTENSION typedef signed __int128 fiat_p384_int128;
-FIAT_P384_FIAT_EXTENSION typedef unsigned __int128 fiat_p384_uint128;
+// Pedantic warnings can be disabled by adding prefix __extension__.
+__extension__ typedef __int128_t fiat_p384_int128;
+__extension__ typedef __uint128_t fiat_p384_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Change `__int128` to `__int128_t` in `fiat/p384_64.h` because gcc 4.1.2 defines only the latter.

### Call-outs:
N/A

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
