### PR TITLE
Add Arm CPU capabilities environment variable override

### DIFF
--- a/crypto/cpu-aarch64-linux.c
+++ b/crypto/cpu-aarch64-linux.c
@@ -96,12 +96,20 @@ void OPENSSL_cpuid_setup(void) {
     OPENSSL_armcap_P |= ARMV8_SHA256;
   }
 
+  // OPENSSL_armcap_P is a 32-bit, unsigned value which may start with "0x" to
+  // indicate a hex value. Prior to the 32-bit value, a '~' or '|' may be given.
+  //
+  // If the '~' prefix is present:
+  //   the value is inverted and ANDed with the probed CPUID result
+  // If the '|' prefix is present:
+  //   the value is ORed with the probed CPUID result
+  // Otherwise:
+  //   the value is taken as the result of the CPUID
   const char *env;
   env = getenv("OPENSSL_armcap_P");
-  if (env == NULL) {
-    return;
+  if (env != NULL) {
+    handle_cpu_env(&OPENSSL_armcap_P, env);
   }
-  handle_cpu_env(&OPENSSL_armcap_P, env);
 }
 
 #endif  // OPENSSL_AARCH64 && !OPENSSL_STATIC_ARMCAP


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Add Arm CPU capabilities environment variable override.

### Call-outs:
The effect of the change can be checked for example by comparing the speed of SHA-256 when run with `bssl speed SHA-256` and `export OPENSSL_armcap_P=0 && bssl speed SHA-256`.



### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
