### PR TITLE
Replace EVP_aead_aes_128/256_gcm with EVP_aead_aes_128/256_gcm_tls12 in ACVP test.

### DIFF
--- a/util/fipstools/acvp/modulewrapper/modulewrapper.cc
+++ b/util/fipstools/acvp/modulewrapper/modulewrapper.cc
@@ -1057,13 +1057,13 @@ static bool AESGCMSetup(EVP_AEAD_CTX *ctx, Span<const uint8_t> tag_len_span,
     // External IVs
     switch (key.size()) {
       case 16:
-        aead = EVP_aead_aes_128_gcm_tls13();
+        aead = EVP_aead_aes_128_gcm_tls12();
         break;
       case 24:
         aead = EVP_aead_aes_192_gcm();
         break;
       case 32:
-        aead = EVP_aead_aes_256_gcm_tls13();
+        aead = EVP_aead_aes_256_gcm_tls12();
         break;
       default:
         LOG_ERROR("Bad AES-GCM key length %u\n",

--- a/util/fipstools/acvp/modulewrapper/modulewrapper.cc
+++ b/util/fipstools/acvp/modulewrapper/modulewrapper.cc
@@ -1057,13 +1057,13 @@ static bool AESGCMSetup(EVP_AEAD_CTX *ctx, Span<const uint8_t> tag_len_span,
     // External IVs
     switch (key.size()) {
       case 16:
-        aead = EVP_aead_aes_128_gcm();
+        aead = EVP_aead_aes_128_gcm_tls13();
         break;
       case 24:
         aead = EVP_aead_aes_192_gcm();
         break;
       case 32:
-        aead = EVP_aead_aes_256_gcm();
+        aead = EVP_aead_aes_256_gcm_tls13();
         break;
       default:
         LOG_ERROR("Bad AES-GCM key length %u\n",


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-902

### Description of changes: 
This PR replaced `EVP_aead_aes_128/256_gcm` with `EVP_aead_aes_128/256_gcm_tls12` in ACVP test based on the FIPS validation lab request. 

### Call-outs:
* `EVP_aead_aes_192_gcm` is not used in s2n/TLS RFC. awslc does not have related tls API.
  * https://datatracker.ietf.org/doc/html/rfc5288
  * https://datatracker.ietf.org/doc/html/rfc8446#section-9.1

### Testing:
CI. `./util/fipstools/acvp/acvptool/test/vectors/ACVP-AES-GCM.bz2` includes the external IV test data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
