### PR TITLE
Enable more Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,7 +407,7 @@ if(FUZZ)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,fuzzer-no-link -fsanitize-coverage=edge,indirect-calls")
 endif()
 
-add_definitions(-DBORINGSSL_IMPLEMENTATION)
+#add_definitions(-DBORINGSSL_IMPLEMENTATION)
 
 if(BUILD_SHARED_LIBS)
   add_definitions(-DBORINGSSL_SHARED_LIBRARY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -705,6 +705,10 @@ if(BUILD_TESTING)
   # Add minimal googletest targets. The provided one has many side-effects, and
   # googletest has a very straightforward build.
   add_library(boringssl_gtest third_party/googletest/src/gtest-all.cc)
+  if(BUILD_SHARED_LIBS)
+    # This is needed for the Windows build to correctly annotate GTest's API with __declspec(dllexport)
+    target_compile_options(boringssl_gtest PRIVATE -DGTEST_CREATE_SHARED_LIBRARY=1)
+  endif()
   target_include_directories(boringssl_gtest PRIVATE third_party/googletest)
 
   include_directories(third_party/googletest/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,8 +407,6 @@ if(FUZZ)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,fuzzer-no-link -fsanitize-coverage=edge,indirect-calls")
 endif()
 
-#add_definitions(-DBORINGSSL_IMPLEMENTATION)
-
 if(BUILD_SHARED_LIBS)
   add_definitions(-DBORINGSSL_SHARED_LIBRARY)
   # Enable position-independent code globally. This is needed because

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -453,7 +453,7 @@ add_library(
   ${CRYPTO_ARCH_SOURCES}
   ${CRYPTO_FIPS_OBJECTS}
 )
-
+target_compile_definitions(crypto PRIVATE BORINGSSL_IMPLEMENTATION)
 if(FIPS_SHARED)
   # Rewrite libcrypto.so to inject the correct module hash value. This assumes
   # UNIX-style library naming, but we only support FIPS mode on Linux anyway.

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -216,6 +216,7 @@ if(FIPS_DELOCATE)
 
     bcm.c
   )
+  target_compile_definitions(bcm_c_generated_asm PRIVATE BORINGSSL_IMPLEMENTATION)
 
   if(ARCH STREQUAL "aarch64")
     # Perlasm output on Aarch64 needs to pass through the C preprocessor
@@ -258,6 +259,7 @@ if(FIPS_DELOCATE)
 
     bcm-delocated.S
   )
+  target_compile_definitions(bcm_hashunset PRIVATE BORINGSSL_IMPLEMENTATION)
 
   add_dependencies(bcm_hashunset global_target)
 
@@ -285,6 +287,7 @@ if(FIPS_DELOCATE)
 
     fips_shared_support.c
   )
+  target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
   add_dependencies(fipsmodule global_target)
 
@@ -301,6 +304,7 @@ elseif(FIPS_SHARED)
 
     fips_shared_support.c
   )
+  target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
   add_dependencies(fipsmodule global_target)
 
@@ -313,6 +317,7 @@ elseif(FIPS_SHARED)
 
     ${BCM_ASM_SOURCES}
   )
+  target_compile_definitions(bcm_library PRIVATE BORINGSSL_IMPLEMENTATION)
 
   add_dependencies(bcm_library global_target)
   # fips_shared.lds does not have 'clang' prefix because we want to keep merging any changes from upstream.
@@ -342,6 +347,7 @@ else()
 
     ${BCM_ASM_SOURCES}
   )
+  target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
   add_dependencies(fipsmodule global_target)
 endif()

--- a/decrepit/CMakeLists.txt
+++ b/decrepit/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   x509/x509_decrepit.c
   xts/xts.c
 )
+target_compile_definitions(decrepit PRIVATE BORINGSSL_IMPLEMENTATION)
 
 add_dependencies(decrepit global_target)
 

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -41,7 +41,7 @@ add_library(
   tls13_enc.cc
   tls13_server.cc
 )
-
+target_compile_definitions(ssl PRIVATE BORINGSSL_IMPLEMENTATION)
 add_dependencies(ssl global_target)
 
 target_link_libraries(ssl crypto)

--- a/tests/ci/run_windows_tests.bat
+++ b/tests/ci/run_windows_tests.bat
@@ -10,7 +10,8 @@ call %1 x64 || goto error
 SET
 call :build_and_test Release "" || goto error
 
-@rem Windows has no concept of Linux's rpath so it can't find the built dlls from CMake, add them to our path to work around this
+@rem Windows has no equivalent of Linux's rpath so it can't find the built dlls from CMake. We also don't want to install our
+@rem tests or copy them around so Windows can find it in the same directory. Instead just put the dll's location onto the path
 set PATH=%BUILD_DIR%;%BUILD_DIR%\crypto;%BUILD_DIR%\ssl;%PATH%
 call :build_and_test Release "-DBUILD_SHARED_LIBS=1" || goto error
 

--- a/tests/ci/run_windows_tests.bat
+++ b/tests/ci/run_windows_tests.bat
@@ -5,11 +5,14 @@ set BUILD_DIR=%SRC_ROOT%\test_build_dir
 
 @rem %1 contains the path to the setup batch file for the version of of visual studio that was passed in from the build spec file.
 @rem x64 comes from the architecture options https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line
-call %1 x64 || goto error
+set MSVC_PATH=%1
+call %MSVC_PATH% x64 || goto error
 SET
 
 @rem Run the same builds as run_posix_tests.sh
-call :build_and_test Debug "" || goto error
+@rem check which version of MSVC we're building with: remove 14.0 from the path to the compiler and check if it matches the
+@rem original string. MSVC 14 has an issue with a missing DLL that causes teh debug build to fail to start
+if x%MSVC_PATH:14.0=%==x%MSVC_PATH% call :build_and_test Debug "" || goto error
 call :build_and_test Release "" || goto error
 call :build_and_test Release "-DOPENSSL_SMALL=1" || goto error
 call :build_and_test Release "-DOPENSSL_NO_ASM=1" || goto error

--- a/tests/ci/run_windows_tests.bat
+++ b/tests/ci/run_windows_tests.bat
@@ -2,7 +2,6 @@
 set SRC_ROOT=%cd%
 set BUILD_DIR=%SRC_ROOT%\test_build_dir
 
-
 @rem %1 contains the path to the setup batch file for the version of of visual studio that was passed in from the build spec file.
 @rem x64 comes from the architecture options https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line
 set MSVC_PATH=%1
@@ -10,8 +9,8 @@ call %MSVC_PATH% x64 || goto error
 SET
 
 @rem Run the same builds as run_posix_tests.sh
-@rem check which version of MSVC we're building with: remove 14.0 from the path to the compiler and check if it matches the
-@rem original string. MSVC 14 has an issue with a missing DLL that causes teh debug build to fail to start
+@rem Check which version of MSVC we're building with: remove 14.0 from the path to the compiler and check if it matches the
+@rem original string. MSVC 14 has an issue with a missing DLL that causes the debug unit tests to fail
 if x%MSVC_PATH:14.0=%==x%MSVC_PATH% call :build_and_test Debug "" || goto error
 call :build_and_test Release "" || goto error
 call :build_and_test Release "-DOPENSSL_SMALL=1" || goto error
@@ -47,7 +46,6 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=%~1 %~2 %SRC_ROOT% || goto error
 @echo  LOG: %date%-%time% %1 %2 cmake generation complete, starting build
 ninja || goto error
 exit /b 0
-
 
 @rem Use the same parameters as build_and_test, this assumes the build is complete
 :test

--- a/tests/ci/run_windows_tests.bat
+++ b/tests/ci/run_windows_tests.bat
@@ -1,28 +1,23 @@
 @echo on
 set SRC_ROOT=%cd%
 set BUILD_DIR=%SRC_ROOT%\test_build_dir
-set INSTALL_DIR=%BUILD_DIR%\install
 
 
 @rem %1 contains the path to the setup batch file for the version of of visual studio that was passed in from the build spec file.
 @rem x64 comes from the architecture options https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line
 call %1 x64 || goto error
 SET
+
+@rem Run the same builds as run_posix_tests.sh
+call :build_and_test Debug "" || goto error
 call :build_and_test Release "" || goto error
+call :build_and_test Release "-DOPENSSL_SMALL=1" || goto error
+call :build_and_test Release "-DOPENSSL_NO_ASM=1" || goto error
 
 @rem Windows has no equivalent of Linux's rpath so it can't find the built dlls from CMake. We also don't want to install our
 @rem tests or copy them around so Windows can find it in the same directory. Instead just put the dll's location onto the path
 set PATH=%BUILD_DIR%;%BUILD_DIR%\crypto;%BUILD_DIR%\ssl;%PATH%
 call :build_and_test Release "-DBUILD_SHARED_LIBS=1" || goto error
-
-
-@rem call :build_and_test Release "-DOPENSSL_SMALL=1" || goto error
-@rem The NO_ASM fails due to some missing 'dummy_chacha20_poly1305_asm'
-@rem call :build_and_test Release "-DOPENSSL_NO_ASM=1" || goto error
-@rem The SHARED_LIBS build fails due to go not being able to write some file
-@rem call :build_and_test Release "-DBUILD_SHARED_LIBS=1" || goto error
-@rem The debug build currently fails due to 1073741515 missing Dll call :build_and_test aws-lc Debug || goto error
-@rem call :build_and_test Debug "" || goto error
 
 goto :EOF
 
@@ -42,10 +37,9 @@ exit /b 0
 cd %SRC_ROOT%
 rmdir /s /q %BUILD_DIR%
 mkdir %BUILD_DIR%
-mkdir %INSTALL_DIR%
 cd %BUILD_DIR%
 
-cmake -GNinja -DCMAKE_BUILD_TYPE=%~1 %~2 -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%" -DCMAKE_PREFIX_PATH="%INSTALL_DIR%" %SRC_ROOT% || goto error
+cmake -GNinja -DCMAKE_BUILD_TYPE=%~1 %~2 %SRC_ROOT% || goto error
 
 @echo  LOG: %date%-%time% %1 %2 cmake generation complete, starting build
 ninja || goto error
@@ -56,7 +50,7 @@ exit /b 0
 :test
 @echo on
 @echo  LOG: %date%-%time% %1 %2 build finished, starting tests
-ninja -C %BUILD_DIR% run_tests || goto error
+ninja run_tests || goto error
 @echo  LOG: %date%-%time% %1 %2 tests complete
 exit /b %errorlevel%
 


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-907

### Description of changes: 
* Turn on most windows build flavors:
    * Debug build
         * Only for MSVC 2017
    * Release small
    * Release no assembly
    * Release shared build
    * Regular Release is still on
* Update Window's PATH variable to search for our DLLs in the build directory
* Update CI script to support testing on local paths
* Update CI script to skip printing useless CMake logs
* Enable `GTEST_CREATE_SHARED_LIBRARY` so Windows can get the `dllexport`s it needs
* Only specify `BORINGSSL_IMPLEMENTATION` when building our code so Windows picks correctly between `__declspec(dllexport)` and `__declspec(dllimport)` in base.h

### Call-outs:
Without the changes to `BORINGSSL_IMPLEMENTATION` Windows tests would fail because in the unit tests `BORINGSSL_IMPLEMENTATION` would be set and all the `OPENSSL_EXPORT`s would still be `dllexport`ing code instead of importing it. This is due to `add_definitions(-DBORINGSSL_IMPLEMENTATION)` which turns it on for everything.

This does **not** fix the Windows FIPS build, more changes coming soon!

### Testing:
`run_windows_tests.bat` passes locally. These changes don't affect the linux behavior as far as I can tell.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
