### PR TITLE
Partial public-key validation for peer key in ECDH

### DIFF
--- a/crypto/ecdh_extra/ecdh_test.cc
+++ b/crypto/ecdh_extra/ecdh_test.cc
@@ -227,7 +227,7 @@ TEST(ECDHTest, InvalidPubKeyLargeCoord) {
     OPENSSL_memcpy(peer_key.get()->pub_key->raw.X.bytes, (const uint8_t *)xpp.get()->d, len);
     ret = ECDH_compute_key_fips(shared_key.data(), shared_key.size(),
                                     EC_KEY_get0_public_key(peer_key.get()), priv_key.get());
-    if (!awslc_fips() && (group.get()->curve_name == NID_secp224r1)) {
+    if (!awslc_fips() && has_uint128_and_not_small() && (group.get()->curve_name == NID_secp224r1)) {
       ASSERT_TRUE(ret);
     } else {
       ASSERT_FALSE(ret);

--- a/crypto/ecdh_extra/ecdh_test.cc
+++ b/crypto/ecdh_extra/ecdh_test.cc
@@ -36,7 +36,6 @@
 #include "../test/test_util.h"
 #include "../test/wycheproof_util.h"
 
-
 static bssl::UniquePtr<EC_GROUP> GetCurve(FileTest *t, const char *key) {
   std::string curve_name;
   if (!t->GetAttribute(&curve_name, key)) {
@@ -128,6 +127,22 @@ TEST(ECDHTest, TestVectors) {
   });
 }
 
+static int has_uint128_and_not_small() {
+#if defined(BORINGSSL_HAS_UINT128) && !defined(OPENSSL_SMALL)
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+static int awslc_fips() {
+#if defined(AWSLC_FIPS)
+  return 1;
+#else
+  return 0;
+#endif
+}
+
 // The following test is adapted from ECTest.LargeXCoordinateVectors
 TEST(ECDHTest, InvalidPubKeyLargeCoord) {
   bssl::UniquePtr<BN_CTX> ctx(BN_CTX_new());
@@ -135,6 +150,7 @@ TEST(ECDHTest, InvalidPubKeyLargeCoord) {
 
   FileTestGTest("crypto/fipsmodule/ec/large_x_coordinate_points.txt",
                 [&](FileTest *t) {
+    int ret;
     bssl::UniquePtr<EC_GROUP> group = GetCurve(t, "Curve");
     ASSERT_TRUE(group);
     bssl::UniquePtr<BIGNUM> x = GetBIGNUM(t, "X");
@@ -162,13 +178,16 @@ TEST(ECDHTest, InvalidPubKeyLargeCoord) {
     // The following call converts the point to Montgomery form for P-256, 384 and 521.
     // For P-224, when the functions from simple.c are used, i.e. when
     // group->meth = EC_GFp_nistp224_method, the coordinate representation is not changed.
-    // This is determined based on compile flags in ec.c that are also used below.
+    // This is determined based on compile flags in ec.c that are also used below
+    // in has_uint128_and_not_small().
     ASSERT_TRUE(EC_POINT_set_affine_coordinates_GFp(
-                    group.get(), pub_key.get(), x.get(), y.get(), nullptr));
+                  group.get(), pub_key.get(), x.get(), y.get(), nullptr));
     ASSERT_TRUE(EC_KEY_set_public_key(peer_key.get(), pub_key.get()));
-    //ASSERT_TRUE(EC_KEY_check_fips(peer_key.get()));
     ASSERT_TRUE(ECDH_compute_key_fips(shared_key.data(), shared_key.size(),
                                       EC_KEY_get0_public_key(peer_key.get()), priv_key.get()));
+    // Ensure the pointers were not affected.
+    ASSERT_TRUE(peer_key.get());
+    ASSERT_TRUE(pub_key.get());
 
     // Set the raw point directly with the BIGNUM coordinates.
     // Note that both are in little-endian byte order.
@@ -177,31 +196,53 @@ TEST(ECDHTest, InvalidPubKeyLargeCoord) {
     OPENSSL_memset(peer_key.get()->pub_key->raw.Z.bytes, 0, len);
     peer_key.get()->pub_key->raw.Z.bytes[0] = 1;
     // As mentioned, for P-224, setting the raw point directly with the coordinates
-    // still passes |EC_KEY_check_fips|.
+    // still passes |EC_KEY_check_fips| and the rest of the computation.
     // For P-256, 384 and 521, the failure is due to that the coordinates are
-    // not in Montgomery representation, and, hence, fail |EC_KEY_check_fips|.
-#if defined(BORINGSSL_HAS_UINT128) && !defined(OPENSSL_SMALL)
-    if (group.get()->curve_name == NID_secp224r1)
+    // not in Montgomery representation, and, hence, fail |EC_KEY_check_fips|, if in FIPS build;
+    // or the shared secret computation, otherwise.
+    ret = ECDH_compute_key_fips(shared_key.data(), shared_key.size(),
+                                EC_KEY_get0_public_key(peer_key.get()), priv_key.get());
+    if (has_uint128_and_not_small() && (group.get()->curve_name == NID_secp224r1))
     {
-      ASSERT_TRUE(ECDH_compute_key_fips(shared_key.data(), shared_key.size(),
-                                        EC_KEY_get0_public_key(peer_key.get()), priv_key.get()));
+      ASSERT_TRUE(ret);
     } else {
-#endif
-      ASSERT_FALSE(ECDH_compute_key_fips(shared_key.data(), shared_key.size(),
-                                        EC_KEY_get0_public_key(peer_key.get()), priv_key.get()));
-       EXPECT_EQ(EC_R_PUBLIC_KEY_VALIDATION_FAILED,
-                ERR_GET_REASON(ERR_peek_last_error()));
-#if defined(BORINGSSL_HAS_UINT128) && !defined(OPENSSL_SMALL)
+      ASSERT_FALSE(ret);
+      if (awslc_fips()) {
+        // Fails in |EC_KEY_check_fips|.
+        EXPECT_EQ(EC_R_PUBLIC_KEY_VALIDATION_FAILED,
+                  ERR_GET_REASON(ERR_peek_last_error()));
+      } else {
+        // Fails in the actual shared secret computation.
+        EXPECT_EQ(ECDH_R_POINT_ARITHMETIC_FAILURE,
+                  ERR_GET_REASON(ERR_peek_last_error()));
+      }
     }
-#endif
+    ASSERT_TRUE(peer_key.get());
+    ASSERT_TRUE(pub_key.get());
 
     // Now replace the x-coordinate with the larger one, x+p;
-    // ECDH fails |EC_KEY_check_fips| in all curves.
+    // ECDH fails |EC_KEY_check_fips| or in the actual shared secret computation
+    // in all curves (except for P-224 in non-FIPS build).
+    // TODO: Do we want to widen the check the non-FIPS builds?.
     OPENSSL_memcpy(peer_key.get()->pub_key->raw.X.bytes, (const uint8_t *)xpp.get()->d, len);
-    ASSERT_FALSE(ECDH_compute_key_fips(shared_key.data(), shared_key.size(),
-                                       EC_KEY_get0_public_key(peer_key.get()), priv_key.get()));
-    EXPECT_EQ(EC_R_PUBLIC_KEY_VALIDATION_FAILED,
-              ERR_GET_REASON(ERR_peek_last_error()));
+    ret = ECDH_compute_key_fips(shared_key.data(), shared_key.size(),
+                                    EC_KEY_get0_public_key(peer_key.get()), priv_key.get());
+    if (!awslc_fips() && (group.get()->curve_name == NID_secp224r1)) {
+      ASSERT_TRUE(ret);
+    } else {
+      ASSERT_FALSE(ret);
+      if (awslc_fips()) {
+        // Fails in |EC_KEY_check_fips|.
+        EXPECT_EQ(EC_R_PUBLIC_KEY_VALIDATION_FAILED,
+                  ERR_GET_REASON(ERR_peek_last_error()));
+      } else {
+        // Fails in the actual shared secret computation.
+        EXPECT_EQ(ECDH_R_POINT_ARITHMETIC_FAILURE,
+                  ERR_GET_REASON(ERR_peek_last_error()));
+      }
+      ASSERT_TRUE(peer_key.get());
+      ASSERT_TRUE(pub_key.get());
+    }
   });
 }
 

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1691,6 +1691,14 @@ static bool HasSuffix(const char *str, const char *suffix) {
   return strcmp(str + str_len - suffix_len, suffix) == 0;
 }
 
+static int has_uint128_and_not_small() {
+#if defined(BORINGSSL_HAS_UINT128) && !defined(OPENSSL_SMALL)
+  return 1;
+#else
+  return 0;
+#endif
+}
+
 // Test for out-of-range coordinates in public-key validation in
 // |EC_KEY_check_fips|, which can only be exercised for P-224 when the
 // coordinates in the raw point are not in Montgomery representation.
@@ -1721,7 +1729,8 @@ TEST(ECTest, LargeXCoordinateVectors) {
     // The following call converts the point to Montgomery form for P-256, 384 and 521.
     // For P-224, when the functions from simple.c are used, i.e. when
     // group->meth = EC_GFp_nistp224_method, the coordinate representation is not changed.
-    // This is determined based on compile flags in ec.c that are also used below.
+    // This is determined based on compile flags in ec.c that are also used below
+    // in has_uint128_and_not_small().
     ASSERT_TRUE(EC_POINT_set_affine_coordinates_GFp(
                     group.get(), pub_key.get(), x.get(), y.get(), nullptr));
     ASSERT_TRUE(EC_KEY_set_public_key(key.get(), pub_key.get()));
@@ -1739,19 +1748,16 @@ TEST(ECTest, LargeXCoordinateVectors) {
     // not in Montgomery representation, hence the checks fail earlier in
     // |EC_KEY_check_key| in the point-on-the-curve calculations, which use
     // Montgomery arithmetic.
-#if defined(BORINGSSL_HAS_UINT128) && !defined(OPENSSL_SMALL)
-    if (group.get()->curve_name == NID_secp224r1)
+    if (has_uint128_and_not_small() && (group.get()->curve_name == NID_secp224r1))
     {
       ASSERT_TRUE(EC_KEY_check_fips(key.get()));
     } else {
-#endif
       ASSERT_FALSE(EC_KEY_check_fips(key.get()));
       EXPECT_EQ(EC_R_POINT_IS_NOT_ON_CURVE,
                 ERR_GET_REASON(ERR_peek_last_error_line(&file, &line)));
       EXPECT_PRED2(HasSuffix, file, "ec_key.c"); // within EC_KEY_check_key
-#if defined(BORINGSSL_HAS_UINT128) && !defined(OPENSSL_SMALL)
     }
-#endif
+
     // Now replace the x-coordinate with the larger one, x+p.
     OPENSSL_memcpy(key.get()->pub_key->raw.X.bytes, (const uint8_t *)xpp.get()->d, len);
     ASSERT_FALSE(EC_KEY_check_fips(key.get()));
@@ -1759,19 +1765,15 @@ TEST(ECTest, LargeXCoordinateVectors) {
     // |EC_KEY_check_fips| check on coordinate range can only be exercised for P-224
     // when the coordinates in the raw point are not in Montgomery representation.
     // For the other curves, they fail for the same reason as above.
-#if defined(BORINGSSL_HAS_UINT128) && !defined(OPENSSL_SMALL)
-    if (group.get()->curve_name == NID_secp224r1) {
+    if (has_uint128_and_not_small() && (group.get()->curve_name == NID_secp224r1)) {
       EXPECT_EQ(EC_R_COORDINATES_OUT_OF_RANGE,
                 ERR_GET_REASON(ERR_peek_last_error_line(&file, &line)));
       EXPECT_PRED2(HasSuffix, file, "ec_key.c"); // within EC_KEY_check_fips
     } else {
-#endif
       EXPECT_EQ(EC_R_POINT_IS_NOT_ON_CURVE,
                 ERR_GET_REASON(ERR_peek_last_error_line(&file, &line)));
       EXPECT_PRED2(HasSuffix, file, "ec_key.c"); // within EC_KEY_check_key
-#if defined(BORINGSSL_HAS_UINT128) && !defined(OPENSSL_SMALL)
     }
-#endif
   });
 }
 

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1728,7 +1728,7 @@ TEST(ECTest, LargeXCoordinateVectors) {
     ASSERT_TRUE(EC_KEY_check_fips(key.get()));
 
     // Set the raw point directly with the BIGNUM coordinates.
-    // Note that both are in big-endian byte order.
+    // Note that both are in little-endian byte order.
     OPENSSL_memcpy(key.get()->pub_key->raw.X.bytes, (const uint8_t *)x.get()->d, len);
     OPENSSL_memcpy(key.get()->pub_key->raw.Y.bytes, (const uint8_t *)y.get()->d, len);
     OPENSSL_memset(key.get()->pub_key->raw.Z.bytes, 0, len);

--- a/crypto/fipsmodule/ecdh/ecdh.c
+++ b/crypto/fipsmodule/ecdh/ecdh.c
@@ -80,33 +80,33 @@
 int ECDH_compute_shared_secret(uint8_t *buf, size_t *buflen, const EC_POINT *pub_key,
                                const EC_KEY *priv_key) {
   int ret = 0;
-  EC_KEY *key_pub_key = NULL;
   if (priv_key->priv_key == NULL) {
     OPENSSL_PUT_ERROR(ECDH, ECDH_R_NO_PRIVATE_VALUE);
-    goto end;
+    goto err;
   }
   const EC_SCALAR *const priv = &priv_key->priv_key->scalar;
   const EC_GROUP *const group = EC_KEY_get0_group(priv_key);
   if (EC_GROUP_cmp(group, pub_key->group, NULL) != 0) {
     OPENSSL_PUT_ERROR(EC, EC_R_INCOMPATIBLE_OBJECTS);
-    goto end;
+    goto err;
   }
 
+#if defined(AWSLC_FIPS)
   // |EC_KEY_check_fips| is not an expensive operation on an external
   // public key.
+  EC_KEY *key_pub_key = NULL;
   key_pub_key = EC_KEY_new();
   if (key_pub_key == NULL) {
     goto end;
   }
 
-  if (is_fips_build()) {
-    if (!EC_KEY_set_group(key_pub_key, group) ||
-        !EC_KEY_set_public_key(key_pub_key, pub_key) || // Creates a copy of pub_key within key_pub_key
-        !EC_KEY_check_fips(key_pub_key)) {
-      OPENSSL_PUT_ERROR(EC, EC_R_PUBLIC_KEY_VALIDATION_FAILED);
-      goto end;
-    }
+  if (!EC_KEY_set_group(key_pub_key, group) ||
+      !EC_KEY_set_public_key(key_pub_key, pub_key) || // Creates a copy of pub_key within key_pub_key
+      !EC_KEY_check_fips(key_pub_key)) {
+    OPENSSL_PUT_ERROR(EC, EC_R_PUBLIC_KEY_VALIDATION_FAILED);
+    goto end;
   }
+#endif
 
   EC_RAW_POINT shared_point;
   if (!ec_point_mul_scalar(group, &shared_point, &pub_key->raw, priv) ||
@@ -118,9 +118,12 @@ int ECDH_compute_shared_secret(uint8_t *buf, size_t *buflen, const EC_POINT *pub
 
   ret = 1;
 end:
+#if defined(AWSLC_FIPS)
   if (key_pub_key != NULL) {
     EC_KEY_free(key_pub_key);
   }
+#endif
+err:
   return ret;
 }
 

--- a/crypto/fipsmodule/ecdh/ecdh.c
+++ b/crypto/fipsmodule/ecdh/ecdh.c
@@ -95,6 +95,10 @@ int ECDH_compute_shared_secret(uint8_t *buf, size_t *buflen, const EC_POINT *pub
   // |EC_KEY_check_fips| is not an expensive operation on an external
   // public key.
   key_pub_key = EC_KEY_new();
+  if (key_pub_key == NULL) {
+    goto end;
+  }
+
   if (!EC_KEY_set_group(key_pub_key, group) ||
       !EC_KEY_set_public_key(key_pub_key, pub_key) ||
       !EC_KEY_check_fips(key_pub_key)) {

--- a/crypto/fipsmodule/ecdh/ecdh.c
+++ b/crypto/fipsmodule/ecdh/ecdh.c
@@ -99,11 +99,13 @@ int ECDH_compute_shared_secret(uint8_t *buf, size_t *buflen, const EC_POINT *pub
     goto end;
   }
 
-  if (!EC_KEY_set_group(key_pub_key, group) ||
-      !EC_KEY_set_public_key(key_pub_key, pub_key) ||
-      !EC_KEY_check_fips(key_pub_key)) {
-    OPENSSL_PUT_ERROR(EC, EC_R_PUBLIC_KEY_VALIDATION_FAILED);
-    goto end;
+  if (is_fips_build()) {
+    if (!EC_KEY_set_group(key_pub_key, group) ||
+        !EC_KEY_set_public_key(key_pub_key, pub_key) || // Creates a copy of pub_key within key_pub_key
+        !EC_KEY_check_fips(key_pub_key)) {
+      OPENSSL_PUT_ERROR(EC, EC_R_PUBLIC_KEY_VALIDATION_FAILED);
+      goto end;
+    }
   }
 
   EC_RAW_POINT shared_point;


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-905

### Description of changes: 
Continuing on the requirements of public key validation in SP 800-56Ar3, this change satisfies Sec. 5.6.2.3.4, where a peer public key should undergo a partial key validation.
This change:
- satisfies performing the check in `EVP_PKEY_derive` and `ECDH_compute_key_fips`.
- ~also performs the check in `ECDH_compute_key` (non-FIPS-Approved), since the check is not expensive.~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
