### PR TITLE
Documentation updates for Windows and building FIPS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,6 +497,10 @@ if(FIPS AND (NOT GO_EXECUTABLE OR NOT PERL_EXECUTABLE))
   message(FATAL_ERROR "Building AWS-LC for FIPS requires Go and Perl")
 endif()
 
+if(FIPS AND NOT BUILD_SHARED_LIBS)
+  message(FATAL_ERROR "Building AWS-LC for FIPS only supports the shared build, you must pass in '-DBUILD_SHARED_LIBS=TRUE'")
+endif()
+
 if(FIPS)
   add_definitions(-DBORINGSSL_FIPS)
   if(FIPS_BREAK_TEST)

--- a/tests/ci/docker_images/windows/README.md
+++ b/tests/ci/docker_images/windows/README.md
@@ -1,8 +1,8 @@
 ## Building Windows Docker Images and Uploading them to AWS Elastic Container Service
 ### Prerequisites
 * An host to build the image with
-  * Windows Server 2016 with Containers. The EC2 AMI
-    Windows_Server-2016-English-Full-Containers-2019.09.11 was used to build the
+  * Windows Server 2019 with Containers. The EC2 AMI
+    EC2LaunchV2-Windows_Server-2019-English-Full-ContainersLatest-2021.12.15 was used to build the
     images used by this repository
 * Docker
   * To install run the following in an admin powershell of your new instance:


### PR DESCRIPTION
### Description of changes: 
* The Windows CI readme was out of date and would not be able to build or use our Docker containers.
* Add a safety check to our FIPS build to reduce confusion. Without the check the build fails with a delocate parse error.

### Call-outs:
We already don't support a FIPS static build, this check just helps users understand the issue.

### Testing:
Not passing in the required flag fails with:
```
CMake Error at CMakeLists.txt:501 (message):
  Building AWS-LC for FIPS only supports the shared build, you must pass in
  '-DBUILD_SHARED_LIBS=TRUE'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
