### PR TITLE
Enabling the FIPS build on macOS

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -459,10 +459,8 @@ if(FIPS_SHARED)
   # hash value. For now we support the FIPS build only on Linux and macOS.
 
   if (APPLE)
-    set(SHARED_LIB_NAME "libcrypto.dylib")
     set(INJECT_HASH_MACOS_FLAG "-macos")
   else()
-    set(SHARED_LIB_NAME "libcrypto.so")
     set(INJECT_HASH_MACOS_FLAG "")
   endif()
 
@@ -470,7 +468,8 @@ if(FIPS_SHARED)
     TARGET crypto POST_BUILD
     COMMAND ${GO_EXECUTABLE} run
     ${CMAKE_SOURCE_DIR}/util/fipstools/inject_hash/inject_hash.go
-    -o ${CMAKE_CURRENT_BINARY_DIR}/${SHARED_LIB_NAME} -in-object ${CMAKE_CURRENT_BINARY_DIR}/${SHARED_LIB_NAME} -sha256 ${INJECT_HASH_MACOS_FLAG}
+    -o $<TARGET_FILE:crypto> -in-object $<TARGET_FILE:crypto>
+    -sha256 ${INJECT_HASH_MACOS_FLAG}
     # The DEPENDS argument to a POST_BUILD rule appears to be ignored. Thus
     # go_executable isn't used (as it doesn't get built), but we list this
     # dependency anyway in case it starts working in some CMake version.

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -455,22 +455,22 @@ add_library(
 )
 
 if(FIPS_SHARED)
-	# Rewrite libcrypto.so (or libcrypto.dylib) to inject the correct module
-	# hash value. For now we support the FIPS build only on Linux and macOS.
+  # Rewrite libcrypto.so (or libcrypto.dylib) to inject the correct module
+  # hash value. For now we support the FIPS build only on Linux and macOS.
 
-	if (APPLE)
-		set(SHARED_LIB_NAME "libcrypto.dylib")
-		set(INJECT_HASH_MACOS_FLAG "-macos")
-	else()
-		set(SHARED_LIB_NAME "libcrypto.so")
-		set(INJECT_HASH_MACOS_FLAG "")
-	endif()
+  if (APPLE)
+    set(SHARED_LIB_NAME "libcrypto.dylib")
+    set(INJECT_HASH_MACOS_FLAG "-macos")
+  else()
+    set(SHARED_LIB_NAME "libcrypto.so")
+    set(INJECT_HASH_MACOS_FLAG "")
+  endif()
 
   add_custom_command(
     TARGET crypto POST_BUILD
     COMMAND ${GO_EXECUTABLE} run
     ${CMAKE_SOURCE_DIR}/util/fipstools/inject_hash/inject_hash.go
-		-o ${CMAKE_CURRENT_BINARY_DIR}/${SHARED_LIB_NAME} -in-object ${CMAKE_CURRENT_BINARY_DIR}/${SHARED_LIB_NAME} -sha256 ${INJECT_HASH_MACOS_FLAG}
+    -o ${CMAKE_CURRENT_BINARY_DIR}/${SHARED_LIB_NAME} -in-object ${CMAKE_CURRENT_BINARY_DIR}/${SHARED_LIB_NAME} -sha256 ${INJECT_HASH_MACOS_FLAG}
     # The DEPENDS argument to a POST_BUILD rule appears to be ignored. Thus
     # go_executable isn't used (as it doesn't get built), but we list this
     # dependency anyway in case it starts working in some CMake version.

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -455,13 +455,22 @@ add_library(
 )
 
 if(FIPS_SHARED)
-  # Rewrite libcrypto.so to inject the correct module hash value. This assumes
-  # UNIX-style library naming, but we only support FIPS mode on Linux anyway.
+	# Rewrite libcrypto.so (or libcrypto.dylib) to inject the correct module
+	# hash value. For now we support the FIPS build only on Linux and macOS.
+
+	if (APPLE)
+		set(SHARED_LIB_NAME "libcrypto.dylib")
+		set(INJECT_HASH_MACOS_FLAG "-macos")
+	else()
+		set(SHARED_LIB_NAME "libcrypto.so")
+		set(INJECT_HASH_MACOS_FLAG "")
+	endif()
+
   add_custom_command(
     TARGET crypto POST_BUILD
     COMMAND ${GO_EXECUTABLE} run
     ${CMAKE_SOURCE_DIR}/util/fipstools/inject_hash/inject_hash.go
-    -o ${CMAKE_CURRENT_BINARY_DIR}/libcrypto.so -in-object ${CMAKE_CURRENT_BINARY_DIR}/libcrypto.so -sha256
+		-o ${CMAKE_CURRENT_BINARY_DIR}/${SHARED_LIB_NAME} -in-object ${CMAKE_CURRENT_BINARY_DIR}/${SHARED_LIB_NAME} -sha256 ${INJECT_HASH_MACOS_FLAG}
     # The DEPENDS argument to a POST_BUILD rule appears to be ignored. Thus
     # go_executable isn't used (as it doesn't get built), but we list this
     # dependency anyway in case it starts working in some CMake version.

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -269,20 +269,52 @@ elseif(FIPS_SHARED)
   )
 
   add_dependencies(bcm_library global_target)
-  # fips_shared.lds does not have 'clang' prefix because we want to keep merging any changes from upstream.
-  set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/fips_shared.lds")
-  if (GCC)
-    # gcc puts some code in sections named ".text.unlikely", ".text.exit" and ".text.startup".
-    # so we have a separate linker script for gcc.
-    set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/gcc_fips_shared.lds")
-  endif()
 
-  add_custom_command(
-    OUTPUT bcm.o
-    COMMAND ${CMAKE_LINKER} -r -T ${FIPS_CUSTOM_LINKER_SCRIPT} -o bcm.o --whole-archive $<TARGET_FILE:bcm_library>
-    DEPENDS bcm_library fips_shared.lds
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  )
+	if (APPLE)
+		# The linker on macOS doesn't have the ability to process linker scripts,
+		# so we build the FIPS module differently than on Linux. Similarly to
+		# what OpenSSL does we produce two object files: fips_macos_{start, end}.o
+		# that contain only the markers for the start and end of __text and __const
+		# sections. The module is then produced by linking the files specified in
+		# the following order: fips_macos_start.o bcm.o fips_macos_end.o. This will
+		# generate the output object file where all the code in the __text section
+		# and all the read-only data in the __const section are between the
+		# respective start and end markers.
+  	add_custom_command(
+  	  OUTPUT fips_macos_start.o
+			COMMAND ${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_macos_support.c -DAWSLC_FIPS_MACOS_START -o fips_macos_start.o
+  	)
+  	add_custom_command(
+  	  OUTPUT fips_macos_end.o
+			COMMAND ${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_macos_support.c -DAWSLC_FIPS_MACOS_END -o fips_macos_end.o
+  	)
+
+  	add_custom_command(
+  	  OUTPUT bcm.o
+  	  COMMAND ${CMAKE_LINKER} -r fips_macos_start.o -force_load $<TARGET_FILE:bcm_library> fips_macos_end.o -keep_private_externs -o bcm.o
+  	  DEPENDS bcm_library fips_macos_start.o fips_macos_end.o
+  	  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  	)
+
+	else()
+		# Linux is the only OS other than macOS on which we build FIPS.
+
+		# fips_shared.lds does not have 'clang' prefix because we want to keep merging any changes from upstream.
+  	set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/fips_shared.lds")
+  	if (GCC)
+  	  # gcc puts some code in sections named ".text.unlikely", ".text.exit" and ".text.startup".
+  	  # so we have a separate linker script for gcc.
+  	  set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/gcc_fips_shared.lds")
+  	endif()
+
+  	add_custom_command(
+  	  OUTPUT bcm.o
+  	  COMMAND ${CMAKE_LINKER} -r -T ${FIPS_CUSTOM_LINKER_SCRIPT} -o bcm.o --whole-archive $<TARGET_FILE:bcm_library>
+  	  DEPENDS bcm_library fips_shared.lds
+  	  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  	)
+	endif()
+
 
   add_custom_target(bcm_o_target DEPENDS bcm.o)
 else()

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -329,10 +329,12 @@ elseif(FIPS_SHARED)
     add_custom_command(
       OUTPUT fips_macos_start.o
       COMMAND ${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_macos_support.c -DAWSLC_FIPS_MACOS_START -o fips_macos_start.o
+      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/fips_macos_support.c
     )
     add_custom_command(
       OUTPUT fips_macos_end.o
       COMMAND ${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_macos_support.c -DAWSLC_FIPS_MACOS_END -o fips_macos_end.o
+      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/fips_macos_support.c
     )
 
     add_custom_command(
@@ -345,20 +347,20 @@ elseif(FIPS_SHARED)
    else()
     # Linux is the only OS other than macOS on which we build FIPS.
 
-		# fips_shared.lds does not have 'clang' prefix because we want to keep merging any changes from upstream.
-  	set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/fips_shared.lds")
-  	if (GCC)
-  	  # gcc puts some code in sections named ".text.unlikely", ".text.exit" and ".text.startup".
-  	  # so we have a separate linker script for gcc.
-  	  set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/gcc_fips_shared.lds")
-  	endif()
+    # fips_shared.lds does not have 'clang' prefix because we want to keep merging any changes from upstream.
+    set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/fips_shared.lds")
+    if (GCC)
+      # gcc puts some code in sections named ".text.unlikely", ".text.exit" and ".text.startup".
+      # so we have a separate linker script for gcc.
+      set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/gcc_fips_shared.lds")
+    endif()
 
-  	add_custom_command(
-  	  OUTPUT bcm.o
-  	  COMMAND ${CMAKE_LINKER} -r -T ${FIPS_CUSTOM_LINKER_SCRIPT} -o bcm.o --whole-archive $<TARGET_FILE:bcm_library>
-  	  DEPENDS bcm_library fips_shared.lds
-  	  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  	)
+    add_custom_command(
+      OUTPUT bcm.o
+      COMMAND ${CMAKE_LINKER} -r -T ${FIPS_CUSTOM_LINKER_SCRIPT} -o bcm.o --whole-archive $<TARGET_FILE:bcm_library>
+      DEPENDS bcm_library ${FIPS_CUSTOM_LINKER_SCRIPT}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
   endif()
 
 

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -316,34 +316,34 @@ elseif(FIPS_SHARED)
 
   add_dependencies(bcm_library global_target)
 
-	if (APPLE)
-		# The linker on macOS doesn't have the ability to process linker scripts,
-		# so we build the FIPS module differently than on Linux. Similarly to
-		# what OpenSSL does we produce two object files: fips_macos_{start, end}.o
-		# that contain only the markers for the start and end of __text and __const
-		# sections. The module is then produced by linking the files specified in
-		# the following order: fips_macos_start.o bcm.o fips_macos_end.o. This will
-		# generate the output object file where all the code in the __text section
-		# and all the read-only data in the __const section are between the
-		# respective start and end markers.
-  	add_custom_command(
-  	  OUTPUT fips_macos_start.o
-			COMMAND ${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_macos_support.c -DAWSLC_FIPS_MACOS_START -o fips_macos_start.o
-  	)
-  	add_custom_command(
-  	  OUTPUT fips_macos_end.o
-			COMMAND ${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_macos_support.c -DAWSLC_FIPS_MACOS_END -o fips_macos_end.o
-  	)
+  if (APPLE)
+    # The linker on macOS doesn't have the ability to process linker scripts,
+    # so we build the FIPS module differently than on Linux. Similarly to
+    # what OpenSSL does we produce two object files: fips_macos_{start, end}.o
+    # that contain only the markers for the start and end of __text and __const
+    # sections. The module is then produced by linking the files specified in
+    # the following order: fips_macos_start.o bcm.o fips_macos_end.o. This will
+    # generate the output object file where all the code in the __text section
+    # and all the read-only data in the __const section are between the
+    # respective start and end markers.
+    add_custom_command(
+      OUTPUT fips_macos_start.o
+      COMMAND ${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_macos_support.c -DAWSLC_FIPS_MACOS_START -o fips_macos_start.o
+    )
+    add_custom_command(
+      OUTPUT fips_macos_end.o
+      COMMAND ${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_macos_support.c -DAWSLC_FIPS_MACOS_END -o fips_macos_end.o
+    )
 
-  	add_custom_command(
-  	  OUTPUT bcm.o
-  	  COMMAND ${CMAKE_LINKER} -r fips_macos_start.o -force_load $<TARGET_FILE:bcm_library> fips_macos_end.o -keep_private_externs -o bcm.o
-  	  DEPENDS bcm_library fips_macos_start.o fips_macos_end.o
-  	  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  	)
+    add_custom_command(
+      OUTPUT bcm.o
+      COMMAND ${CMAKE_LINKER} -r fips_macos_start.o -force_load $<TARGET_FILE:bcm_library> fips_macos_end.o -keep_private_externs -o bcm.o
+      DEPENDS bcm_library fips_macos_start.o fips_macos_end.o
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
 
-	else()
-		# Linux is the only OS other than macOS on which we build FIPS.
+   else()
+    # Linux is the only OS other than macOS on which we build FIPS.
 
 		# fips_shared.lds does not have 'clang' prefix because we want to keep merging any changes from upstream.
   	set(FIPS_CUSTOM_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/fips_shared.lds")
@@ -359,7 +359,7 @@ elseif(FIPS_SHARED)
   	  DEPENDS bcm_library fips_shared.lds
   	  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   	)
-	endif()
+  endif()
 
 
   add_custom_target(bcm_o_target DEPENDS bcm.o)

--- a/crypto/fipsmodule/fips_macos_support.c
+++ b/crypto/fipsmodule/fips_macos_support.c
@@ -1,0 +1,41 @@
+/*
+------------------------------------------------------------------------------------
+ Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+------------------------------------------------------------------------------------
+*/
+
+// The FIPS build on macOS is different than the build on Linux.
+// Apple's linker doesn't support linker scripts so we have to build the module
+// in a different way. This file is compiled twice:
+//    - with AWSLC_FIPS_MACOS_START flag to generate fips_macos_start.o
+//    - with AWSLC_FIPS_MACOS_END flag to generate fips_macos_end.o
+// The two generated files are used to link with the module bcm.o such that
+// the final module object has start and end markers for  __text and __const
+// sections that are used for the integrity check.
+
+#include <stdio.h>
+#include <stdint.h>
+
+#if defined(AWSLC_FIPS_MACOS_START)
+
+const uint8_t *BORINGSSL_bcm_text_start(void) {
+  return NULL;
+}
+const uint8_t BORINGSSL_bcm_rodata_start[16] =
+              {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}; 
+
+#elif defined(AWSLC_FIPS_MACOS_END)
+
+const uint8_t *BORINGSSL_bcm_text_end(void){
+  return NULL;
+}
+const uint8_t BORINGSSL_bcm_rodata_end[16] =
+              {16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}; 
+
+#else
+
+#error "This file should be compiled only as part of the FIPS build on macOS."
+
+#endif
+

--- a/crypto/thread_test.cc
+++ b/crypto/thread_test.cc
@@ -56,7 +56,7 @@ TEST(ThreadTest, Once) {
 
 #if !defined(OPENSSL_MACOS)
 // The |InitZeros| test is excluded from the macOS FIPS build.
-// The three macros defined following in |crypto/internal.h|:
+// The following three macros are defined in |crypto/internal.h|:
 //   #define CRYPTO_ONCE_INIT PTHREAD_ONCE_INIT
 //   #define CRYPTO_STATIC_MUTEX_INIT { PTHREAD_RWLOCK_INITIALIZER }
 //   #define CRYPTO_EX_DATA_CLASS_INIT {CRYPTO_STATIC_MUTEX_INIT, NULL, 0}

--- a/crypto/thread_test.cc
+++ b/crypto/thread_test.cc
@@ -54,6 +54,26 @@ TEST(ThreadTest, Once) {
   EXPECT_EQ(1u, g_once_init_called);
 }
 
+#if !defined(OPENSSL_MACOS)
+// The |InitZeros| test is excluded from the macOS FIPS build.
+// The three macros defined following in |crypto/internal.h|:
+//   #define CRYPTO_ONCE_INIT PTHREAD_ONCE_INIT
+//   #define CRYPTO_STATIC_MUTEX_INIT { PTHREAD_RWLOCK_INITIALIZER }
+//   #define CRYPTO_EX_DATA_CLASS_INIT {CRYPTO_STATIC_MUTEX_INIT, NULL, 0}
+// On Linux, the above macros all resolve to a zero (or an array of zeroes).
+// On macOS, the macros are prefixed with a "signature". For example,
+// |PTHREAD_ONCE_INIT| is defined in |pthread.h| as:
+//   #define PTHREAD_ONCE_INIT {_PTHREAD_ONCE_SIG_init, {0}}
+// where, |pthread_impl.h| defines:
+//   #define _PTHREAD_ONCE_SIG_init	0x30B1BCBA
+// Therefore, on macOS, |CRYPTO_ONCE_INIT| and the other two macros don't
+// resolve to a zero and the |InitZeros| test fails.
+//
+// Rather than making the test work on macOS by handling the "signature",
+// we disable it because the file |pthread_impl.h| that contains the macro
+// in question has the following note:
+//   /* This whole header file will disappear, so don't depend on it... */
+
 static CRYPTO_once_t once_init_value = CRYPTO_ONCE_INIT;
 static CRYPTO_once_t once_bss;
 
@@ -77,6 +97,7 @@ TEST(ThreadTest, InitZeros) {
         Bytes((uint8_t *)&ex_data_class_value, sizeof(ex_data_class_value)));
   }
 }
+#endif
 
 static int g_test_thread_ok = 0;
 static unsigned g_destructor_called_count = 0;

--- a/util/fipstools/inject_hash/inject_hash.go
+++ b/util/fipstools/inject_hash/inject_hash.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"debug/elf"
+	"debug/macho"
 	"encoding/binary"
 	"errors"
 	"flag"
@@ -36,7 +37,270 @@ import (
 	"boringssl.googlesource.com/boringssl/util/fipstools/fipscommon"
 )
 
-func do(outPath, oInput string, arInput string, useSHA256 bool) error {
+func doLinux(objectBytes []byte, isStatic bool) ([]byte, []byte, error) {
+
+	object, err := elf.NewFile(bytes.NewReader(objectBytes))
+	if err != nil {
+		return nil, nil, errors.New("failed to parse object: " + err.Error())
+	}
+
+	// Find the .text and, optionally, .data sections.
+
+	var textSection, rodataSection *elf.Section
+	var textSectionIndex, rodataSectionIndex elf.SectionIndex
+	for i, section := range object.Sections {
+		switch section.Name {
+		case ".text":
+			textSectionIndex = elf.SectionIndex(i)
+			textSection = section
+		case ".rodata":
+			rodataSectionIndex = elf.SectionIndex(i)
+			rodataSection = section
+		}
+	}
+
+	if textSection == nil {
+		return nil, nil, errors.New("failed to find .text section in object")
+	}
+
+	// Find the starting and ending symbols for the module.
+
+	var textStart, textEnd, rodataStart, rodataEnd *uint64
+
+	symbols, err := object.Symbols()
+	if err != nil {
+		return nil, nil, errors.New("failed to parse symbols: " + err.Error())
+	}
+
+	for _, symbol := range symbols {
+		var base uint64
+		switch symbol.Section {
+		case textSectionIndex:
+			base = textSection.Addr
+		case rodataSectionIndex:
+			if rodataSection == nil {
+				continue
+			}
+			base = rodataSection.Addr
+		default:
+			continue
+		}
+
+		if isStatic {
+			// Static objects appear to have different semantics about whether symbol
+			// values are relative to their section or not.
+			base = 0
+		} else if symbol.Value < base {
+			return nil, nil, fmt.Errorf("symbol %q at %x, which is below base of %x", symbol.Name, symbol.Value, base)
+		}
+
+		value := symbol.Value - base
+		switch symbol.Name {
+		case "BORINGSSL_bcm_text_start":
+			if textStart != nil {
+				return nil, nil, errors.New("duplicate start symbol found")
+			}
+			textStart = &value
+		case "BORINGSSL_bcm_text_end":
+			if textEnd != nil {
+				return nil, nil, errors.New("duplicate end symbol found")
+			}
+			textEnd = &value
+		case "BORINGSSL_bcm_rodata_start":
+			if rodataStart != nil {
+				return nil, nil, errors.New("duplicate rodata start symbol found")
+			}
+			rodataStart = &value
+		case "BORINGSSL_bcm_rodata_end":
+			if rodataEnd != nil {
+				return nil, nil, errors.New("duplicate rodata end symbol found")
+			}
+			rodataEnd = &value
+		default:
+			continue
+		}
+	}
+
+	if textStart == nil || textEnd == nil {
+		return nil, nil, errors.New("could not find .text module boundaries in object")
+	}
+
+	if (rodataStart == nil) != (rodataSection == nil) {
+		return nil, nil, errors.New("rodata start marker inconsistent with rodata section presence")
+	}
+
+	if (rodataStart != nil) != (rodataEnd != nil) {
+		return nil, nil, errors.New("rodata marker presence inconsistent")
+	}
+
+	if max := textSection.Size; *textStart > max || *textStart > *textEnd || *textEnd > max {
+		return nil, nil, fmt.Errorf("invalid module .text boundaries: start: %x, end: %x, max: %x", *textStart, *textEnd, max)
+	}
+
+	if rodataSection != nil {
+		if max := rodataSection.Size; *rodataStart > max || *rodataStart > *rodataEnd || *rodataEnd > max {
+			return nil, nil, fmt.Errorf("invalid module .rodata boundaries: start: %x, end: %x, max: %x", *rodataStart, *rodataEnd, max)
+		}
+	}
+
+	// Extract the module from the .text section and hash it.
+
+	text := textSection.Open()
+	if _, err := text.Seek(int64(*textStart), 0); err != nil {
+		return nil, nil, errors.New("failed to seek to module start in .text: " + err.Error())
+	}
+	moduleText := make([]byte, *textEnd-*textStart)
+	if _, err := io.ReadFull(text, moduleText); err != nil {
+		return nil, nil, errors.New("failed to read .text: " + err.Error())
+	}
+
+	// Maybe extract the module's read-only data too
+	var moduleROData []byte
+	if rodataSection != nil {
+		rodata := rodataSection.Open()
+		if _, err := rodata.Seek(int64(*rodataStart), 0); err != nil {
+			return nil, nil, errors.New("failed to seek to module start in .rodata: " + err.Error())
+		}
+		moduleROData = make([]byte, *rodataEnd-*rodataStart)
+		if _, err := io.ReadFull(rodata, moduleROData); err != nil {
+			return nil, nil, errors.New("failed to read .rodata: " + err.Error())
+		}
+	}
+
+	return moduleText, moduleROData, nil
+}
+
+
+func doMacOS(objectBytes []byte) ([]byte, []byte, error) {
+
+	object, err := macho.NewFile(bytes.NewReader(objectBytes))
+	if err != nil {
+		return nil, nil, errors.New("failed to parse object: " + err.Error())
+	}
+
+	// Find the __text and, optionally, __const sections.
+	var textSection, rodataSection *macho.Section
+	var textSectionIndex, rodataSectionIndex int
+	for i, section := range object.Sections {
+
+    if section.Seg == "__TEXT" && section.Name == "__text" {
+			textSection = section
+			textSectionIndex = i + 1
+    }
+    if section.Seg == "__TEXT" && section.Name == "__const" {
+			rodataSection = section
+			rodataSectionIndex = i + 1
+    }
+	}
+
+	if textSection == nil {
+		return nil, nil, errors.New("failed to find __text section in object")
+	}
+
+	// Find the starting and ending symbols for the module.
+	var textStart, textEnd, rodataStart, rodataEnd *uint64
+
+	symbols := object.Symtab.Syms
+	if symbols == nil {
+		return nil, nil, errors.New("failed to parse symbols: " + err.Error())
+	}
+
+	for _, symbol := range symbols {
+		var base uint64
+		switch int(symbol.Sect) {
+		case textSectionIndex:
+			base = textSection.Addr
+		case rodataSectionIndex:
+			if rodataSection == nil {
+				continue
+			}
+			base = rodataSection.Addr
+		default:
+			continue
+		}
+
+		if symbol.Name != "" && symbol.Name != " " && symbol.Value < base {
+			return nil, nil, fmt.Errorf("symbol %q at %x, which is below base of %x\n", symbol.Name, symbol.Value, base)
+		}
+
+		value := symbol.Value - base
+		switch symbol.Name {
+		case "_BORINGSSL_bcm_text_start":
+			if textStart != nil {
+				return nil, nil, errors.New("duplicate start symbol found")
+			}
+			textStart = &value
+		case "_BORINGSSL_bcm_text_end":
+			if textEnd != nil {
+				return nil, nil, errors.New("duplicate end symbol found")
+			}
+			textEnd = &value
+		case "_BORINGSSL_bcm_rodata_start":
+			if rodataStart != nil {
+				return nil, nil, errors.New("duplicate rodata start symbol found")
+			}
+			rodataStart = &value
+		case "_BORINGSSL_bcm_rodata_end":
+			if rodataEnd != nil {
+				return nil, nil, errors.New("duplicate rodata end symbol found")
+			}
+			rodataEnd = &value
+		default:
+			continue
+		}
+	}
+
+	if textStart == nil || textEnd == nil {
+		return nil, nil, errors.New("could not find .text module boundaries in object")
+	}
+
+	if (rodataStart == nil) != (rodataSection == nil) {
+		return nil, nil, errors.New("rodata start marker inconsistent with rodata section presence")
+	}
+
+	if (rodataStart != nil) != (rodataEnd != nil) {
+		return nil, nil, errors.New("rodata marker presence inconsistent")
+	}
+
+	if max := textSection.Size; *textStart > max || *textStart > *textEnd || *textEnd > max {
+		return nil, nil, fmt.Errorf("invalid module __text boundaries: start: %x, end: %x, max: %x", *textStart, *textEnd, max)
+	}
+
+	if rodataSection != nil {
+		if max := rodataSection.Size; *rodataStart > max || *rodataStart > *rodataEnd || *rodataEnd > max {
+			return nil, nil, fmt.Errorf("invalid module __const boundaries: start: %x, end: %x, max: %x", *rodataStart, *rodataEnd, max)
+		}
+	}
+
+	// Extract the module from the __text section.
+	text := textSection.Open()
+	if _, err := text.Seek(int64(*textStart), 0); err != nil {
+		return nil, nil, errors.New("failed to seek to module start in __text: " + err.Error())
+	}
+	moduleText := make([]byte, *textEnd-*textStart)
+	if _, err := io.ReadFull(text, moduleText); err != nil {
+		return nil, nil, errors.New("failed to read __text: " + err.Error())
+	}
+
+	// Maybe extract the module's read-only data too
+	var moduleROData []byte
+	if rodataSection != nil {
+		rodata := rodataSection.Open()
+		if _, err := rodata.Seek(int64(*rodataStart), 0); err != nil {
+			return nil, nil, errors.New("failed to seek to module start in __const: " + err.Error())
+		}
+		moduleROData = make([]byte, *rodataEnd-*rodataStart)
+		if _, err := io.ReadFull(rodata, moduleROData); err != nil {
+			return nil, nil, errors.New("failed to read __const: " + err.Error())
+		}
+	}
+
+	return moduleText, moduleROData, nil
+}
+
+
+
+func do(outPath, oInput string, arInput string, useSHA256 bool, macOS bool) error {
 	var objectBytes []byte
 	var isStatic bool
 	var perm os.FileMode
@@ -47,6 +311,10 @@ func do(outPath, oInput string, arInput string, useSHA256 bool) error {
 		if len(oInput) > 0 {
 			return fmt.Errorf("-in-archive and -in-object are mutually exclusive")
 		}
+
+    if macOS {
+      return fmt.Errorf("only shared libraries can be handled on macOS")
+    }
 
 		fi, err := os.Stat(arInput)
 		if err != nil {
@@ -87,133 +355,18 @@ func do(outPath, oInput string, arInput string, useSHA256 bool) error {
 		return fmt.Errorf("exactly one of -in-archive or -in-object is required")
 	}
 
-	object, err := elf.NewFile(bytes.NewReader(objectBytes))
+	var moduleText, moduleROData []byte
+	var err error
+	if macOS == true {
+		moduleText, moduleROData, err = doMacOS(objectBytes)
+	} else {
+		moduleText, moduleROData, err = doLinux(objectBytes, isStatic)
+	}
+
 	if err != nil {
-		return errors.New("failed to parse object: " + err.Error())
+		return err
 	}
 
-	// Find the .text and, optionally, .data sections.
-
-	var textSection, rodataSection *elf.Section
-	var textSectionIndex, rodataSectionIndex elf.SectionIndex
-	for i, section := range object.Sections {
-		switch section.Name {
-		case ".text":
-			textSectionIndex = elf.SectionIndex(i)
-			textSection = section
-		case ".rodata":
-			rodataSectionIndex = elf.SectionIndex(i)
-			rodataSection = section
-		}
-	}
-
-	if textSection == nil {
-		return errors.New("failed to find .text section in object")
-	}
-
-	// Find the starting and ending symbols for the module.
-
-	var textStart, textEnd, rodataStart, rodataEnd *uint64
-
-	symbols, err := object.Symbols()
-	if err != nil {
-		return errors.New("failed to parse symbols: " + err.Error())
-	}
-
-	for _, symbol := range symbols {
-		var base uint64
-		switch symbol.Section {
-		case textSectionIndex:
-			base = textSection.Addr
-		case rodataSectionIndex:
-			if rodataSection == nil {
-				continue
-			}
-			base = rodataSection.Addr
-		default:
-			continue
-		}
-
-		if isStatic {
-			// Static objects appear to have different semantics about whether symbol
-			// values are relative to their section or not.
-			base = 0
-		} else if symbol.Value < base {
-			return fmt.Errorf("symbol %q at %x, which is below base of %x", symbol.Name, symbol.Value, base)
-		}
-
-		value := symbol.Value - base
-		switch symbol.Name {
-		case "BORINGSSL_bcm_text_start":
-			if textStart != nil {
-				return errors.New("duplicate start symbol found")
-			}
-			textStart = &value
-		case "BORINGSSL_bcm_text_end":
-			if textEnd != nil {
-				return errors.New("duplicate end symbol found")
-			}
-			textEnd = &value
-		case "BORINGSSL_bcm_rodata_start":
-			if rodataStart != nil {
-				return errors.New("duplicate rodata start symbol found")
-			}
-			rodataStart = &value
-		case "BORINGSSL_bcm_rodata_end":
-			if rodataEnd != nil {
-				return errors.New("duplicate rodata end symbol found")
-			}
-			rodataEnd = &value
-		default:
-			continue
-		}
-	}
-
-	if textStart == nil || textEnd == nil {
-		return errors.New("could not find .text module boundaries in object")
-	}
-
-	if (rodataStart == nil) != (rodataSection == nil) {
-		return errors.New("rodata start marker inconsistent with rodata section presence")
-	}
-
-	if (rodataStart != nil) != (rodataEnd != nil) {
-		return errors.New("rodata marker presence inconsistent")
-	}
-
-	if max := textSection.Size; *textStart > max || *textStart > *textEnd || *textEnd > max {
-		return fmt.Errorf("invalid module .text boundaries: start: %x, end: %x, max: %x", *textStart, *textEnd, max)
-	}
-
-	if rodataSection != nil {
-		if max := rodataSection.Size; *rodataStart > max || *rodataStart > *rodataEnd || *rodataEnd > max {
-			return fmt.Errorf("invalid module .rodata boundaries: start: %x, end: %x, max: %x", *rodataStart, *rodataEnd, max)
-		}
-	}
-
-	// Extract the module from the .text section and hash it.
-
-	text := textSection.Open()
-	if _, err := text.Seek(int64(*textStart), 0); err != nil {
-		return errors.New("failed to seek to module start in .text: " + err.Error())
-	}
-	moduleText := make([]byte, *textEnd-*textStart)
-	if _, err := io.ReadFull(text, moduleText); err != nil {
-		return errors.New("failed to read .text: " + err.Error())
-	}
-
-	// Maybe extract the module's read-only data too
-	var moduleROData []byte
-	if rodataSection != nil {
-		rodata := rodataSection.Open()
-		if _, err := rodata.Seek(int64(*rodataStart), 0); err != nil {
-			return errors.New("failed to seek to module start in .rodata: " + err.Error())
-		}
-		moduleROData = make([]byte, *rodataEnd-*rodataStart)
-		if _, err := io.ReadFull(rodata, moduleROData); err != nil {
-			return errors.New("failed to read .rodata: " + err.Error())
-		}
-	}
 
 	var zeroKey [64]byte
 	hashFunc := sha512.New
@@ -258,10 +411,11 @@ func main() {
 	oInput := flag.String("in-object", "", "Path to a .o file")
 	outPath := flag.String("o", "", "Path to output object")
 	sha256 := flag.Bool("sha256", false, "Whether to use SHA-256 over SHA-512. This must match what the compiled module expects.")
+  macOS := flag.Bool("macos", false, "Whether the FIPS module is built for macOS or not.")
 
 	flag.Parse()
 
-	if err := do(*outPath, *oInput, *arInput, *sha256); err != nil {
+	if err := do(*outPath, *oInput, *arInput, *sha256, *macOS); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}

--- a/util/fipstools/inject_hash/inject_hash.go
+++ b/util/fipstools/inject_hash/inject_hash.go
@@ -179,18 +179,18 @@ func doMacOS(objectBytes []byte) ([]byte, []byte, error) {
 	}
 
 	// Find the __text and, optionally, __const sections.
+	// They are both in __TEXT segment and are unique.
 	var textSection, rodataSection *macho.Section
 	var textSectionIndex, rodataSectionIndex int
 	for i, section := range object.Sections {
-
-    if section.Seg == "__TEXT" && section.Name == "__text" {
+		if section.Seg == "__TEXT" && section.Name == "__text" {
 			textSection = section
 			textSectionIndex = i + 1
-    }
-    if section.Seg == "__TEXT" && section.Name == "__const" {
+		}
+		if section.Seg == "__TEXT" && section.Name == "__const" {
 			rodataSection = section
 			rodataSectionIndex = i + 1
-    }
+		}
 	}
 
 	if textSection == nil {
@@ -312,9 +312,9 @@ func do(outPath, oInput string, arInput string, useSHA256 bool, macOS bool) erro
 			return fmt.Errorf("-in-archive and -in-object are mutually exclusive")
 		}
 
-    if macOS {
-      return fmt.Errorf("only shared libraries can be handled on macOS")
-    }
+		if macOS {
+			return fmt.Errorf("only shared libraries can be handled on macOS")
+		}
 
 		fi, err := os.Stat(arInput)
 		if err != nil {
@@ -411,7 +411,7 @@ func main() {
 	oInput := flag.String("in-object", "", "Path to a .o file")
 	outPath := flag.String("o", "", "Path to output object")
 	sha256 := flag.Bool("sha256", false, "Whether to use SHA-256 over SHA-512. This must match what the compiled module expects.")
-  macOS := flag.Bool("macos", false, "Whether the FIPS module is built for macOS or not.")
+	macOS := flag.Bool("macos", false, "Whether the FIPS module is built for macOS or not.")
 
 	flag.Parse()
 


### PR DESCRIPTION
### Issues:
CryptoAlg-906

### Description of changes: 
This change enables the FIPS build of the shared library on macOS.

### Call-outs:
We don't have macOS testing in the CI yet, so this change is tested only on my macbook. The reviewers should download the code and try to build the library to at least verify that it works on their macbook.

### Testing:
See call-outs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
