### PR TITLE
Include the RSA PCT check in the number of keygen attempts.

### DIFF
--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -513,21 +513,20 @@ int EC_KEY_generate_key_fips(EC_KEY *eckey) {
     ret = EC_KEY_generate_key(eckey);
     ret &= EC_KEY_check_fips(eckey);
     num_attempts++;
-  } while (ret == 0 && num_attempts < MAX_PCT_ATTEMPTS);
+  } while (ret == 0 && num_attempts < MAX_EC_KEYGEN_ATTEMPTS);
 
+  FIPS_service_indicator_unlock_state();
   if (ret) {
-    FIPS_service_indicator_unlock_state();
     FIPS_service_indicator_update_state();
     return 1;
   }
 
-  FIPS_service_indicator_unlock_state();
   EC_POINT_free(eckey->pub_key);
   ec_wrapped_scalar_free(eckey->priv_key);
   eckey->pub_key = NULL;
   eckey->priv_key = NULL;
 
-#if defined(BORINGSSL_FIPS)
+#if defined(AWSLC_FIPS)
   BORINGSSL_FIPS_abort();
 #else
   return 0;

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -897,14 +897,16 @@ static inline void CRYPTO_store_word_le(void *out, crypto_word_t v) {
 
 // FIPS functions.
 
-#if defined(BORINGSSL_FIPS)
-#define MAX_PCT_ATTEMPTS  5
+#define MAX_RSA_KEYGEN_ATTEMPTS  4
+
+#if defined(AWSLC_FIPS)
+#define MAX_EC_KEYGEN_ATTEMPTS  4
 // BORINGSSL_FIPS_abort is called when a FIPS power-on or continuous test
 // fails. It prevents any further cryptographic operations by the current
 // process.
 void BORINGSSL_FIPS_abort(void) __attribute__((noreturn));
 #else
-#define MAX_PCT_ATTEMPTS  1
+#define MAX_EC_KEYGEN_ATTEMPTS  1
 #endif
 
 // boringssl_fips_self_test runs the FIPS KAT-based self tests. It returns one


### PR DESCRIPTION
### Issues:
Addresses #CryptoAlg-908

### Description of changes: 
PR#331 to main:
Based on feedback about the FIPS RSA PCT, it was only done once and not included in the number of attempts of key generation. This change:
- moves it inside the `do-while` loop
- maintains the existing logic around RSA keygen retries for non-FIPS build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
