### PR TITLE
Reverted the inner loop of RSA keygen to retry when TOO_MANY_ITERATIONS

### DIFF
--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -513,7 +513,7 @@ int EC_KEY_generate_key_fips(EC_KEY *eckey) {
     ret = EC_KEY_generate_key(eckey);
     ret &= EC_KEY_check_fips(eckey);
     num_attempts++;
-  } while (ret == 0 && num_attempts < MAX_EC_KEYGEN_ATTEMPTS);
+  } while (ret == 0 && (num_attempts < MAX_KEYGEN_ATTEMPTS));
 
   FIPS_service_indicator_unlock_state();
   if (ret) {

--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -513,7 +513,7 @@ int EC_KEY_generate_key_fips(EC_KEY *eckey) {
     ret = EC_KEY_generate_key(eckey);
     ret &= EC_KEY_check_fips(eckey);
     num_attempts++;
-  } while (ret == 0 && (num_attempts < MAX_KEYGEN_ATTEMPTS));
+  } while ((ret == 0) && (num_attempts < MAX_KEYGEN_ATTEMPTS));
 
   FIPS_service_indicator_unlock_state();
   if (ret) {

--- a/crypto/fipsmodule/rsa/rsa_impl.c
+++ b/crypto/fipsmodule/rsa/rsa_impl.c
@@ -1366,7 +1366,7 @@ static int RSA_generate_key_ex_maybe_fips(RSA *rsa, int bits,
       }
     }
     num_attempts++;
-  } while ((num_attempts < MAX_KEYGEN_ATTEMPTS) && (tmp == NULL));
+  } while ((tmp == NULL) && (num_attempts < MAX_KEYGEN_ATTEMPTS));
 
   if (tmp == NULL) {
     goto out;

--- a/crypto/fipsmodule/rsa/rsa_impl.c
+++ b/crypto/fipsmodule/rsa/rsa_impl.c
@@ -1327,37 +1327,46 @@ static int RSA_generate_key_ex_maybe_fips(RSA *rsa, int bits,
   RSA *tmp = NULL;
   uint32_t err;
   int ret = 0;
+  int failures;
+  int num_attempts = 0;
 
+  do {
   // |rsa_generate_key_impl|'s 2^-20 failure probability is too high at scale,
-  // so we run the FIPS algorithm |MAX_RSA_KEYGEN_ATTEMPTS| times,
-  // bringing it down to 2^-80 when it's equal to 4. We
+  // so we run the FIPS algorithm four times, bringing it down to 2^-80. We
   // should just adjust the retry limit, but FIPS 186-4 prescribes that value
   // and thus results in unnecessary complexity.
-  int failures = 0;
-  do {
-    ERR_clear_error();
-    // Generate into scratch space, to avoid leaving partial work on failure.
-    tmp = RSA_new();
-    if (tmp == NULL) {
-      goto out;
-    }
+  failures = 0;
+    do {
+      ERR_clear_error();
+      // Generate into scratch space, to avoid leaving partial work on failure.
+      tmp = RSA_new();
+      if (tmp == NULL) {
+        goto out;
+      }
 
-    if (rsa_generate_key_impl(tmp, bits, e_value, cb)) {
-      if (check_fips && !RSA_check_fips(tmp)) {
-        failures++;
-      } else {
+      if (rsa_generate_key_impl(tmp, bits, e_value, cb)) {
         break;
       }
+
+      err = ERR_peek_error();
+      RSA_free(tmp);
+      tmp = NULL;
+      failures++;
+
+      // Only retry on |RSA_R_TOO_MANY_ITERATIONS|. This is so a caller-induced
+      // failure in |BN_GENCB_call| is still fatal.
+    } while (failures < 4 && ERR_GET_LIB(err) == ERR_LIB_RSA &&
+             ERR_GET_REASON(err) == RSA_R_TOO_MANY_ITERATIONS);
+
+    // Perform PCT test in the case of FIPS
+    if (tmp) {
+      if (check_fips && !RSA_check_fips(tmp)) {
+        RSA_free(tmp);
+        tmp = NULL;
+      }
     }
-
-    err = ERR_peek_error();
-    RSA_free(tmp);
-    tmp = NULL;
-
-    // Only retry on |RSA_R_TOO_MANY_ITERATIONS|. This is so a caller-induced
-    // failure in |BN_GENCB_call| is still fatal.
-  } while (failures < MAX_RSA_KEYGEN_ATTEMPTS && ERR_GET_LIB(err) == ERR_LIB_RSA &&
-           ERR_GET_REASON(err) == RSA_R_TOO_MANY_ITERATIONS);
+    num_attempts++;
+  } while ((num_attempts < MAX_KEYGEN_ATTEMPTS) && (tmp == NULL));
 
   if (tmp == NULL) {
     goto out;

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -936,16 +936,14 @@ static inline uint64_t CRYPTO_rotr_u64(uint64_t value, int shift) {
 
 // FIPS functions.
 
-#define MAX_RSA_KEYGEN_ATTEMPTS  4
-
 #if defined(AWSLC_FIPS)
-#define MAX_EC_KEYGEN_ATTEMPTS  4
+#define MAX_KEYGEN_ATTEMPTS  5
 // BORINGSSL_FIPS_abort is called when a FIPS power-on or continuous test
 // fails. It prevents any further cryptographic operations by the current
 // process.
 void BORINGSSL_FIPS_abort(void) __attribute__((noreturn));
 #else
-#define MAX_EC_KEYGEN_ATTEMPTS  1
+#define MAX_KEYGEN_ATTEMPTS  1
 #endif
 
 // boringssl_fips_self_test runs the FIPS KAT-based self tests. It returns one

--- a/crypto/rsa_extra/rsa_test.cc
+++ b/crypto/rsa_extra/rsa_test.cc
@@ -981,6 +981,33 @@ TEST(RSATest, KeygenFail) {
   EXPECT_NE(Bytes(der, der_len), Bytes(der3, der3_len));
 }
 
+TEST(RSATest, KeygenFailOnce) {
+  bssl::UniquePtr<RSA> rsa(RSA_new());
+  ASSERT_TRUE(rsa);
+
+  // Cause only the first iteration of RSA key generation to fail.
+  bool failed = false;
+  BN_GENCB cb;
+  BN_GENCB_set(&cb,
+               [](int event, int n, BN_GENCB *cb_ptr) -> int {
+                 bool *failed_ptr = static_cast<bool *>(cb_ptr->arg);
+                 if (*failed_ptr) {
+                   ADD_FAILURE() << "Callback called multiple times.";
+                   return 1;
+                 }
+                 *failed_ptr = true;
+                 return 0;
+               },
+               &failed);
+
+  // Although key generation internally retries, the external behavior of
+  // |BN_GENCB| is preserved.
+  bssl::UniquePtr<BIGNUM> e(BN_new());
+  ASSERT_TRUE(e);
+  ASSERT_TRUE(BN_set_word(e.get(), RSA_F4));
+  EXPECT_FALSE(RSA_generate_key_ex(rsa.get(), 2048, e.get(), &cb));
+}
+
 #else
 // In the case of a FIPS build, expect abort() when |RSA_generate_key_ex| fails.
 TEST(RSADeathTest, KeygenFailAndDie) {
@@ -1044,9 +1071,13 @@ TEST(RSADeathTest, KeygenFailAndDie) {
   EXPECT_NE(Bytes(der, der_len), Bytes(der3, der3_len));
 }
 
-#endif
-
-TEST(RSATest, KeygenFailOnce) {
+// This is not a death test. It's similar to the test KeygenFailOnce
+// in the non-FIPS case, with the following differences:
+// - the callback gets called again in the outer loop,
+// ADD_FAILURE() is removed.
+// - On subsequent retries (in FIPS, MAX_KEYGEN_ATTEMPTS > 1),
+// |RSA_generate_key_ex| succeeds.
+TEST(RSATest, KeygenFailOnceThenSucceed) {
   bssl::UniquePtr<RSA> rsa(RSA_new());
   ASSERT_TRUE(rsa);
 
@@ -1057,7 +1088,6 @@ TEST(RSATest, KeygenFailOnce) {
                [](int event, int n, BN_GENCB *cb_ptr) -> int {
                  bool *failed_ptr = static_cast<bool *>(cb_ptr->arg);
                  if (*failed_ptr) {
-                   ADD_FAILURE() << "Callback called multiple times.";
                    return 1;
                  }
                  *failed_ptr = true;
@@ -1070,8 +1100,10 @@ TEST(RSATest, KeygenFailOnce) {
   bssl::UniquePtr<BIGNUM> e(BN_new());
   ASSERT_TRUE(e);
   ASSERT_TRUE(BN_set_word(e.get(), RSA_F4));
-  EXPECT_FALSE(RSA_generate_key_ex(rsa.get(), 2048, e.get(), &cb));
+  EXPECT_TRUE(RSA_generate_key_ex(rsa.get(), 2048, e.get(), &cb));
 }
+#endif
+
 
 TEST(RSATest, KeygenInternalRetry) {
   bssl::UniquePtr<RSA> rsa(RSA_new());


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-908

### Description of changes: 
In the FIPS feedback of the previous commit, it was pointed out a flaw in the logic:
Failing for other reasons than TOO_MANY_ITERATIONS would not allow more retries.
So the original loop in `RSA_generate_key_ex_maybe_fips()` in rsa_impl.c as in 6bdd4c3 is brought back to focus on only retrying keygen when TOO_MANY_ITERATIONS is the reason for failure.

An outer loop is added to test for PCT and have its own number of attempts which covers both keygen and PCT failures. This behaviour now matches that of `EC_KEY_generate_key_fips()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
