### PR TITLE
Set RSA_PSS_SALTLEN_DIGEST(-1) in acvp tool.

### DIFF
--- a/util/fipstools/acvp/modulewrapper/modulewrapper.cc
+++ b/util/fipstools/acvp/modulewrapper/modulewrapper.cc
@@ -1760,6 +1760,7 @@ static bool RSASigGen(const Span<const uint8_t> args[], ReplyCallback write_repl
   int padding = UsePSS ? RSA_PKCS1_PSS_PADDING : RSA_PKCS1_PADDING;
   if (!EVP_DigestSignInit(ctx.get(), &pctx, md, nullptr, evp_pkey) ||
       !EVP_PKEY_CTX_set_rsa_padding(pctx, padding) ||
+      (UsePSS && !EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx, RSA_PSS_SALTLEN_DIGEST)) ||
       !EVP_DigestSign(ctx.get(), nullptr, &sig_len, msg.data(), msg.size())) {
     return false;
   }
@@ -1799,6 +1800,7 @@ static bool RSASigVer(const Span<const uint8_t> args[], ReplyCallback write_repl
   int padding = UsePSS ? RSA_PKCS1_PSS_PADDING : RSA_PKCS1_PADDING;
   if (!EVP_DigestVerifyInit(ctx.get(), &pctx, md, nullptr, evp_pkey.get()) ||
       !EVP_PKEY_CTX_set_rsa_padding(pctx, padding) ||
+      (UsePSS && !EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx, RSA_PSS_SALTLEN_DIGEST)) ||
       !EVP_DigestVerify(ctx.get(), sig.data(), sig.size(), msg.data(), msg.size())) {
     ok = 0;
   } else {


### PR DESCRIPTION
### Description of changes: 
By default, the auto mode is used in some crypto lib impl (e.g. [Golang VerifyPSS](https://pkg.go.dev/crypto/rsa#VerifyPSS) and awslc code) when generating PSS signature. In FIPS validation, the data we request expects the `saltlen == hashlen`. Accordingly, `RSA_PSS_SALTLEN_DIGEST` should be set.

### Call-outs:
* Will merge this PR when the ACVP lab confirms this fix works for the non sample data.

### Testing:
The generated signature was tested with Golang https://pkg.go.dev/crypto/rsa#VerifyPSS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
