### PR TITLE
Fix service indicator check for `EC_KEY_check_fips` 

### DIFF
--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -327,10 +327,6 @@ int EC_KEY_check_key(const EC_KEY *eckey) {
 }
 
 static int EVP_EC_KEY_check_fips(EC_KEY *key) {
-  // We have to avoid the underlying |EVP_DigestSign| and |EVP_DigestVerify|
-  // services updating the indicator state, so we lock the state here.
-  FIPS_service_indicator_lock_state();
-
   uint8_t msg[16] = {0};
   size_t msg_len = 16;
   int ret = 0;
@@ -363,22 +359,24 @@ err:
   EVP_PKEY_free(evp_pkey);
   OPENSSL_free(sig_der);
   EVP_MD_CTX_free(ctx);
-  FIPS_service_indicator_unlock_state();
-  if(ret){
-    FIPS_service_indicator_update_state();
-  }
   return ret;
 }
 
 int EC_KEY_check_fips(const EC_KEY *key) {
+  // We have to avoid the underlying |EVP_DigestSign| and |EVP_DigestVerify|
+  // services in |EVP_EC_KEY_check_fips| updating the indicator state, so we
+  // lock the state here.
+  FIPS_service_indicator_lock_state();
+  int ret = 0;
+
   if (EC_KEY_is_opaque(key)) {
     // Opaque keys can't be checked.
     OPENSSL_PUT_ERROR(EC, EC_R_PUBLIC_KEY_VALIDATION_FAILED);
-    return 0;
+    goto end;
   }
 
   if (!EC_KEY_check_key(key)) {
-    return 0;
+    goto end;
   }
 
   // Check that the coordinates are within the range [0,p-1], when the (raw)
@@ -389,34 +387,41 @@ int EC_KEY_check_fips(const EC_KEY *key) {
   if(ec_felem_equal(key->pub_key->group, &key->pub_key->group->one, &key->pub_key->raw.Z)) {
     BIGNUM *x = BN_new();
     BIGNUM *y = BN_new();
-    int ret = 1;
+    int check_ret = 1;
     if (key->pub_key->group->meth->felem_to_bytes == NULL) {
       OPENSSL_PUT_ERROR(EC, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
-      ret = 0;
+      check_ret = 0;
     } else if (!ec_felem_to_bignum(key->pub_key->group, x, &key->pub_key->raw.X) ||
                !ec_felem_to_bignum(key->pub_key->group, y, &key->pub_key->raw.Y)) {
       // Error already written to error queue by |bn_wexpand|.
-      ret = 0;
+      check_ret = 0;
     } else if (BN_is_negative(x) || BN_is_negative(y) ||
                BN_cmp(x, &key->pub_key->group->field) >= 0 ||
                BN_cmp(y, &key->pub_key->group->field) >= 0) {
       OPENSSL_PUT_ERROR(EC, EC_R_COORDINATES_OUT_OF_RANGE);
-      ret = 0;
+      check_ret = 0;
     }
     BN_free(x);
     BN_free(y);
-    if (ret == 0) {
-      return ret;
+    if (check_ret == 0) {
+      goto end;
     }
   }
 
   if (key->priv_key) {
     if (!EVP_EC_KEY_check_fips((EC_KEY*)key)) {
       OPENSSL_PUT_ERROR(EC, EC_R_PUBLIC_KEY_VALIDATION_FAILED);
-      return 0;
+      goto end;
     }
   }
-  return 1;
+
+  ret = 1;
+end:
+  FIPS_service_indicator_unlock_state();
+  if(ret){
+    FIPS_service_indicator_update_state();
+  }
+  return ret;
 }
 
 int EC_KEY_set_public_key_affine_coordinates(EC_KEY *key, const BIGNUM *x,

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -1271,7 +1271,13 @@ TEST_P(ECDSA_ServiceIndicatorTest, ECDSAKeyCheck) {
   ASSERT_EQ(approved, ecdsaTestVector.key_check_expect_approved);
   CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(EC_KEY_check_fips(key.get())));
   ASSERT_EQ(approved, ecdsaTestVector.key_check_expect_approved);
-
+  // Remove reference to private key in generated key and see if
+  // |EC_KEY_check_fips| still returns approval for keys with only public keys
+  // available.
+  bssl::UniquePtr<EC_KEY> key_only_public(EC_KEY_new_by_curve_name(ecdsaTestVector.nid));
+  ASSERT_TRUE(EC_KEY_set_public_key(key_only_public.get(), EC_KEY_get0_public_key(key.get())));
+  CALL_SERVICE_AND_CHECK_APPROVED(approved, ASSERT_TRUE(EC_KEY_check_fips(key_only_public.get())));
+  ASSERT_EQ(approved, ecdsaTestVector.key_check_expect_approved);
 
   // Test running the EVP_PKEY_keygen interfaces one by one directly, and check
   // |EVP_PKEY_keygen| for approval at the end. |EVP_PKEY_keygen_init| should


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-835 (FIPS follow-up)

### Description of changes: 
The previous service indicator check in `EC_KEY_check_fips` missed out on `EC_KEY`s that only had `pub_key` available. This was not the correct behavior and this PR fixes that.

### Testing:
New test in `crypto/fipsmodule/service_indicator/service_indicator_test.cc` where only `pub_key` is copied over from a generated `EC_KEY`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
