### PR TITLE
cherry-pick to fips-2021-10-20: Abort when RSA and EC keygen fail

### DIFF
--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1108,7 +1108,7 @@ TEST(ECTest, BrainpoolP256r1) {
 }
 
 #if !defined(AWSLC_FIPS)
-TEST(ECTest, SmallGroup) {
+TEST(ECTest, SmallGroupOrder) {
   // Make a P-224 key and corrupt the group order to be small in order to fail
   // |EC_KEY_generate_key|.
   bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(NID_secp224r1));
@@ -1161,7 +1161,7 @@ TEST(ECTest, SmallGroup) {
   ASSERT_FALSE(EC_KEY_generate_key_fips(key2.get()));
 }
 #else
-TEST(ECDeathTest, SmallGroupAndDie) {
+TEST(ECDeathTest, SmallGroupOrderAndDie) {
   // Make a P-224 key and corrupt the group order to be small in order to fail
   // |EC_KEY_generate_key|.
   bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(NID_secp224r1));

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1107,6 +1107,114 @@ TEST(ECTest, BrainpoolP256r1) {
   EXPECT_EQ(0, BN_cmp(y.get(), qy.get()));
 }
 
+#if !defined(AWSLC_FIPS)
+TEST(ECTest, SmallGroup) {
+  // Make a P-224 key and corrupt the group order to be small in order to fail
+  // |EC_KEY_generate_key|.
+  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(NID_secp224r1));
+  ASSERT_TRUE(key);
+  ASSERT_TRUE(EC_KEY_generate_key(key.get()));
+
+  bssl::UniquePtr<EC_GROUP> group_org(EC_GROUP_new_by_curve_name(NID_secp224r1));
+  ASSERT_TRUE(group_org);
+  bssl::UniquePtr<BN_CTX> ctx(BN_CTX_new());
+  ASSERT_TRUE(ctx);
+  bssl::UniquePtr<BIGNUM> p(BN_new());
+  ASSERT_TRUE(p);
+  bssl::UniquePtr<BIGNUM> a(BN_new());
+  ASSERT_TRUE(a);
+  bssl::UniquePtr<BIGNUM> b(BN_new());
+  ASSERT_TRUE(b);
+  bssl::UniquePtr<BIGNUM> order(BN_new());
+  ASSERT_TRUE(order);
+  ASSERT_TRUE(BN_copy(order.get(), EC_GROUP_get0_order(group_org.get())));
+  ASSERT_TRUE(EC_GROUP_get_curve_GFp(group_org.get(),
+                                     p.get(), a.get(), b.get(), ctx.get()));
+
+  // Set a new group with p, a, b
+  bssl::UniquePtr<EC_GROUP> group(
+      EC_GROUP_new_curve_GFp(p.get(), a.get(), b.get(), ctx.get()));
+  ASSERT_TRUE(group);
+  // The generator has to be created using the new group so they match when calling
+  // |EC_GROUP_set_generator|
+  bssl::UniquePtr<EC_POINT> generator(EC_POINT_new(group.get()));
+  ASSERT_TRUE(generator);
+  // Get the original group's generator's coordinates.
+  bssl::UniquePtr<BIGNUM> gx(BN_new());
+  ASSERT_TRUE(gx);
+  bssl::UniquePtr<BIGNUM> gy(BN_new());
+  ASSERT_TRUE(gy);
+  EXPECT_TRUE(EC_POINT_get_affine_coordinates_GFp(
+      group_org.get(), EC_GROUP_get0_generator(group_org.get()), gx.get(), gy.get(), ctx.get()));
+  // Set the coordinates of the new generator.
+  ASSERT_TRUE(EC_POINT_set_affine_coordinates_GFp(
+      group.get(), generator.get(), gx.get(), gy.get(), ctx.get()));
+  ASSERT_TRUE(EC_GROUP_set_generator(group.get(), generator.get(), order.get(),
+                                     BN_value_one()));
+
+  // Create a key2 with the new group and make the order value 7
+  bssl::UniquePtr<EC_KEY> key2(EC_KEY_new());
+  ASSERT_TRUE(key2);
+  ASSERT_TRUE(EC_KEY_set_group(key2.get(), group.get()));
+  BN_clear(&key2.get()->group->order);
+  ASSERT_TRUE(BN_set_word(&key2.get()->group->order, 7));
+  ASSERT_FALSE(EC_KEY_generate_key_fips(key2.get()));
+}
+#else
+TEST(ECDeathTest, SmallGroupAndDie) {
+  // Make a P-224 key and corrupt the group order to be small in order to fail
+  // |EC_KEY_generate_key|.
+  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(NID_secp224r1));
+  ASSERT_TRUE(key);
+  ASSERT_TRUE(EC_KEY_generate_key(key.get()));
+
+  bssl::UniquePtr<EC_GROUP> group_org(EC_GROUP_new_by_curve_name(NID_secp224r1));
+  ASSERT_TRUE(group_org);
+  bssl::UniquePtr<BN_CTX> ctx(BN_CTX_new());
+  ASSERT_TRUE(ctx);
+  bssl::UniquePtr<BIGNUM> p(BN_new());
+  ASSERT_TRUE(p);
+  bssl::UniquePtr<BIGNUM> a(BN_new());
+  ASSERT_TRUE(a);
+  bssl::UniquePtr<BIGNUM> b(BN_new());
+  ASSERT_TRUE(b);
+  bssl::UniquePtr<BIGNUM> order(BN_new());
+  ASSERT_TRUE(order);
+  ASSERT_TRUE(BN_copy(order.get(), EC_GROUP_get0_order(group_org.get())));
+  ASSERT_TRUE(EC_GROUP_get_curve_GFp(group_org.get(),
+                                     p.get(), a.get(), b.get(), ctx.get()));
+
+  // Set a new group with p, a, b
+  bssl::UniquePtr<EC_GROUP> group(
+      EC_GROUP_new_curve_GFp(p.get(), a.get(), b.get(), ctx.get()));
+  ASSERT_TRUE(group);
+  // The generator has to be created using the new group so they match when calling
+  // |EC_GROUP_set_generator|
+  bssl::UniquePtr<EC_POINT> generator(EC_POINT_new(group.get()));
+  ASSERT_TRUE(generator);
+  // Get the original group's generator's coordinates.
+  bssl::UniquePtr<BIGNUM> gx(BN_new());
+  ASSERT_TRUE(gx);
+  bssl::UniquePtr<BIGNUM> gy(BN_new());
+  ASSERT_TRUE(gy);
+  EXPECT_TRUE(EC_POINT_get_affine_coordinates_GFp(
+      group_org.get(), EC_GROUP_get0_generator(group_org.get()), gx.get(), gy.get(), ctx.get()));
+  // Set the coordinates of the new generator.
+  ASSERT_TRUE(EC_POINT_set_affine_coordinates_GFp(
+      group.get(), generator.get(), gx.get(), gy.get(), ctx.get()));
+  ASSERT_TRUE(EC_GROUP_set_generator(group.get(), generator.get(), order.get(),
+                                     BN_value_one()));
+
+  // Create a key2 with the new group and make the order value 7
+  bssl::UniquePtr<EC_KEY> key2(EC_KEY_new());
+  ASSERT_TRUE(key2);
+  ASSERT_TRUE(EC_KEY_set_group(key2.get(), group.get()));
+  BN_clear(&key2.get()->group->order);
+  ASSERT_TRUE(BN_set_word(&key2.get()->group->order, 7));
+  ASSERT_DEATH(EC_KEY_generate_key_fips(key2.get()), "");
+}
+#endif
+
 class ECCurveTest : public testing::TestWithParam<EC_builtin_curve> {
  public:
   const EC_GROUP *group() const { return group_.get(); }

--- a/crypto/fipsmodule/rsa/rsa_impl.c
+++ b/crypto/fipsmodule/rsa/rsa_impl.c
@@ -1380,6 +1380,11 @@ static int RSA_generate_key_ex_maybe_fips(RSA *rsa, int bits,
 
 out:
   RSA_free(tmp);
+#if defined(BORINGSSL_FIPS)
+  if (ret == 0) {
+    BORINGSSL_FIPS_abort();
+  }
+#endif
   return ret;
 }
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -898,10 +898,13 @@ static inline void CRYPTO_store_word_le(void *out, crypto_word_t v) {
 // FIPS functions.
 
 #if defined(BORINGSSL_FIPS)
+#define MAX_PCT_ATTEMPTS  5
 // BORINGSSL_FIPS_abort is called when a FIPS power-on or continuous test
 // fails. It prevents any further cryptographic operations by the current
 // process.
 void BORINGSSL_FIPS_abort(void) __attribute__((noreturn));
+#else
+#define MAX_PCT_ATTEMPTS  1
 #endif
 
 // boringssl_fips_self_test runs the FIPS KAT-based self tests. It returns one

--- a/crypto/rsa_extra/rsa_test.cc
+++ b/crypto/rsa_extra/rsa_test.cc
@@ -639,7 +639,7 @@ TEST(RSATest, BadExponent) {
   ERR_clear_error();
 }
 
-#if !defined(BORINGSSL_FIPS)
+#if !defined(AWSLC_FIPS)
 // Attempting to generate an excessively small key should fail.
 TEST(RSATest, GenerateSmallKey) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
@@ -656,7 +656,7 @@ TEST(RSATest, GenerateSmallKey) {
 #else
 // Attempting to generate an excessively small key should fail.
 // In the case of a FIPS build, expect abort() when |RSA_generate_key_ex| fails.
-TEST(RSADeathTest, GenerateSmallKeyDeath) {
+TEST(RSADeathTest, GenerateSmallKeyAndDie) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
   ASSERT_TRUE(rsa);
   bssl::UniquePtr<BIGNUM> e(BN_new());
@@ -919,7 +919,7 @@ TEST(RSATest, CheckKey) {
   ASSERT_TRUE(BN_sub(rsa->iqmp, rsa->iqmp, rsa->p));
 }
 
-#if !defined(BORINGSSL_FIPS)
+#if !defined(AWSLC_FIPS)
 TEST(RSATest, KeygenFail) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
   ASSERT_TRUE(rsa);
@@ -1010,7 +1010,7 @@ TEST(RSATest, KeygenFailOnce) {
 
 #else
 // In the case of a FIPS build, expect abort() when |RSA_generate_key_ex| fails.
-TEST(RSADeathTest, KeygenFail) {
+TEST(RSADeathTest, KeygenFailAndDie) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
   ASSERT_TRUE(rsa);
 
@@ -1071,7 +1071,7 @@ TEST(RSADeathTest, KeygenFail) {
   EXPECT_NE(Bytes(der, der_len), Bytes(der3, der3_len));
 }
 
-TEST(RSADeathTest, KeygenFailOnce) {
+TEST(RSADeathTest, KeygenFailOnceAndDie) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
   ASSERT_TRUE(rsa);
 


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-908

### Description of changes: 
It's required that the FIPS module aborts when PCT tests fail in `EC_KEY_generate_key_fips()` and `RSA_check_fips()`.
This change inserts the abort on failure after a certain number of attempts in the case of a FIPS build.

- In RSA, there existed a number of attempts already in the key generation.
There were also tests for the failure cases.
These tests are here repeated as part of the RSADeathTest suite when
built with -DFIPS=1 using ASSERT_DEATH.

- In EC, a number of attempts is introduced around the key generation and check.
And a failure test case for EC_KEY_generate_key_fips was added which fails in non-FIPS builds and aborts in FIPS builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
