### PR TITLE
cherry-pick to fips-2021-10-20: Reverted the inner loop of RSA keygen

### DIFF
--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -513,7 +513,7 @@ int EC_KEY_generate_key_fips(EC_KEY *eckey) {
     ret = EC_KEY_generate_key(eckey);
     ret &= EC_KEY_check_fips(eckey);
     num_attempts++;
-  } while (ret == 0 && num_attempts < MAX_EC_KEYGEN_ATTEMPTS);
+  } while ((ret == 0) && (num_attempts < MAX_KEYGEN_ATTEMPTS));
 
   FIPS_service_indicator_unlock_state();
   if (ret) {

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -897,16 +897,14 @@ static inline void CRYPTO_store_word_le(void *out, crypto_word_t v) {
 
 // FIPS functions.
 
-#define MAX_RSA_KEYGEN_ATTEMPTS  4
-
 #if defined(AWSLC_FIPS)
-#define MAX_EC_KEYGEN_ATTEMPTS  4
+#define MAX_KEYGEN_ATTEMPTS  5
 // BORINGSSL_FIPS_abort is called when a FIPS power-on or continuous test
 // fails. It prevents any further cryptographic operations by the current
 // process.
 void BORINGSSL_FIPS_abort(void) __attribute__((noreturn));
 #else
-#define MAX_EC_KEYGEN_ATTEMPTS  1
+#define MAX_KEYGEN_ATTEMPTS  1
 #endif
 
 // boringssl_fips_self_test runs the FIPS KAT-based self tests. It returns one


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-908

### Description of changes: 
In the FIPS feedback of the previous commit, it was pointed out a flaw in the logic:
Failing for other reasons than TOO_MANY_ITERATIONS would not allow more retries.
So the original loop in `RSA_generate_key_ex_maybe_fips()` in rsa_impl.c as in 6bdd4c3 is brought back to focus on only retrying keygen when TOO_MANY_ITERATIONS is the reason for failure.
This inner loop can be thought of as one call for RSA key generation.

An outer loop is added to test for PCT and have its own number of attempts which covers both keygen and PCT failures. This behaviour now matches that of `EC_KEY_generate_key_fips()`.

### PR to main:
Reverted the inner loop of RSA keygen to retry when TOO_MANY_ITERATIONS #334 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
