### PR TITLE
Add support to ACVP tool to parse new TLS 1.2 with RFC7267 KDF tests

### DIFF
--- a/util/fipstools/acvp/acvptool/subprocess/subprocess.go
+++ b/util/fipstools/acvp/acvptool/subprocess/subprocess.go
@@ -100,8 +100,9 @@ func NewWithIO(cmd *exec.Cmd, in io.WriteCloser, out io.ReadCloser) *Subprocess 
 		"KAS-KDF":          &hkdf{},
 		"CMAC-AES":         &keyedMACPrimitive{"CMAC-AES"},
 		"RSA":              &rsa{},
-		"kdf-components":   &tlsKDF{},
-		"KAS-ECC-SSC":      &kas{},
+		"kdf-components":   &tlsKDF{"kdf-components"},
+		"TLS-v1.2":         &tlsKDF{"TLS-v1.2"},
+        "KAS-ECC-SSC":      &kas{},
 		"KAS-FFC-SSC":      &kasDH{},
 	}
 	m.primitives["ECDSA"] = &ecdsa{"ECDSA", map[string]bool{"P-224": true, "P-256": true, "P-384": true, "P-521": true}, m.primitives}

--- a/util/fipstools/acvp/acvptool/subprocess/subprocess.go
+++ b/util/fipstools/acvp/acvptool/subprocess/subprocess.go
@@ -102,7 +102,7 @@ func NewWithIO(cmd *exec.Cmd, in io.WriteCloser, out io.ReadCloser) *Subprocess 
 		"RSA":              &rsa{},
 		"kdf-components":   &tlsKDF{"kdf-components"},
 		"TLS-v1.2":         &tlsKDF{"TLS-v1.2"},
-        "KAS-ECC-SSC":      &kas{},
+		"KAS-ECC-SSC":      &kas{},
 		"KAS-FFC-SSC":      &kasDH{},
 	}
 	m.primitives["ECDSA"] = &ecdsa{"ECDSA", map[string]bool{"P-224": true, "P-256": true, "P-384": true, "P-521": true}, m.primitives}

--- a/util/fipstools/acvp/acvptool/subprocess/tlskdf.go
+++ b/util/fipstools/acvp/acvptool/subprocess/tlskdf.go
@@ -46,6 +46,7 @@ type tlsKDFTest struct {
 	ServerHelloRandomHex string `json:"serverHelloRandom"`
 	ClientRandomHex      string `json:"clientRandom"`
 	ServerRandomHex      string `json:"serverRandom"`
+	SessionHashHex       string `json:"sessionHash""`
 }
 
 type tlsKDFTestGroupResponse struct {
@@ -141,19 +142,33 @@ func (k *tlsKDF) Process(vectorSet []byte, m Transactable) (interface{}, error) 
 				return nil, err
 			}
 
+			sessionHash, err := hex.DecodeString(test.SessionHashHex)
+			if err != nil {
+				return nil, err
+			}
+
 			const (
 				masterSecretLength = 48
 				masterSecretLabel  = "master secret"
+				extendedLabel      = "extended master secret"
 				keyBlockLabel      = "key expansion"
 			)
 
 			var outLenBytes [4]byte
 			binary.LittleEndian.PutUint32(outLenBytes[:], uint32(masterSecretLength))
-			result, err := m.Transact(method, 1, outLenBytes[:], pms, []byte(masterSecretLabel), clientHelloRandom, serverHelloRandom)
+			var result [][]byte
+			switch k.algo {
+			case "kdf-components":
+				result, err = m.Transact(method, 1, outLenBytes[:], pms, []byte(masterSecretLabel), clientHelloRandom, serverHelloRandom)
+
+			case "TLS-v1.2":
+				result, err = m.Transact(method, 1, outLenBytes[:], pms, []byte(extendedLabel), sessionHash, nil)
+			default:
+				return nil, fmt.Errorf("unknown algorithm %q", k.algo)
+			}
 			if err != nil {
 				return nil, err
 			}
-
 			binary.LittleEndian.PutUint32(outLenBytes[:], uint32(group.KeyBlockBits/8))
 			// TLS 1.0, 1.1, and 1.2 use a different order for the client and server
 			// randoms when computing the key block.

--- a/util/fipstools/acvp/modulewrapper/modulewrapper.cc
+++ b/util/fipstools/acvp/modulewrapper/modulewrapper.cc
@@ -814,6 +814,16 @@ static bool GetConfig(const Span<const uint8_t> args[], ReplyCallback write_repl
         ]
       },
       {
+        "algorithm": "TLS-v1.2",
+        "revision": "RFC7627",
+        "mode": "KDF",
+        "hashAlg": [
+          "SHA2-256",
+          "SHA2-384",
+          "SHA2-512"
+        ]
+      },
+      {
         "algorithm": "KAS-ECC-SSC",
         "revision": "Sp800-56Ar3",
         "scheme": {


### PR DESCRIPTION
Addresses CryptoAlg-921

### Description of changes: 
Our ACVP tool previously only supported the TLS KDF tests for 1.0/1.1/1.2. Recently TLS extended master secret got it's own ACVP tests under a new section. This change adds support to parse and run these tests. 

### Call-outs:
I have run this locally with demo vectors and confirmed the generated output matches the expected out for the old style and new extended master secret tests.

### Testing:
With sample vectors `./acvptool -json request-1.2 ` returns the expected answers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
