### PR TITLE
Use DCMAKE_BUILD_TYPE=Release as FIPS build type.

### DIFF
--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -10,18 +10,15 @@ fips_build_and_test -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
 # The AL2 version of Clang does not have all of the required artifacts for address sanitizer, see P45594051
 if [[ "${AWSLC_NO_ASM_FIPS}" == "1" ]]; then
   if [[ ("$(uname -p)" == 'x86_64'*) ]]; then
-    echo "Building with Clang and testing AWS-LC in FIPS RelWithDebInfo mode with address sanitizer."
-    fips_build_and_test -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=1
+    echo "Building with Clang and testing AWS-LC in FIPS Release mode with address sanitizer."
+    fips_build_and_test -DASAN=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
   else
     # See the comment in run_posix_santizers.sh for more context. ASAN on Arm has a huge performance impact on ssl_test
     # which causes it to take over 2 hours to complete.
-    echo "Building with Clang and testing AWS-LC in FIPS RelWithDebInfo mode with address sanitizer only running crypto_test"
-    run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=1
+    echo "Building with Clang and testing AWS-LC in FIPS Release mode with address sanitizer only running crypto_test"
+    run_build -DASAN=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
     go run util/all_tests.go -build-dir "$BUILD_ROOT"
   fi
-else
-  echo "Not building with Clang and testing AWS-LC in FIPS RelWithDebInfo mode."
-  fips_build_and_test -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=1
 fi
 
 echo "Testing shared AWS-LC in FIPS Debug mode in a different folder."

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -16,7 +16,7 @@ if [[ "${AWSLC_NO_ASM_FIPS}" == "1" ]]; then
     # See the comment in run_posix_santizers.sh for more context. ASAN on Arm has a huge performance impact on ssl_test
     # which causes it to take over 2 hours to complete.
     echo "Building with Clang and testing AWS-LC in FIPS Release mode with address sanitizer only running crypto_test"
-    run_build -DASAN=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
+    run_build -DFIPS=1 -DASAN=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
     go run util/all_tests.go -build-dir "$BUILD_ROOT"
   fi
 fi


### PR DESCRIPTION
### Description of changes: 
This PR used `DCMAKE_BUILD_TYPE=Release` as FIPS build type based on the ACVP lab request.

### Call-outs:
TBD

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
