### PR TITLE
Test EC_KEY_generate_key_fips failure case in FIPS and non-FIPS builds

### DIFF
--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1107,6 +1107,114 @@ TEST(ECTest, BrainpoolP256r1) {
   EXPECT_EQ(0, BN_cmp(y.get(), qy.get()));
 }
 
+#if !defined(AWSLC_FIPS)
+TEST(ECTest, SmallGroup) {
+  // Make a P-224 key and corrupt the group order to be small in order to fail
+  // |EC_KEY_generate_key|.
+  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(NID_secp224r1));
+  ASSERT_TRUE(key);
+  ASSERT_TRUE(EC_KEY_generate_key(key.get()));
+
+  bssl::UniquePtr<EC_GROUP> group_org(EC_GROUP_new_by_curve_name(NID_secp224r1));
+  ASSERT_TRUE(group_org);
+  bssl::UniquePtr<BN_CTX> ctx(BN_CTX_new());
+  ASSERT_TRUE(ctx);
+  bssl::UniquePtr<BIGNUM> p(BN_new());
+  ASSERT_TRUE(p);
+  bssl::UniquePtr<BIGNUM> a(BN_new());
+  ASSERT_TRUE(a);
+  bssl::UniquePtr<BIGNUM> b(BN_new());
+  ASSERT_TRUE(b);
+  bssl::UniquePtr<BIGNUM> order(BN_new());
+  ASSERT_TRUE(order);
+  ASSERT_TRUE(BN_copy(order.get(), EC_GROUP_get0_order(group_org.get())));
+  ASSERT_TRUE(EC_GROUP_get_curve_GFp(group_org.get(),
+                                     p.get(), a.get(), b.get(), ctx.get()));
+
+  // Set a new group with p, a, b
+  bssl::UniquePtr<EC_GROUP> group(
+      EC_GROUP_new_curve_GFp(p.get(), a.get(), b.get(), ctx.get()));
+  ASSERT_TRUE(group);
+  // The generator has to be created using the new group so they match when calling
+  // |EC_GROUP_set_generator|
+  bssl::UniquePtr<EC_POINT> generator(EC_POINT_new(group.get()));
+  ASSERT_TRUE(generator);
+  // Get the original group's generator's coordinates.
+  bssl::UniquePtr<BIGNUM> gx(BN_new());
+  ASSERT_TRUE(gx);
+  bssl::UniquePtr<BIGNUM> gy(BN_new());
+  ASSERT_TRUE(gy);
+  EXPECT_TRUE(EC_POINT_get_affine_coordinates_GFp(
+      group_org.get(), EC_GROUP_get0_generator(group_org.get()), gx.get(), gy.get(), ctx.get()));
+  // Set the coordinates of the new generator.
+  ASSERT_TRUE(EC_POINT_set_affine_coordinates_GFp(
+      group.get(), generator.get(), gx.get(), gy.get(), ctx.get()));
+  ASSERT_TRUE(EC_GROUP_set_generator(group.get(), generator.get(), order.get(),
+                                     BN_value_one()));
+
+  // Create a key2 with the new group and make the order value 7
+  bssl::UniquePtr<EC_KEY> key2(EC_KEY_new());
+  ASSERT_TRUE(key2);
+  ASSERT_TRUE(EC_KEY_set_group(key2.get(), group.get()));
+  BN_clear(&key2.get()->group->order);
+  ASSERT_TRUE(BN_set_word(&key2.get()->group->order, 7));
+  ASSERT_FALSE(EC_KEY_generate_key_fips(key2.get()));
+}
+#else
+TEST(ECDeathTest, SmallGroupAndDie) {
+  // Make a P-224 key and corrupt the group order to be small in order to fail
+  // |EC_KEY_generate_key|.
+  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(NID_secp224r1));
+  ASSERT_TRUE(key);
+  ASSERT_TRUE(EC_KEY_generate_key(key.get()));
+
+  bssl::UniquePtr<EC_GROUP> group_org(EC_GROUP_new_by_curve_name(NID_secp224r1));
+  ASSERT_TRUE(group_org);
+  bssl::UniquePtr<BN_CTX> ctx(BN_CTX_new());
+  ASSERT_TRUE(ctx);
+  bssl::UniquePtr<BIGNUM> p(BN_new());
+  ASSERT_TRUE(p);
+  bssl::UniquePtr<BIGNUM> a(BN_new());
+  ASSERT_TRUE(a);
+  bssl::UniquePtr<BIGNUM> b(BN_new());
+  ASSERT_TRUE(b);
+  bssl::UniquePtr<BIGNUM> order(BN_new());
+  ASSERT_TRUE(order);
+  ASSERT_TRUE(BN_copy(order.get(), EC_GROUP_get0_order(group_org.get())));
+  ASSERT_TRUE(EC_GROUP_get_curve_GFp(group_org.get(),
+                                     p.get(), a.get(), b.get(), ctx.get()));
+
+  // Set a new group with p, a, b
+  bssl::UniquePtr<EC_GROUP> group(
+      EC_GROUP_new_curve_GFp(p.get(), a.get(), b.get(), ctx.get()));
+  ASSERT_TRUE(group);
+  // The generator has to be created using the new group so they match when calling
+  // |EC_GROUP_set_generator|
+  bssl::UniquePtr<EC_POINT> generator(EC_POINT_new(group.get()));
+  ASSERT_TRUE(generator);
+  // Get the original group's generator's coordinates.
+  bssl::UniquePtr<BIGNUM> gx(BN_new());
+  ASSERT_TRUE(gx);
+  bssl::UniquePtr<BIGNUM> gy(BN_new());
+  ASSERT_TRUE(gy);
+  EXPECT_TRUE(EC_POINT_get_affine_coordinates_GFp(
+      group_org.get(), EC_GROUP_get0_generator(group_org.get()), gx.get(), gy.get(), ctx.get()));
+  // Set the coordinates of the new generator.
+  ASSERT_TRUE(EC_POINT_set_affine_coordinates_GFp(
+      group.get(), generator.get(), gx.get(), gy.get(), ctx.get()));
+  ASSERT_TRUE(EC_GROUP_set_generator(group.get(), generator.get(), order.get(),
+                                     BN_value_one()));
+
+  // Create a key2 with the new group and make the order value 7
+  bssl::UniquePtr<EC_KEY> key2(EC_KEY_new());
+  ASSERT_TRUE(key2);
+  ASSERT_TRUE(EC_KEY_set_group(key2.get(), group.get()));
+  BN_clear(&key2.get()->group->order);
+  ASSERT_TRUE(BN_set_word(&key2.get()->group->order, 7));
+  ASSERT_DEATH(EC_KEY_generate_key_fips(key2.get()), "");
+}
+#endif
+
 class ECCurveTest : public testing::TestWithParam<EC_builtin_curve> {
  public:
   const EC_GROUP *group() const { return group_.get(); }

--- a/crypto/rsa_extra/rsa_test.cc
+++ b/crypto/rsa_extra/rsa_test.cc
@@ -639,7 +639,7 @@ TEST(RSATest, BadExponent) {
   ERR_clear_error();
 }
 
-#if !defined(BORINGSSL_FIPS)
+#if !defined(AWSLC_FIPS)
 // Attempting to generate an excessively small key should fail.
 TEST(RSATest, GenerateSmallKey) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
@@ -656,7 +656,7 @@ TEST(RSATest, GenerateSmallKey) {
 #else
 // Attempting to generate an excessively small key should fail.
 // In the case of a FIPS build, expect abort() when |RSA_generate_key_ex| fails.
-TEST(RSADeathTest, GenerateSmallKeyDeath) {
+TEST(RSADeathTest, GenerateSmallKeyAndDie) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
   ASSERT_TRUE(rsa);
   bssl::UniquePtr<BIGNUM> e(BN_new());
@@ -919,7 +919,7 @@ TEST(RSATest, CheckKey) {
   ASSERT_TRUE(BN_sub(rsa->iqmp, rsa->iqmp, rsa->p));
 }
 
-#if !defined(BORINGSSL_FIPS)
+#if !defined(AWSLC_FIPS)
 TEST(RSATest, KeygenFail) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
   ASSERT_TRUE(rsa);
@@ -1010,7 +1010,7 @@ TEST(RSATest, KeygenFailOnce) {
 
 #else
 // In the case of a FIPS build, expect abort() when |RSA_generate_key_ex| fails.
-TEST(RSADeathTest, KeygenFail) {
+TEST(RSADeathTest, KeygenFailAndDie) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
   ASSERT_TRUE(rsa);
 
@@ -1071,7 +1071,7 @@ TEST(RSADeathTest, KeygenFail) {
   EXPECT_NE(Bytes(der, der_len), Bytes(der3, der3_len));
 }
 
-TEST(RSADeathTest, KeygenFailOnce) {
+TEST(RSADeathTest, KeygenFailOnceAndDie) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
   ASSERT_TRUE(rsa);
 


### PR DESCRIPTION
### Issues:
Addresses #CryptoAlg-908

### Description of changes: 
This commits continues 6bdd4c340 (Abort when RSA or EC key generation fail (#324)) by adding to ECTest a failure case for `EC_KEY_generate_key_fips` which fails in non-FIPS builds and aborts in FIPS builds.

### Call-outs:
Attempting to make this test simpler by setting the group order directly in `key` causes other tests because it actually changes the group order of the P-224 curve. See this [TODO in ec.c about making the built-in groups actually static](https://github.com/awslabs/aws-lc/blob/6bdd4c3403a17f85cf8cee0a245f220c5c0c28e5/crypto/fipsmodule/ec/ec.c#L499-L500).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
