### PR TITLE
Enable SSL runner tests with ASAN on arm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,6 +753,12 @@ endif()
 
 if(UNIX AND NOT APPLE AND NOT ANDROID)
   set(HANDSHAKER_ARGS "-handshaker-path" $<TARGET_FILE:handshaker>)
+  if(DEFINED ENV{AWS_LC_SSL_RUNNER_START_INDEX})
+    set(AWS_LC_SSL_RUNNER_INDEX_FILTER "-test-case-start-index" $ENV{AWS_LC_SSL_RUNNER_START_INDEX})
+  endif()
+  if(DEFINED ENV{AWS_LC_SSL_RUNNER_END_INDEX})
+    set(AWS_LC_SSL_RUNNER_INDEX_FILTER "${AWS_LC_SSL_RUNNER_INDEX_FILTER}" "-test-case-end-index" $ENV{AWS_LC_SSL_RUNNER_END_INDEX})
+  endif()
 endif()
 
 # Define GO_TEST_TIMEOUT based on env variable.
@@ -797,14 +803,20 @@ if(BUILD_TESTING)
 
     if(BUILD_LIBSSL)
       add_custom_target(
+          run_ssl_runner_tests
+          COMMAND cd ssl/test/runner &&
+                  ${GO_EXECUTABLE} test -timeout ${GO_TEST_TIMEOUT} -shim-path $<TARGET_FILE:bssl_shim>
+                    ${HANDSHAKER_ARGS} ${RUNNER_ARGS} ${AWS_LC_SSL_RUNNER_INDEX_FILTER}
+          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          DEPENDS bssl_shim handshaker fips_specific_tests_if_any
+          ${MAYBE_USES_TERMINAL})
+
+      add_custom_target(
           run_tests
           COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
                   ${CMAKE_BINARY_DIR}
-          COMMAND cd ssl/test/runner &&
-                  ${GO_EXECUTABLE} test -timeout ${GO_TEST_TIMEOUT} -shim-path $<TARGET_FILE:bssl_shim>
-                    ${HANDSHAKER_ARGS} ${RUNNER_ARGS}
           WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-          DEPENDS all_tests bssl_shim handshaker fips_specific_tests_if_any
+          DEPENDS all_tests run_ssl_runner_tests
           ${MAYBE_USES_TERMINAL})
     else()
       add_custom_target(

--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -77,6 +77,8 @@ var (
 	shimConfigFile     = flag.String("shim-config", "", "A config file to use to configure the tests for this shim.")
 	includeDisabled    = flag.Bool("include-disabled", false, "If true, also runs disabled tests.")
 	repeatUntilFailure = flag.Bool("repeat-until-failure", false, "If true, the first selected test will be run repeatedly until failure.")
+	testCaseStartIndex = flag.Int("test-case-start-index", -1, "If non-negative, test case is filtered in if the index in |testCases| >= test-case-start-index.")
+	testCaseEndIndex   = flag.Int("test-case-end-index", -1, "If non-negative, test case is filtered in if the index in |testCases| <= test-case-end-index.")
 )
 
 // ShimConfigurations is used with the “json” package and represents a shim
@@ -18894,6 +18896,34 @@ func checkTests() {
 	}
 }
 
+// filterTests filters |inputTests| given the index range [|startIndex|, |endIndex|].
+// When |startIndex| is negative, the default value |0| is used.
+// When |endIndex| is negative, the default value |len(inputTests) - 1| is used.
+// |inputTests| and the final filtered test cases cannot be empty.
+func filterTests(inputTests []testCase, startIndex int, endIndex int) []testCase {
+	if (len(inputTests) == 0) || ((startIndex < 0) && (endIndex < 0)) {
+		return inputTests
+	}
+	var filteredTestCases []testCase
+	if startIndex < 0 {
+		// Default to the start index of |inputTests|.
+		startIndex = 0
+	}
+	if endIndex < 0 {
+		// Default to the end index of |inputTests|.
+		endIndex = len(inputTests) - 1
+	}
+	for i, t := range inputTests {
+		if (i >= startIndex) && (i <= endIndex) {
+			filteredTestCases = append(filteredTestCases, t)
+		}
+	}
+	if len(filteredTestCases) == 0 {
+		panic(fmt.Sprintf("filteredTestCases is empty. startIndex: %d, endIndex: %d.", startIndex, endIndex))
+	}
+	return filteredTestCases
+}
+
 func main() {
 	flag.Parse()
 	*resourceDir = path.Clean(*resourceDir)
@@ -18969,6 +18999,8 @@ func main() {
 		os.Exit(1)
 	}
 	testCases = append(testCases, toAppend...)
+
+	testCases = filterTests(testCases, *testCaseStartIndex, *testCaseEndIndex)
 
 	checkTests()
 

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -90,6 +90,56 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-9x_latest
 
+    # BoringSSL has 7k+ ssl runner tests, and the total number of the runner tests keep increasing.
+    # When ASAN enabled, the tests take more than 1 hour to finish. The cause relates to https://github.com/google/sanitizers/issues/1331
+    # To reduce the total time, these tests will be executed in below CodeBuild dimensions:
+    #   1. ubuntu2004_clang9x_ssl_asan_1
+    #   2. ubuntu2004_clang9x_ssl_asan_2
+    #   3. ubuntu2004_clang9x_ssl_asan_3
+    #   4. ubuntu2004_clang9x_ssl_asan_4
+    # Env var |AWS_LC_SSL_RUNNER_START_INDEX| and |AWS_LC_SSL_RUNNER_END_INDEX| are used to filter the runner tests.
+    - identifier: ubuntu2004_clang9x_ssl_asan_1
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_ssl_asan_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-9x_latest
+        variables:
+          AWS_LC_SSL_RUNNER_END_INDEX: 3500
+
+    - identifier: ubuntu2004_clang9x_ssl_asan_2
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_ssl_asan_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-9x_latest
+        variables:
+          AWS_LC_SSL_RUNNER_START_INDEX: 3501
+          AWS_LC_SSL_RUNNER_END_INDEX: 5500
+
+    - identifier: ubuntu2004_clang9x_ssl_asan_3
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_ssl_asan_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-9x_latest
+        variables:
+          AWS_LC_SSL_RUNNER_START_INDEX: 5501
+          AWS_LC_SSL_RUNNER_END_INDEX: 7000
+
+    - identifier: ubuntu2004_clang9x_ssl_asan_4
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_ssl_asan_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-9x_latest
+        variables:
+          AWS_LC_SSL_RUNNER_START_INDEX: 7001
+
     - identifier: ubuntu2004_clang10x_aarch
       buildspec: ./tests/ci/codebuild/linux-aarch/run_posix_tests.yml
       env:

--- a/tests/ci/codebuild/linux-aarch/run_ssl_asan_tests.yml
+++ b/tests/ci/codebuild/linux-aarch/run_ssl_asan_tests.yml
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      # To use this build spec file, CMake environment variable CC and CXX compiler should be pre-defined.
+      - if [[ -z "${CC+x}" || -z "${CC}" ]]; then echo "CC is not defined." && exit 1; else ${CC} --version && echo "Found CC."; fi
+      - if [[ -z "${CXX+x}" || -z "${CXX}" ]]; then echo "CXX is not defined." && exit 1; else ${CXX} --version && echo "Found CXX."; fi
+      # Sanitizer is very slow on ARM.
+      # https://github.com/google/sanitizers/issues/1331
+      - export AWS_LC_GO_TEST_TIMEOUT='60m'
+  build:
+    commands:
+      - ./tests/ci/run_ssl_asan_tests.sh 

--- a/tests/ci/run_posix_sanitizers.sh
+++ b/tests/ci/run_posix_sanitizers.sh
@@ -13,8 +13,8 @@ if [ $(dpkg --print-architecture) == "arm64" ]; then
   # Details: https://github.com/google/boringssl/blob/master/BUILDING.md
   # The blackbox tests (run `go test` under `ssl/test/runner`) take 30 minutes to complete on ARM when ASAN clang flag enabled.
   # But the blackbox tests take less than 2 minutes to complete on other test dimensions -- X86 ASAN and ARM (when ASAN disabled).
-  # Instead of running the two sets tests, only the former test is executed here.
-  # TODO: Open a GitHub issue on https://github.com/google/sanitizers/issues, and then link the issue here.
+  # Instead of running the two sets tests, only the former test is executed here. ssl runner tests are covered by |run_ssl_asan_tests.sh|.
+  # https://github.com/google/sanitizers/issues/1331
   echo "Building AWS-LC in ${build_type} mode with address sanitizer, and running only non ssl test."
   run_build -DASAN=1 -DUSE_CUSTOM_LIBCXX=1 "${cflags[@]}"
   go run util/all_tests.go -build-dir "$BUILD_ROOT"

--- a/tests/ci/run_ssl_asan_tests.sh
+++ b/tests/ci/run_ssl_asan_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -exo pipefail
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# BoringSSL has 7k+ ssl runner tests, and the total number of the runner tests keep increasing.
+# When ASAN enabled, the tests take more than 1 hour to finish. The cause relates to https://github.com/google/sanitizers/issues/1331
+# To reduce the total time, these tests will be executed in diff CodeBuild dimensions.
+# Env var |AWS_LC_SSL_RUNNER_START_INDEX| and |AWS_LC_SSL_RUNNER_END_INDEX| will be used with this script to split runner tests.
+source tests/ci/common_posix_setup.sh
+
+build_type=Release
+cflags=("-DCMAKE_BUILD_TYPE=${build_type}")
+
+if [ $(dpkg --print-architecture) == "arm64" ]; then
+  echo "Executing AWS-LC SSL runner tests in ${build_type} mode with address sanitizer."
+  run_build -DASAN=1 -DUSE_CUSTOM_LIBCXX=1 "${cflags[@]}"
+  run_cmake_custom_target 'run_ssl_runner_tests'
+fi


### PR DESCRIPTION
Cherry pick ee356753851b1682ac90c86fd0b755bfe2278f2b from main onto the FIPS branch to fix the CI. Without this change the CI fails due to:
```
[Container] 2021/12/22 02:50:53 Phase context status code: YAML_FILE_ERROR Message: stat /codebuild/output/src352659667/src/github.com/awslabs/aws-lc/tests/ci/codebuild/linux-aarch/run_ssl_asan_tests.yml: no such file or directory
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
