### PR TITLE
Include the RSA PCT check in the number of keygen attempts.

### DIFF
--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -513,7 +513,7 @@ int EC_KEY_generate_key_fips(EC_KEY *eckey) {
     ret = EC_KEY_generate_key(eckey);
     ret &= EC_KEY_check_fips(eckey);
     num_attempts++;
-  } while (ret == 0 && num_attempts < MAX_KEYGEN_ATTEMPTS);
+  } while (ret == 0 && num_attempts < MAX_EC_KEYGEN_ATTEMPTS);
 
   FIPS_service_indicator_unlock_state();
   if (ret) {

--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -513,21 +513,20 @@ int EC_KEY_generate_key_fips(EC_KEY *eckey) {
     ret = EC_KEY_generate_key(eckey);
     ret &= EC_KEY_check_fips(eckey);
     num_attempts++;
-  } while (ret == 0 && num_attempts < MAX_PCT_ATTEMPTS);
+  } while (ret == 0 && num_attempts < MAX_KEYGEN_ATTEMPTS);
 
+  FIPS_service_indicator_unlock_state();
   if (ret) {
-    FIPS_service_indicator_unlock_state();
     FIPS_service_indicator_update_state();
     return 1;
   }
 
-  FIPS_service_indicator_unlock_state();
   EC_POINT_free(eckey->pub_key);
   ec_wrapped_scalar_free(eckey->priv_key);
   eckey->pub_key = NULL;
   eckey->priv_key = NULL;
 
-#if defined(BORINGSSL_FIPS)
+#if defined(AWSLC_FIPS)
   BORINGSSL_FIPS_abort();
 #else
   return 0;

--- a/crypto/fipsmodule/rsa/rsa_impl.c
+++ b/crypto/fipsmodule/rsa/rsa_impl.c
@@ -1329,7 +1329,8 @@ static int RSA_generate_key_ex_maybe_fips(RSA *rsa, int bits,
   int ret = 0;
 
   // |rsa_generate_key_impl|'s 2^-20 failure probability is too high at scale,
-  // so we run the FIPS algorithm four times, bringing it down to 2^-80. We
+  // so we run the FIPS algorithm |MAX_RSA_KEYGEN_ATTEMPTS| times,
+  // bringing it down to 2^-80 when it's equal to 4. We
   // should just adjust the retry limit, but FIPS 186-4 prescribes that value
   // and thus results in unnecessary complexity.
   int failures = 0;
@@ -1352,11 +1353,10 @@ static int RSA_generate_key_ex_maybe_fips(RSA *rsa, int bits,
     err = ERR_peek_error();
     RSA_free(tmp);
     tmp = NULL;
-    failures++;
 
     // Only retry on |RSA_R_TOO_MANY_ITERATIONS|. This is so a caller-induced
     // failure in |BN_GENCB_call| is still fatal.
-  } while (failures < MAX_KEYGEN_ATTEMPTS && ERR_GET_LIB(err) == ERR_LIB_RSA &&
+  } while (failures < MAX_RSA_KEYGEN_ATTEMPTS && ERR_GET_LIB(err) == ERR_LIB_RSA &&
            ERR_GET_REASON(err) == RSA_R_TOO_MANY_ITERATIONS);
 
   if (tmp == NULL) {

--- a/crypto/fipsmodule/rsa/rsa_impl.c
+++ b/crypto/fipsmodule/rsa/rsa_impl.c
@@ -1342,7 +1342,11 @@ static int RSA_generate_key_ex_maybe_fips(RSA *rsa, int bits,
     }
 
     if (rsa_generate_key_impl(tmp, bits, e_value, cb)) {
-      break;
+      if (check_fips && !RSA_check_fips(tmp)) {
+        failures++;
+      } else {
+        break;
+      }
     }
 
     err = ERR_peek_error();
@@ -1352,10 +1356,10 @@ static int RSA_generate_key_ex_maybe_fips(RSA *rsa, int bits,
 
     // Only retry on |RSA_R_TOO_MANY_ITERATIONS|. This is so a caller-induced
     // failure in |BN_GENCB_call| is still fatal.
-  } while (failures < 4 && ERR_GET_LIB(err) == ERR_LIB_RSA &&
+  } while (failures < MAX_KEYGEN_ATTEMPTS && ERR_GET_LIB(err) == ERR_LIB_RSA &&
            ERR_GET_REASON(err) == RSA_R_TOO_MANY_ITERATIONS);
 
-  if (tmp == NULL || (check_fips && !RSA_check_fips(tmp))) {
+  if (tmp == NULL) {
     goto out;
   }
 
@@ -1380,7 +1384,7 @@ static int RSA_generate_key_ex_maybe_fips(RSA *rsa, int bits,
 
 out:
   RSA_free(tmp);
-#if defined(BORINGSSL_FIPS)
+#if defined(AWSLC_FIPS)
   if (ret == 0) {
     BORINGSSL_FIPS_abort();
   }

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -936,14 +936,16 @@ static inline uint64_t CRYPTO_rotr_u64(uint64_t value, int shift) {
 
 // FIPS functions.
 
-#if defined(BORINGSSL_FIPS)
-#define MAX_KEYGEN_ATTEMPTS  4
+#define MAX_RSA_KEYGEN_ATTEMPTS  4
+
+#if defined(AWSLC_FIPS)
+#define MAX_EC_KEYGEN_ATTEMPTS  4
 // BORINGSSL_FIPS_abort is called when a FIPS power-on or continuous test
 // fails. It prevents any further cryptographic operations by the current
 // process.
 void BORINGSSL_FIPS_abort(void) __attribute__((noreturn));
 #else
-#define MAX_KEYGEN_ATTEMPTS  1
+#define MAX_EC_KEYGEN_ATTEMPTS  1
 #endif
 
 // boringssl_fips_self_test runs the FIPS KAT-based self tests. It returns one

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -937,13 +937,13 @@ static inline uint64_t CRYPTO_rotr_u64(uint64_t value, int shift) {
 // FIPS functions.
 
 #if defined(BORINGSSL_FIPS)
-#define MAX_PCT_ATTEMPTS  5
+#define MAX_KEYGEN_ATTEMPTS  4
 // BORINGSSL_FIPS_abort is called when a FIPS power-on or continuous test
 // fails. It prevents any further cryptographic operations by the current
 // process.
 void BORINGSSL_FIPS_abort(void) __attribute__((noreturn));
 #else
-#define MAX_PCT_ATTEMPTS  1
+#define MAX_KEYGEN_ATTEMPTS  1
 #endif
 
 // boringssl_fips_self_test runs the FIPS KAT-based self tests. It returns one


### PR DESCRIPTION
### Issues:
Continues CryptoAlg-908

### Description of changes: 
Based on feedback about the FIPS RSA PCT, it was only done once and not included in the number of attempts of key generation. This change moves it inside the `do-while` loop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
