### PR TITLE
Refactoring P-384 implementation for consistency

### DIFF
--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -110,7 +110,7 @@ static p384_limb_t p384_felem_nz(const p384_limb_t in1[P384_NLIMBS]) {
 #define p384_felem_to_bytes(out, in0)   fiat_p384_to_bytes(out, in0)
 #define p384_felem_from_bytes(out, in0) fiat_p384_from_bytes(out, in0)
 
-static p384_limb_t p384_felem_nz( const p384_limb_t in1[P384_NLIMBS]) {
+static p384_limb_t p384_felem_nz(const p384_limb_t in1[P384_NLIMBS]) {
   p384_limb_t ret;
   fiat_p384_nonzero(&ret, in1);
   return ret;

--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -25,16 +25,16 @@
 #endif
 
 #if defined(BORINGSSL_NISTP384_64BIT)
-#define FIAT_P384_NLIMBS 6
-typedef uint64_t fiat_p384_limb_t;
-typedef uint64_t fiat_p384_felem[FIAT_P384_NLIMBS];
-static const fiat_p384_felem fiat_p384_one = {0xffffffff00000001, 0xffffffff,
-                                              0x1, 0x0, 0x0, 0x0};
+#define P384_NLIMBS (6)
+typedef uint64_t p384_limb_t;
+typedef uint64_t p384_felem[P384_NLIMBS];
+static const p384_felem p384_felem_one = {
+    0xffffffff00000001, 0xffffffff, 0x1, 0x0, 0x0, 0x0};
 #else  // 64BIT; else 32BIT
-#define FIAT_P384_NLIMBS 12
-typedef uint32_t fiat_p384_limb_t;
-typedef uint32_t fiat_p384_felem[FIAT_P384_NLIMBS];
-static const fiat_p384_felem fiat_p384_one = {
+#define P384_NLIMBS (12)
+typedef uint32_t p384_limb_t;
+typedef uint32_t p384_felem[P384_NLIMBS];
+static const p384_felem p384_felem_one = {
     0x1, 0xffffffff, 0xffffffff, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 #endif  // 64BIT
 
@@ -93,8 +93,7 @@ static inline uint8_t use_s2n_bignum(void) { return 1; }
   if (use_s2n_bignum()) bignum_deamont_p384(out, in0); \
   else fiat_p384_from_montgomery(out, in0);
 
-static fiat_p384_limb_t fiat_p384_nz(
-    const fiat_p384_limb_t in1[FIAT_P384_NLIMBS]) {
+static p384_limb_t p384_felem_nz(const p384_limb_t in1[P384_NLIMBS]) {
   return bignum_nonzero_6(in1);
 }
 
@@ -111,33 +110,33 @@ static fiat_p384_limb_t fiat_p384_nz(
 #define p384_felem_to_bytes(out, in0)   fiat_p384_to_bytes(out, in0)
 #define p384_felem_from_bytes(out, in0) fiat_p384_from_bytes(out, in0)
 
-static fiat_p384_limb_t fiat_p384_nz(
-    const fiat_p384_limb_t in1[FIAT_P384_NLIMBS]) {
-  fiat_p384_limb_t ret;
+static p384_limb_t p384_felem_nz( const p384_limb_t in1[P384_NLIMBS]) {
+  p384_limb_t ret;
   fiat_p384_nonzero(&ret, in1);
   return ret;
 }
-#endif // !NO_ASM && !WINDOWS && (X86_64 || AARCH64)
 
-static void fiat_p384_copy(fiat_p384_limb_t out[FIAT_P384_NLIMBS],
-                           const fiat_p384_limb_t in1[FIAT_P384_NLIMBS]) {
-  for (size_t i = 0; i < FIAT_P384_NLIMBS; i++) {
+#endif // !NO_ASM && LINUX && (X86_64 || AARCH64)
+
+static void p384_felem_copy(p384_limb_t out[P384_NLIMBS],
+                           const p384_limb_t in1[P384_NLIMBS]) {
+  for (size_t i = 0; i < P384_NLIMBS; i++) {
     out[i] = in1[i];
   }
 }
 
-static void fiat_p384_cmovznz(fiat_p384_limb_t out[FIAT_P384_NLIMBS],
-                              fiat_p384_limb_t t,
-                              const fiat_p384_limb_t z[FIAT_P384_NLIMBS],
-                              const fiat_p384_limb_t nz[FIAT_P384_NLIMBS]) {
+static void p384_felem_cmovznz(p384_limb_t out[P384_NLIMBS],
+                               p384_limb_t t,
+                               const p384_limb_t z[P384_NLIMBS],
+                               const p384_limb_t nz[P384_NLIMBS]) {
   fiat_p384_selectznz(out, !!t, z, nz);
 }
 
-static void p384_from_generic(fiat_p384_felem out, const EC_FELEM *in) {
+static void p384_from_generic(p384_felem out, const EC_FELEM *in) {
   p384_felem_from_bytes(out, in->bytes);
 }
 
-static void p384_to_generic(EC_FELEM *out, const fiat_p384_felem in) {
+static void p384_to_generic(EC_FELEM *out, const p384_felem in) {
   // This works because 384 is a multiple of 64, so there are no excess bytes to
   // zero when rounding up to |BN_ULONG|s.
   OPENSSL_STATIC_ASSERT(
@@ -156,14 +155,14 @@ static void p384_to_generic(EC_FELEM *out, const fiat_p384_felem in) {
 // Hexadecimal representation of p − 3:
 // p-3 = ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe
 //       ffffffff 00000000 00000000 fffffffc
-static void p384_inv_square(fiat_p384_felem out,
-                            const fiat_p384_felem in) {
+static void p384_inv_square(p384_felem out,
+                            const p384_felem in) {
   // This implements the addition chain described in
   // https://briansmith.org/ecc-inversion-addition-chains-01#p384_field_inversion
   // The side comments show the value of the exponent:
   // squaring the element => doubling the exponent
   // multiplying by an element => adding to the exponent the power of that element
-  fiat_p384_felem x2, x3, x6, x12, x15, x30, x60, x120;
+  p384_felem x2, x3, x6, x12, x15, x30, x60, x120;
   p384_felem_sqr(x2, in);   // 2^2 - 2^1
   p384_felem_mul(x2, x2, in);  // 2^2 - 2^0
 
@@ -206,7 +205,7 @@ static void p384_inv_square(fiat_p384_felem out,
   }                                // 2^120 - 2^60
   p384_felem_mul(x120, x120, x60);  // 2^120 - 2^0
 
-  fiat_p384_felem ret;
+  p384_felem ret;
   p384_felem_sqr(ret, x120);
   for (int i = 1; i < 120; i++) {
     p384_felem_sqr(ret, ret);
@@ -219,11 +218,13 @@ static void p384_inv_square(fiat_p384_felem out,
   p384_felem_mul(ret, ret, x15);    // 2^255 - 2^0
 
   // Why (1 + 30) in the loop?
-  // This is as expressed in https://briansmith.org/ecc-inversion-addition-chains-01#p384_field_inversion
-  // My guess is to say that we're going to shift 31 bits, but this time we won't add x31
-  // to make all the new bits 1s, as was done in previous steps,
-  // but we're going to add x30 so there will be 255 1s, then a 0, then 30 1s to form this pattern:
-  // ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe ffffffff
+  // This is as expressed in:
+  //   https://briansmith.org/ecc-inversion-addition-chains-01#p384_field_inversion
+  // My guess is to say that we're going to shift 31 bits, but this time we
+  // won't add x31 to make all the new bits 1s, as was done in previous steps,
+  // but we're going to add x30 so there will be 255 1s, then a 0, then 30 1s
+  // to form this pattern:
+  //   ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe ffffffff
   // (the last 2 1s are appended in the following step).
   for (int i = 0; i < (1 + 30); i++) {
     p384_felem_sqr(ret, ret);
@@ -235,9 +236,10 @@ static void p384_inv_square(fiat_p384_felem out,
   p384_felem_mul(ret, ret, x2);     // 2^288 - 2^32 - 2^0
 
   // Why not 94 instead of (64 + 30) in the loop?
-  // Similarly to the comment above, there is a shift of 94 bits but what will be added is x30,
-  // which will cause 64 of those bits to be 64 0s and 30 1s to complete the pattern above with:
-  // 00000000 00000000 fffffffc
+  // Similarly to the comment above, there is a shift of 94 bits
+  // but what will be added is x30, which will cause 64 of those bits
+  // to be 64 0s and 30 1s to complete the pattern above with:
+  //   00000000 00000000 fffffffc
   // (the last 2 0s are appended by the last 2 shifts).
   for (int i = 0; i < (64 + 30); i++) {
     p384_felem_sqr(ret, ret);
@@ -255,7 +257,7 @@ static void p384_inv_square(fiat_p384_felem out,
 // elliptic curve group itself. Points on the curve are represented in Jacobian
 // coordinates.
 //
-// fiat_p384_point_double calculates 2*(x_in, y_in, z_in)
+// p384_point_double calculates 2*(x_in, y_in, z_in)
 //
 // The method is taken from:
 //   http://hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-3.html#doubling-dbl-2001-b
@@ -265,12 +267,13 @@ static void p384_inv_square(fiat_p384_felem out,
 // <https://github.com/mit-plv/fiat-crypto/blob/79f8b5f39ed609339f0233098dee1a3c4e6b3080/src/Curves/Weierstrass/Jacobian.v#L201>
 // Outputs can equal corresponding inputs, i.e., x_out == x_in is allowed;
 // while x_out == y_in is not (maybe this works, but it's not tested).
-static void fiat_p384_point_double(fiat_p384_felem x_out, fiat_p384_felem y_out,
-                                   fiat_p384_felem z_out,
-                                   const fiat_p384_felem x_in,
-                                   const fiat_p384_felem y_in,
-                                   const fiat_p384_felem z_in) {
-  fiat_p384_felem delta, gamma, beta, ftmp, ftmp2, tmptmp, alpha, fourbeta;
+static void p384_point_double(p384_felem x_out,
+                              p384_felem y_out,
+                              p384_felem z_out,
+                              const p384_felem x_in,
+                              const p384_felem y_in,
+                              const p384_felem z_in) {
+  p384_felem delta, gamma, beta, ftmp, ftmp2, tmptmp, alpha, fourbeta;
   // delta = z^2
   p384_felem_sqr(delta, z_in);
   // gamma = y^2
@@ -310,7 +313,7 @@ static void fiat_p384_point_double(fiat_p384_felem x_out, fiat_p384_felem y_out,
   p384_felem_sub(y_out, y_out, gamma);
 }
 
-// fiat_p384_point_add calculates (x1, y1, z1) + (x2, y2, z2)
+// p384_point_add calculates (x1, y1, z1) + (x2, y2, z2)
 //
 // The method is taken from:
 //   http://hyperelliptic.org/EFD/g1p/auto-shortw-jacobian.html#addition-add-2007-bl
@@ -319,25 +322,26 @@ static void fiat_p384_point_double(fiat_p384_felem x_out, fiat_p384_felem y_out,
 // Coq transcription and correctness proof:
 // <https://github.com/davidben/fiat-crypto/blob/c7b95f62b2a54b559522573310e9b487327d219a/src/Curves/Weierstrass/Jacobian.v#L467>
 // <https://github.com/davidben/fiat-crypto/blob/c7b95f62b2a54b559522573310e9b487327d219a/src/Curves/Weierstrass/Jacobian.v#L544>
-static void fiat_p384_point_add(fiat_p384_felem x3, fiat_p384_felem y3,
-                                fiat_p384_felem z3, const fiat_p384_felem x1,
-                                const fiat_p384_felem y1,
-                                const fiat_p384_felem z1, const int mixed,
-                                const fiat_p384_felem x2,
-                                const fiat_p384_felem y2,
-                                const fiat_p384_felem z2) {
-  fiat_p384_felem x_out, y_out, z_out;
-  fiat_p384_limb_t z1nz = fiat_p384_nz(z1);
-  fiat_p384_limb_t z2nz = fiat_p384_nz(z2);
+static void p384_point_add(p384_felem x3, p384_felem y3, p384_felem z3,
+                           const p384_felem x1,
+                           const p384_felem y1,
+                           const p384_felem z1,
+                           const int mixed,
+                           const p384_felem x2,
+                           const p384_felem y2,
+                           const p384_felem z2) {
+  p384_felem x_out, y_out, z_out;
+  p384_limb_t z1nz = p384_felem_nz(z1);
+  p384_limb_t z2nz = p384_felem_nz(z2);
 
   // z1z1 = z1**2
-  fiat_p384_felem z1z1;
+  p384_felem z1z1;
   p384_felem_sqr(z1z1, z1);
 
-  fiat_p384_felem u1, s1, two_z1z2;
+  p384_felem u1, s1, two_z1z2;
   if (!mixed) {
     // z2z2 = z2**2
-    fiat_p384_felem z2z2;
+    p384_felem z2z2;
     p384_felem_sqr(z2z2, z2);
 
     // u1 = x1*z2z2
@@ -356,61 +360,61 @@ static void fiat_p384_point_add(fiat_p384_felem x3, fiat_p384_felem y3,
     // We'll assume z2 = 1 (special case z2 = 0 is handled later).
 
     // u1 = x1*z2z2
-    fiat_p384_copy(u1, x1);
+    p384_felem_copy(u1, x1);
     // two_z1z2 = 2z1z2
     p384_felem_add(two_z1z2, z1, z1);
     // s1 = y1 * z2**3
-    fiat_p384_copy(s1, y1);
+    p384_felem_copy(s1, y1);
   }
 
   // u2 = x2*z1z1
-  fiat_p384_felem u2;
+  p384_felem u2;
   p384_felem_mul(u2, x2, z1z1);
 
   // h = u2 - u1
-  fiat_p384_felem h;
+  p384_felem h;
   p384_felem_sub(h, u2, u1);
 
-  fiat_p384_limb_t xneq = fiat_p384_nz(h);
+  p384_limb_t xneq = p384_felem_nz(h);
 
   // z_out = two_z1z2 * h
   p384_felem_mul(z_out, h, two_z1z2);
 
   // z1z1z1 = z1 * z1z1
-  fiat_p384_felem z1z1z1;
+  p384_felem z1z1z1;
   p384_felem_mul(z1z1z1, z1, z1z1);
 
   // s2 = y2 * z1**3
-  fiat_p384_felem s2;
+  p384_felem s2;
   p384_felem_mul(s2, y2, z1z1z1);
 
   // r = (s2 - s1)*2
-  fiat_p384_felem r;
+  p384_felem r;
   p384_felem_sub(r, s2, s1);
   p384_felem_add(r, r, r);
 
-  fiat_p384_limb_t yneq = fiat_p384_nz(r);
+  p384_limb_t yneq = p384_felem_nz(r);
 
   // This case will never occur in the constant-time |ec_GFp_mont_mul|.
-  fiat_p384_limb_t is_nontrivial_double = constant_time_is_zero_w(xneq | yneq) &
-                                          ~constant_time_is_zero_w(z1nz) &
-                                          ~constant_time_is_zero_w(z2nz);
+  p384_limb_t is_nontrivial_double = constant_time_is_zero_w(xneq | yneq) &
+                                    ~constant_time_is_zero_w(z1nz) &
+                                    ~constant_time_is_zero_w(z2nz);
   if (is_nontrivial_double) {
-    fiat_p384_point_double(x3, y3, z3, x1, y1, z1);
+    p384_point_double(x3, y3, z3, x1, y1, z1);
     return;
   }
 
   // I = (2h)**2
-  fiat_p384_felem i;
+  p384_felem i;
   p384_felem_add(i, h, h);
   p384_felem_sqr(i, i);
 
   // J = h * I
-  fiat_p384_felem j;
+  p384_felem j;
   p384_felem_mul(j, h, i);
 
   // V = U1 * I
-  fiat_p384_felem v;
+  p384_felem v;
   p384_felem_mul(v, u1, i);
 
   // x_out = r**2 - J - 2V
@@ -422,44 +426,45 @@ static void fiat_p384_point_add(fiat_p384_felem x3, fiat_p384_felem y3,
   // y_out = r(V-x_out) - 2 * s1 * J
   p384_felem_sub(y_out, v, x_out);
   p384_felem_mul(y_out, y_out, r);
-  fiat_p384_felem s1j;
+  p384_felem s1j;
   p384_felem_mul(s1j, s1, j);
   p384_felem_sub(y_out, y_out, s1j);
   p384_felem_sub(y_out, y_out, s1j);
 
-  fiat_p384_cmovznz(x_out, z1nz, x2, x_out);
-  fiat_p384_cmovznz(x3, z2nz, x1, x_out);
-  fiat_p384_cmovznz(y_out, z1nz, y2, y_out);
-  fiat_p384_cmovznz(y3, z2nz, y1, y_out);
-  fiat_p384_cmovznz(z_out, z1nz, z2, z_out);
-  fiat_p384_cmovznz(z3, z2nz, z1, z_out);
+  p384_felem_cmovznz(x_out, z1nz, x2, x_out);
+  p384_felem_cmovznz(x3, z2nz, x1, x_out);
+  p384_felem_cmovznz(y_out, z1nz, y2, y_out);
+  p384_felem_cmovznz(y3, z2nz, y1, y_out);
+  p384_felem_cmovznz(z_out, z1nz, z2, z_out);
+  p384_felem_cmovznz(z3, z2nz, z1, z_out);
 }
 
 // OPENSSL EC_METHOD FUNCTIONS
 
-// Takes the Jacobian coordinates (X, Y, Z) of a point and returns (X', Y') =
-// (X/Z^2, Y/Z^3).
+// Takes the Jacobian coordinates (X, Y, Z) of a point and returns:
+//   (X', Y') = (X/Z^2, Y/Z^3).
 static int ec_GFp_nistp384_point_get_affine_coordinates(
-    const EC_GROUP *group, const EC_RAW_POINT *point, EC_FELEM *x_out,
-    EC_FELEM *y_out) {
+    const EC_GROUP *group, const EC_RAW_POINT *point,
+    EC_FELEM *x_out, EC_FELEM *y_out) {
+
   if (ec_GFp_simple_is_at_infinity(group, point)) {
     OPENSSL_PUT_ERROR(EC, EC_R_POINT_AT_INFINITY);
     return 0;
   }
 
-  fiat_p384_felem z1, z2;
+  p384_felem z1, z2;
   p384_from_generic(z1, &point->Z);
   p384_inv_square(z2, z1);
 
   if (x_out != NULL) {
-    fiat_p384_felem x;
+    p384_felem x;
     p384_from_generic(x, &point->X);
     p384_felem_mul(x, x, z2);
     p384_to_generic(x_out, x);
   }
 
   if (y_out != NULL) {
-    fiat_p384_felem y;
+    p384_felem y;
     p384_from_generic(y, &point->Y);
     p384_felem_sqr(z2, z2);  // z^-4
     p384_felem_mul(y, y, z1);   // y * z
@@ -472,14 +477,14 @@ static int ec_GFp_nistp384_point_get_affine_coordinates(
 
 static void ec_GFp_nistp384_add(const EC_GROUP *group, EC_RAW_POINT *r,
                                 const EC_RAW_POINT *a, const EC_RAW_POINT *b) {
-  fiat_p384_felem x1, y1, z1, x2, y2, z2;
+  p384_felem x1, y1, z1, x2, y2, z2;
   p384_from_generic(x1, &a->X);
   p384_from_generic(y1, &a->Y);
   p384_from_generic(z1, &a->Z);
   p384_from_generic(x2, &b->X);
   p384_from_generic(y2, &b->Y);
   p384_from_generic(z2, &b->Z);
-  fiat_p384_point_add(x1, y1, z1, x1, y1, z1, 0 /* both Jacobian */, x2, y2, z2);
+  p384_point_add(x1, y1, z1, x1, y1, z1, 0 /* both Jacobian */, x2, y2, z2);
   p384_to_generic(&r->X, x1);
   p384_to_generic(&r->Y, y1);
   p384_to_generic(&r->Z, z1);
@@ -487,11 +492,11 @@ static void ec_GFp_nistp384_add(const EC_GROUP *group, EC_RAW_POINT *r,
 
 static void ec_GFp_nistp384_dbl(const EC_GROUP *group, EC_RAW_POINT *r,
                                 const EC_RAW_POINT *a) {
-  fiat_p384_felem x, y, z;
+  p384_felem x, y, z;
   p384_from_generic(x, &a->X);
   p384_from_generic(y, &a->Y);
   p384_from_generic(z, &a->Z);
-  fiat_p384_point_double(x, y, z, x, y, z);
+  p384_point_double(x, y, z, x, y, z);
   p384_to_generic(&r->X, x);
   p384_to_generic(&r->Y, y);
   p384_to_generic(&r->Z, z);
@@ -500,11 +505,12 @@ static void ec_GFp_nistp384_dbl(const EC_GROUP *group, EC_RAW_POINT *r,
 // The calls to from/to_generic are needed for the case
 // when BORINGSSL_HAS_UINT128 is undefined, i.e. p384_32.h fiat code is used;
 // while OPENSSL_64_BIT is defined, i.e. BN_ULONG is uint64_t
-static void ec_GFp_nistp384_mont_felem_to_bytes(const EC_GROUP *group, uint8_t *out,
-                                         size_t *out_len, const EC_FELEM *in) {
+static void ec_GFp_nistp384_mont_felem_to_bytes(
+  const EC_GROUP *group,uint8_t *out, size_t *out_len, const EC_FELEM *in) {
+
   size_t len = BN_num_bytes(&group->field);
   EC_FELEM felem_tmp;
-  fiat_p384_felem tmp;
+  p384_felem tmp;
   p384_from_generic(tmp, in);
   p384_felem_from_mont(tmp, tmp);
   p384_to_generic(&felem_tmp, tmp);
@@ -516,10 +522,11 @@ static void ec_GFp_nistp384_mont_felem_to_bytes(const EC_GROUP *group, uint8_t *
   *out_len = len;
 }
 
-static int ec_GFp_nistp384_mont_felem_from_bytes(const EC_GROUP *group, EC_FELEM *out,
-                                          const uint8_t *in, size_t len) {
+static int ec_GFp_nistp384_mont_felem_from_bytes(
+  const EC_GROUP *group, EC_FELEM *out, const uint8_t *in, size_t len) {
+
   EC_FELEM felem_tmp;
-  fiat_p384_felem tmp;
+  p384_felem tmp;
   // This function calls bn_cmp_words_consttime
   if (!ec_GFp_simple_felem_from_bytes(group, &felem_tmp, in, len)) {
     return 0;
@@ -540,15 +547,15 @@ static int ec_GFp_nistp384_cmp_x_coordinate(const EC_GROUP *group,
   // We wish to compare X/Z^2 with r. This is equivalent to comparing X with
   // r*Z^2. Note that X and Z are represented in Montgomery form, while r is
   // not.
-  fiat_p384_felem Z2_mont;
+  p384_felem Z2_mont;
   p384_from_generic(Z2_mont, &p->Z);
   p384_felem_mul(Z2_mont, Z2_mont, Z2_mont);
 
-  fiat_p384_felem r_Z2;
+  p384_felem r_Z2;
   p384_felem_from_bytes(r_Z2, r->bytes);  // r < order < p, so this is valid.
   p384_felem_mul(r_Z2, r_Z2, Z2_mont);
 
-  fiat_p384_felem X;
+  p384_felem X;
   p384_from_generic(X, &p->X);
   p384_felem_from_mont(X, X);
 
@@ -597,8 +604,8 @@ static int ec_GFp_nistp384_cmp_x_coordinate(const EC_GROUP *group,
 //
 // Moreover, the order in which the digits of the scalar are processed in
 // |ec_GFp_nistp384_point_mul_base| is different from the ECCKiila project, to
-// ensure that the least significant digit is processed last which together with
-// the window size 7 guarantees constant-time execution of the function.
+// ensure that the least significant digit is processed last which together
+// with the window size 7 guarantees constant-time execution of the function.
 //
 // Another difference is that in |ec_GFp_nistp384_point_mul_public| function we
 // use window size 5 for the public point and 7 for the base point. Here it is
@@ -608,8 +615,8 @@ static int ec_GFp_nistp384_cmp_x_coordinate(const EC_GROUP *group,
 // The precomputed table of base point multiples is generated by the code in
 // |make_tables.go| script.
 
-// fiat_p384_get_bit returns the |i|-th bit in |in|
-static crypto_word_t fiat_p384_get_bit(const uint8_t *in, int i) {
+// p384_get_bit returns the |i|-th bit in |in|
+static crypto_word_t p384_get_bit(const uint8_t *in, int i) {
   if (i < 0 || i >= 384) {
     return 0;
   }
@@ -629,8 +636,8 @@ static crypto_word_t fiat_p384_get_bit(const uint8_t *in, int i) {
 #define P384_MUL_TABLE_SIZE     (P384_MUL_TWO_TO_WSIZE >> 1)
 #define P384_MUL_PUB_TABLE_SIZE (1 << (P384_MUL_PUB_WSIZE - 1))
 
-// Compute "regular" wNAF representation of a scalar.
-// See Joye, Tunstall, "Exponent Recoding and Regular Exponentiation Algorithms",
+// Compute "regular" wNAF representation of a scalar, see
+// Joye, Tunstall, "Exponent Recoding and Regular Exponentiation Algorithms",
 // AfricaCrypt 2009, Alg 6.
 // It forces an odd scalar and outputs digits in
 // {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
@@ -643,43 +650,43 @@ static void p384_felem_mul_scalar_rwnaf(int16_t *out, const unsigned char *in) {
     d = (window & P384_MUL_WSIZE_MASK) - P384_MUL_TWO_TO_WSIZE;
     out[i] = d;
     window = (window - d) >> P384_MUL_WSIZE;
-    window += fiat_p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 1) << 1;
-    window += fiat_p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 2) << 2;
-    window += fiat_p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 3) << 3;
-    window += fiat_p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 4) << 4;
-    window += fiat_p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 5) << 5;
-    window += fiat_p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 6) << 6;
-    window += fiat_p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 7) << 7;
+    window += p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 1) << 1;
+    window += p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 2) << 2;
+    window += p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 3) << 3;
+    window += p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 4) << 4;
+    window += p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 5) << 5;
+    window += p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 6) << 6;
+    window += p384_get_bit(in, (i + 1) * P384_MUL_WSIZE + 7) << 7;
   }
   out[54] = window;
 }
 
 // fiat_p384_select_point selects the |idx|-th projective point from the given
 // precomputed table and copies it to |out| in constant time.
-static void fiat_p384_select_point(fiat_p384_felem out[3],
+static void fiat_p384_select_point(p384_felem out[3],
                                    size_t idx,
-                                   fiat_p384_felem table[][3],
+                                   p384_felem table[][3],
                                    size_t table_size) {
-  OPENSSL_memset(out, 0, sizeof(fiat_p384_felem) * 3);
+  OPENSSL_memset(out, 0, sizeof(p384_felem) * 3);
   for (size_t i = 0; i < table_size; i++) {
-    fiat_p384_limb_t mismatch = i ^ idx;
-    fiat_p384_cmovznz(out[0], mismatch, table[i][0], out[0]);
-    fiat_p384_cmovznz(out[1], mismatch, table[i][1], out[1]);
-    fiat_p384_cmovznz(out[2], mismatch, table[i][2], out[2]);
+    p384_limb_t mismatch = i ^ idx;
+    p384_felem_cmovznz(out[0], mismatch, table[i][0], out[0]);
+    p384_felem_cmovznz(out[1], mismatch, table[i][1], out[1]);
+    p384_felem_cmovznz(out[2], mismatch, table[i][2], out[2]);
   }
 }
 
 // fiat_p384_select_point_affine selects the |idx|-th affine point from
 // the given precomputed table and copies it to |out| in constant-time.
-static void fiat_p384_select_point_affine(fiat_p384_felem out[2],
+static void fiat_p384_select_point_affine(p384_felem out[2],
                                           size_t idx,
-                                          const fiat_p384_felem table[][2],
+                                          const p384_felem table[][2],
                                           size_t table_size) {
-  OPENSSL_memset(out, 0, sizeof(fiat_p384_felem) * 2);
+  OPENSSL_memset(out, 0, sizeof(p384_felem) * 2);
   for (size_t i = 0; i < table_size; i++) {
-    fiat_p384_limb_t mismatch = i ^ idx;
-    fiat_p384_cmovznz(out[0], mismatch, table[i][0], out[0]);
-    fiat_p384_cmovznz(out[1], mismatch, table[i][1], out[1]);
+    p384_limb_t mismatch = i ^ idx;
+    p384_felem_cmovznz(out[0], mismatch, table[i][0], out[0]);
+    p384_felem_cmovznz(out[1], mismatch, table[i][1], out[1]);
   }
 }
 
@@ -689,7 +696,8 @@ static void fiat_p384_select_point_affine(fiat_p384_felem out[2],
 //
 // The precomputed (on-the-fly) table |p_pre_comp| holds 64 odd multiples of P:
 //     [2i + 1]P for i in [0, 63].
-// Computing the negation of a point P = (x, y) is relatively easy -P = (x, -y).
+// Computing the negation of a point P = (x, y) is relatively easy:
+//     -P = (x, -y).
 // So we may assume that instead of the above-mentioned 64, we have 128 points:
 //     [\pm 1]P, [\pm 3]P, [\pm 5]P, ..., [\pm 127]P.
 //
@@ -715,10 +723,10 @@ static void ec_GFp_nistp384_point_mul(const EC_GROUP *group, EC_RAW_POINT *r,
                                       const EC_RAW_POINT *p,
                                       const EC_SCALAR *scalar) {
 
-  fiat_p384_felem res[3] = {{0}, {0}, {0}}, tmp[3] = {{0}, {0}, {0}}, ftmp;
+  p384_felem res[3] = {{0}, {0}, {0}}, tmp[3] = {{0}, {0}, {0}}, ftmp;
 
   // Table of multiples of P:  [2i + 1]P for i in [0, 63].
-  fiat_p384_felem p_pre_comp[P384_MUL_TABLE_SIZE][3];
+  p384_felem p_pre_comp[P384_MUL_TABLE_SIZE][3];
 
   // Set the first point in the table to P.
   p384_from_generic(p_pre_comp[0][0], &p->X);
@@ -726,15 +734,16 @@ static void ec_GFp_nistp384_point_mul(const EC_GROUP *group, EC_RAW_POINT *r,
   p384_from_generic(p_pre_comp[0][2], &p->Z);
 
   // Compute tmp = [2]P.
-  fiat_p384_point_double(tmp[0], tmp[1], tmp[2],
-                         p_pre_comp[0][0], p_pre_comp[0][1], p_pre_comp[0][2]);
+  p384_point_double(tmp[0], tmp[1], tmp[2],
+                    p_pre_comp[0][0], p_pre_comp[0][1], p_pre_comp[0][2]);
 
   // Generate the remaining 63 multiples of P.
   for (size_t i = 1; i < P384_MUL_TABLE_SIZE; i++) {
-    fiat_p384_point_add(p_pre_comp[i][0], p_pre_comp[i][1], p_pre_comp[i][2],
-                        tmp[0], tmp[1], tmp[2], 0 /* both Jacobian */,
-                        p_pre_comp[i - 1][0], p_pre_comp[i - 1][1],
-                        p_pre_comp[i - 1][2]);
+    p384_point_add(p_pre_comp[i][0], p_pre_comp[i][1], p_pre_comp[i][2],
+                   tmp[0], tmp[1], tmp[2], 0 /* both Jacobian */,
+                   p_pre_comp[i - 1][0],
+                   p_pre_comp[i - 1][1],
+                   p_pre_comp[i - 1][2]);
   }
 
   // Recode the scalar.
@@ -751,7 +760,7 @@ static void ec_GFp_nistp384_point_mul(const EC_GROUP *group, EC_RAW_POINT *r,
   for (size_t i = 53; i < 54; i--) {
     // Double |res| 5 times in each iteration.
     for (size_t j = 0; j < P384_MUL_WSIZE; j++) {
-      fiat_p384_point_double(res[0], res[1], res[2], res[0], res[1], res[2]);
+      p384_point_double(res[0], res[1], res[2], res[0], res[1], res[2]);
     }
 
     int16_t d = rnaf[i];
@@ -768,26 +777,26 @@ static void ec_GFp_nistp384_point_mul(const EC_GROUP *group, EC_RAW_POINT *r,
     // Negate y coordinate of the point tmp = (x, y); ftmp = -y.
     p384_felem_opp(ftmp, tmp[1]);
     // Conditionally select y or -y depending on the sign of the digit |d|.
-    fiat_p384_cmovznz(tmp[1], is_neg, tmp[1], ftmp);
+    p384_felem_cmovznz(tmp[1], is_neg, tmp[1], ftmp);
 
     // Add the point to the accumulator |res|.
-    fiat_p384_point_add(res[0], res[1], res[2], res[0], res[1], res[2],
-                        0 /* both Jacobian */, tmp[0], tmp[1], tmp[2]);
+    p384_point_add(res[0], res[1], res[2], res[0], res[1], res[2],
+                   0 /* both Jacobian */, tmp[0], tmp[1], tmp[2]);
 
   }
 
   // Conditionally subtract P if the scalar is even, in constant-time.
   // First, compute |tmp| = |res| + (-P).
-  fiat_p384_copy(tmp[0], p_pre_comp[0][0]);
+  p384_felem_copy(tmp[0], p_pre_comp[0][0]);
   p384_felem_opp(tmp[1], p_pre_comp[0][1]);
-  fiat_p384_copy(tmp[2], p_pre_comp[0][2]);
-  fiat_p384_point_add(tmp[0], tmp[1], tmp[2], res[0], res[1], res[2],
-                      0 /* both Jacobian */, tmp[0], tmp[1], tmp[2]);
+  p384_felem_copy(tmp[2], p_pre_comp[0][2]);
+  p384_point_add(tmp[0], tmp[1], tmp[2], res[0], res[1], res[2],
+                 0 /* both Jacobian */, tmp[0], tmp[1], tmp[2]);
 
   // Select |res| or |tmp| based on the |scalar| parity, in constant-time.
-  fiat_p384_cmovznz(res[0], scalar->bytes[0] & 1, tmp[0], res[0]);
-  fiat_p384_cmovznz(res[1], scalar->bytes[0] & 1, tmp[1], res[1]);
-  fiat_p384_cmovznz(res[2], scalar->bytes[0] & 1, tmp[2], res[2]);
+  p384_felem_cmovznz(res[0], scalar->bytes[0] & 1, tmp[0], res[0]);
+  p384_felem_cmovznz(res[1], scalar->bytes[0] & 1, tmp[1], res[1]);
+  p384_felem_cmovznz(res[2], scalar->bytes[0] & 1, tmp[2], res[2]);
 
   // Copy the result to the output.
   p384_to_generic(&r->X, res[0]);
@@ -800,23 +809,24 @@ static void ec_GFp_nistp384_point_mul(const EC_GROUP *group, EC_RAW_POINT *r,
 
 // Multiplication of the base point G of P-384 curve with the given scalar.
 // The product is computed with the Comb method using the precomputed table
-// |fiat_p384_g_pre_comp| from |p384_table.h| file and the regular-wNAF scalar
+// |p384_g_pre_comp| from |p384_table.h| file and the regular-wNAF scalar
 // encoding.
 //
-// The |fiat_p384_g_pre_comp| table has 14 sub-tables each holding 64 points:
+// The |p384_g_pre_comp| table has 14 sub-tables each holding 64 points:
 //      0 :      [1]G,        [3]G,  ...,       [127]G
 //      1 : [1*2^28]G,   [3*2^28]G,  ...,  [127*2^28]G
 //                         ...
 //      i : [1*2^28i]G, [3*2^28i]G,  ..., [127*2^28i]G
 //                         ...
 //     13 :   [2^364]G, [3*2^364]G,  ..., [127*2^364]G.
-// Computing the negation of a point P = (x, y) is relatively easy -P = (x, -y).
+// Computing the negation of a point P = (x, y) is relatively easy:
+//     -P = (x, -y).
 // So we may assume that for each sub-table we have 128 points instead of 64:
 //     [\pm 1*2^28i]G, [\pm 3*2^28i]G, ..., [\pm 127*2^28i]G.
 //
-// The 384-bit |scalar| is recoded (regular-wNAF encoding) into 55 signed digits
-// each of length 7 bits, as explained in the |p384_felem_mul_scalar_rwnaf|
-// function. Namely,
+// The 384-bit |scalar| is recoded (regular-wNAF encoding) into 55 signed
+// digits, each of length 7 bits, as explained in the
+// |p384_felem_mul_scalar_rwnaf| function. Namely,
 //     scalar' = s_0 + s_1*2^7 + s_2*2^14 + ... + s_54*2^378,
 // where digits s_i are in [\pm 1, \pm 3, ..., \pm 127]. Note that for an odd
 // scalar we have that scalar = scalar', while in the case of an even
@@ -824,14 +834,14 @@ static void ec_GFp_nistp384_point_mul(const EC_GROUP *group, EC_RAW_POINT *r,
 //
 // To compute the required product, [scalar]G, we may do the following.
 // Group the recoded digits of the scalar in 4 groups:
-//                                            |   corresponding multiples in
-//                    digits                  |   the recoded representation
-//     -------------------------------------------------------------------------
-//     (0): {s_0, s_4,  s_8, ..., s_48, s_52} |  { 2^0, 2^28, ...,      , 2^364}
-//     (1): {s_1, s_5,  s_9, ..., s_49, s_53} |  { 2^7, 2^35, ...,      , 2^371}
-//     (2): {s_2, s_6, s_10, ..., s_50, s_54} |  {2^14, 2^42, ...,      , 2^378}
-//     (3): {s_3, s_7, s_11, ..., s_51}       |  {2^21, 2^49, ..., 2^357}
-//          corresponding sub-table lookup    |  {  T0,   T1, ...,   T12,   T13}
+//                                           |   corresponding multiples in
+//                   digits                  |   the recoded representation
+//    -------------------------------------------------------------------------
+//    (0): {s_0, s_4,  s_8, ..., s_48, s_52} |  { 2^0, 2^28, ...,      , 2^364}
+//    (1): {s_1, s_5,  s_9, ..., s_49, s_53} |  { 2^7, 2^35, ...,      , 2^371}
+//    (2): {s_2, s_6, s_10, ..., s_50, s_54} |  {2^14, 2^42, ...,      , 2^378}
+//    (3): {s_3, s_7, s_11, ..., s_51}       |  {2^21, 2^49, ..., 2^357}
+//         corresponding sub-table lookup    |  {  T0,   T1, ...,   T12,   T13}
 //
 // The group (0) digits correspond precisely to the multiples of G that are
 // held in the 14 precomputed sub-tables, so we may simply read the appropriate
@@ -858,7 +868,7 @@ static void ec_GFp_nistp384_point_mul_base(const EC_GROUP *group,
                                            EC_RAW_POINT *r,
                                            const EC_SCALAR *scalar) {
 
-  fiat_p384_felem res[3] = {{0}, {0}, {0}}, tmp[3] = {{0}, {0}, {0}}, ftmp;
+  p384_felem res[3] = {{0}, {0}, {0}}, tmp[3] = {{0}, {0}, {0}}, ftmp;
   int16_t rnaf[55] = {0};
 
   // Recode the scalar.
@@ -868,7 +878,7 @@ static void ec_GFp_nistp384_point_mul_base(const EC_GROUP *group,
   for (size_t i = 0; i < 4; i++) {
     // Double |res| 7 times in each iteration, except in the first one.
     for (size_t j = 0; i != 0 && j < P384_MUL_WSIZE; j++) {
-      fiat_p384_point_double(res[0], res[1], res[2], res[0], res[1], res[2]);
+      p384_point_double(res[0], res[1], res[2], res[0], res[1], res[2]);
     }
 
     // Process the digits in the current group from the most to the least
@@ -878,9 +888,9 @@ static void ec_GFp_nistp384_point_mul_base(const EC_GROUP *group,
     // group (1) s_53 to s_1, and for group (0) s_52 to s_0.
     const size_t start_idx = 55 - i - (i == 0 ? 4 : 0);
     for (size_t j = start_idx; j < 55; j -= 4) {
-      // For each digit |d| in the current group read the corresponding point in
-      // the table and add it to |res|. If |d| is negative, negate the point
-      // before adding it to |res|.
+      // For each digit |d| in the current group read the corresponding point
+      // from the table and add it to |res|. If |d| is negative, negate
+      // the point before adding it to |res|.
       int16_t d = rnaf[j];
       // is_neg = (d < 0) ? 1 : 0
       int16_t is_neg = (d >> 7) & 1;
@@ -890,13 +900,13 @@ static void ec_GFp_nistp384_point_mul_base(const EC_GROUP *group,
       int16_t idx = d >> 1;
 
       // Select the point to add, in constant time.
-      fiat_p384_select_point_affine(tmp, idx, fiat_p384_g_pre_comp[j / 4],
+      fiat_p384_select_point_affine(tmp, idx, p384_g_pre_comp[j / 4],
                                     P384_MUL_TABLE_SIZE);
 
       // Negate y coordinate of the point tmp = (x, y); ftmp = -y.
       p384_felem_opp(ftmp, tmp[1]);
       // Conditionally select y or -y depending on the sign of the digit |d|.
-      fiat_p384_cmovznz(tmp[1], is_neg, tmp[1], ftmp);
+      p384_felem_cmovznz(tmp[1], is_neg, tmp[1], ftmp);
 
       // Add the point to the accumulator |res|.
       // Note that the points in the pre-computed table are given with affine
@@ -904,22 +914,22 @@ static void ec_GFp_nistp384_point_mul_base(const EC_GROUP *group,
       // either both given in projective, or one in projective and the other one
       // in affine coordinates. The |mixed| flag indicates the latter option,
       // in which case we set the third coordinate of the second point to one.
-      fiat_p384_point_add(res[0], res[1], res[2], res[0], res[1], res[2],
-                          1 /* mixed */, tmp[0], tmp[1], fiat_p384_one);
+      p384_point_add(res[0], res[1], res[2], res[0], res[1], res[2],
+                          1 /* mixed */, tmp[0], tmp[1], p384_felem_one);
     }
   }
 
   // Conditionally subtract G if the scalar is even, in constant-time.
   // First, compute |tmp| = |res| + (-G).
-  fiat_p384_copy(tmp[0], fiat_p384_g_pre_comp[0][0][0]);
-  p384_felem_opp(tmp[1], fiat_p384_g_pre_comp[0][0][1]);
-  fiat_p384_point_add(tmp[0], tmp[1], tmp[2], res[0], res[1], res[2],
-                      1 /* mixed */, tmp[0], tmp[1], fiat_p384_one);
+  p384_felem_copy(tmp[0], p384_g_pre_comp[0][0][0]);
+  p384_felem_opp(tmp[1], p384_g_pre_comp[0][0][1]);
+  p384_point_add(tmp[0], tmp[1], tmp[2], res[0], res[1], res[2],
+                      1 /* mixed */, tmp[0], tmp[1], p384_felem_one);
 
   // Select |res| or |tmp| based on the |scalar| parity.
-  fiat_p384_cmovznz(res[0], scalar->bytes[0] & 1, tmp[0], res[0]);
-  fiat_p384_cmovznz(res[1], scalar->bytes[0] & 1, tmp[1], res[1]);
-  fiat_p384_cmovznz(res[2], scalar->bytes[0] & 1, tmp[2], res[2]);
+  p384_felem_cmovznz(res[0], scalar->bytes[0] & 1, tmp[0], res[0]);
+  p384_felem_cmovznz(res[1], scalar->bytes[0] & 1, tmp[1], res[1]);
+  p384_felem_cmovznz(res[2], scalar->bytes[0] & 1, tmp[2], res[2]);
 
   // Copy the result to the output.
   p384_to_generic(&r->X, res[0]);
@@ -933,12 +943,13 @@ static void ec_GFp_nistp384_point_mul_base(const EC_GROUP *group,
 // Both scalar products are computed by the same "textbook" wNAF method,
 // with w = 7 for g_scalar and w = 5 for p_scalar.
 // For the base point G product we use the first sub-table of the precomputed
-// table |fiat_p384_g_pre_comp| from p384_table.h file, while for P we generate
-// the |p_pre_comp| table on-the-fly. The tables hold the first 64 odd multiples
+// table |p384_g_pre_comp| from p384_table.h file, while for P we generate
+// |p_pre_comp| table on-the-fly. The tables hold the first 64 odd multiples
 // of G or P:
 //     g_pre_comp = {[1]G, [3]G, ..., [31]G},
 //     p_pre_comp = {[1]P, [3]P, ..., [31]P}.
-// Computing the negation of a point P = (x, y) is relatively easy -P = (x, -y).
+// Computing the negation of a point P = (x, y) is relatively easy:
+//     -P = (x, -y).
 // So we may assume that we also have the negatives of the points in the tables.
 //
 // The 384-bit scalars are recoded by the textbook wNAF method to 385 digits,
@@ -965,10 +976,10 @@ static void ec_GFp_nistp384_point_mul_public(const EC_GROUP *group,
                                              const EC_RAW_POINT *p,
                                              const EC_SCALAR *p_scalar) {
 
-  fiat_p384_felem res[3] = {{0}, {0}, {0}}, two_p[3] = {{0}, {0}, {0}}, ftmp;
+  p384_felem res[3] = {{0}, {0}, {0}}, two_p[3] = {{0}, {0}, {0}}, ftmp;
 
   // Table of multiples of P:  [2i + 1]P for i in [0, 15].
-  fiat_p384_felem p_pre_comp[P384_MUL_PUB_TABLE_SIZE][3];
+  p384_felem p_pre_comp[P384_MUL_PUB_TABLE_SIZE][3];
 
   // Set the first point in the table to P.
   p384_from_generic(p_pre_comp[0][0], &p->X);
@@ -976,15 +987,16 @@ static void ec_GFp_nistp384_point_mul_public(const EC_GROUP *group,
   p384_from_generic(p_pre_comp[0][2], &p->Z);
 
   // Compute two_p = [2]P.
-  fiat_p384_point_double(two_p[0], two_p[1], two_p[2],
+  p384_point_double(two_p[0], two_p[1], two_p[2],
                          p_pre_comp[0][0], p_pre_comp[0][1], p_pre_comp[0][2]);
 
   // Generate the remaining 15 multiples of P.
   for (size_t i = 1; i < P384_MUL_PUB_TABLE_SIZE; i++) {
-    fiat_p384_point_add(p_pre_comp[i][0], p_pre_comp[i][1], p_pre_comp[i][2],
-                        two_p[0], two_p[1], two_p[2], 0 /* both Jacobian */,
-                        p_pre_comp[i - 1][0], p_pre_comp[i - 1][1],
-                        p_pre_comp[i - 1][2]);
+    p384_point_add(p_pre_comp[i][0], p_pre_comp[i][1], p_pre_comp[i][2],
+                   two_p[0], two_p[1], two_p[2], 0 /* both Jacobian */,
+                   p_pre_comp[i - 1][0],
+                   p_pre_comp[i - 1][1],
+                   p_pre_comp[i - 1][2]);
   }
 
   // Recode the scalars.
@@ -1000,7 +1012,7 @@ static void ec_GFp_nistp384_point_mul_public(const EC_GROUP *group,
 
     // If |res| is point-at-infinity there is no point in doubling so skip it.
     if (!res_is_inf) {
-      fiat_p384_point_double(res[0], res[1], res[2], res[0], res[1], res[2]);
+      p384_point_double(res[0], res[1], res[2], res[0], res[1], res[2]);
     }
 
     // Process the p_scalar digit.
@@ -1012,9 +1024,9 @@ static void ec_GFp_nistp384_point_mul_public(const EC_GROUP *group,
       if (res_is_inf) {
         // If |res| is point-at-infinity there is no need to add the new point,
         // we can simply copy it.
-        fiat_p384_copy(res[0], p_pre_comp[idx][0]);
-        fiat_p384_copy(res[1], p_pre_comp[idx][1]);
-        fiat_p384_copy(res[2], p_pre_comp[idx][2]);
+        p384_felem_copy(res[0], p_pre_comp[idx][0]);
+        p384_felem_copy(res[1], p_pre_comp[idx][1]);
+        p384_felem_copy(res[2], p_pre_comp[idx][2]);
         res_is_inf = 0;
       } else {
         // Otherwise, add to the accumulator either the point at position idx
@@ -1022,12 +1034,12 @@ static void ec_GFp_nistp384_point_mul_public(const EC_GROUP *group,
         if (is_neg) {
           p384_felem_opp(ftmp, p_pre_comp[idx][1]);
         } else {
-          fiat_p384_copy(ftmp, p_pre_comp[idx][1]);
+          p384_felem_copy(ftmp, p_pre_comp[idx][1]);
         }
-        fiat_p384_point_add(res[0], res[1], res[2],
-                            res[0], res[1], res[2],
-                            0 /* both Jacobian */,
-                            p_pre_comp[idx][0], ftmp, p_pre_comp[idx][2]);
+        p384_point_add(res[0], res[1], res[2],
+                       res[0], res[1], res[2],
+                       0 /* both Jacobian */,
+                       p_pre_comp[idx][0], ftmp, p_pre_comp[idx][2]);
       }
     }
 
@@ -1040,17 +1052,17 @@ static void ec_GFp_nistp384_point_mul_public(const EC_GROUP *group,
       if (res_is_inf) {
         // If |res| is point-at-infinity there is no need to add the new point,
         // we can simply copy it.
-        fiat_p384_copy(res[0], fiat_p384_g_pre_comp[0][idx][0]);
-        fiat_p384_copy(res[1], fiat_p384_g_pre_comp[0][idx][1]);
-        fiat_p384_copy(res[2], fiat_p384_one);
+        p384_felem_copy(res[0], p384_g_pre_comp[0][idx][0]);
+        p384_felem_copy(res[1], p384_g_pre_comp[0][idx][1]);
+        p384_felem_copy(res[2], p384_felem_one);
         res_is_inf = 0;
       } else {
         // Otherwise, add to the accumulator either the point at position idx
         // in the table or its negation.
         if (is_neg) {
-          p384_felem_opp(ftmp, fiat_p384_g_pre_comp[0][idx][1]);
+          p384_felem_opp(ftmp, p384_g_pre_comp[0][idx][1]);
         } else {
-          fiat_p384_copy(ftmp, fiat_p384_g_pre_comp[0][idx][1]);
+          p384_felem_copy(ftmp, p384_g_pre_comp[0][idx][1]);
         }
         // Add the point to the accumulator |res|.
         // Note that the points in the pre-computed table are given with affine
@@ -1058,10 +1070,10 @@ static void ec_GFp_nistp384_point_mul_public(const EC_GROUP *group,
         // either both given in projective, or one in projective and one in
         // affine coordinates. The |mixed| flag indicates the latter option,
         // in which case we set the third coordinate of the second point to one.
-        fiat_p384_point_add(res[0], res[1], res[2],
-                            res[0], res[1], res[2],
-                            1 /* mixed */,
-                            fiat_p384_g_pre_comp[0][idx][0], ftmp, fiat_p384_one);
+        p384_point_add(res[0], res[1], res[2],
+                       res[0], res[1], res[2],
+                       1 /* mixed */,
+                       p384_g_pre_comp[0][idx][0], ftmp, p384_felem_one);
       }
     }
   }

--- a/crypto/fipsmodule/ec/p384_table.h
+++ b/crypto/fipsmodule/ec/p384_table.h
@@ -28,7 +28,7 @@
 // The windows size is chosen based on analysis analogous to the one in
 // |ec_GFp_nistp_recode_scalar_bits| function in |util.c| file.
 #if defined(BORINGSSL_NISTP384_64BIT)
-static const fiat_p384_felem fiat_p384_g_pre_comp[14][64][2] = {
+static const p384_felem p384_g_pre_comp[14][64][2] = {
     {{{0x3dd0756649c0b528, 0x20e378e2a0d6ce38, 0x879c3afc541b4d6e,
        0x6454868459a30eff, 0x812ff723614ede2b, 0x4d3aadc2299e1513},
       {0x23043dad4b03a4fe, 0xa1bfa8bf7bb4a9ac, 0x8bade7562e83b050,
@@ -3614,7 +3614,7 @@ static const fiat_p384_felem fiat_p384_g_pre_comp[14][64][2] = {
       {0x11c2fe3661211331, 0xa73d8ed58b978268, 0x123dc0155eff3d1b,
        0x9037038c2ef09d17, 0xe7303e05dbf682cf, 0xa098c659f99a62d3}}}};
 #else
-static const fiat_p384_felem fiat_p384_g_pre_comp[14][64][2] = {
+static const p384_felem p384_g_pre_comp[14][64][2] = {
     {{{0x49c0b528, 0x3dd07566, 0xa0d6ce38, 0x20e378e2, 0x541b4d6e, 0x879c3afc,
        0x59a30eff, 0x64548684, 0x614ede2b, 0x812ff723, 0x299e1513, 0x4d3aadc2},
       {0x4b03a4fe, 0x23043dad, 0x7bb4a9ac, 0xa1bfa8bf, 0x2e83b050, 0x8bade756,

--- a/third_party/fiat/p384_32.h
+++ b/third_party/fiat/p384_32.h
@@ -23,15 +23,6 @@ typedef signed char fiat_p384_int1;
 #error "This code only works on a two's complement system"
 #endif
 
-#if !defined(FIAT_P384_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
-static __inline__ uint32_t fiat_p384_value_barrier_u32(uint32_t a) {
-  __asm__("" : "+r"(a) : /* no inputs */);
-  return a;
-}
-#else
-#  define fiat_p384_value_barrier_u32(x) (x)
-#endif
-
 // TODO: if we regenerate the Fiat-crypto files with only the needed functions, no need for these declarations.
 OPENSSL_UNUSED static void fiat_p384_opp(uint32_t out1[6], const uint32_t arg1[6]);
 OPENSSL_UNUSED static void fiat_p384_set_one(uint32_t out1[6]);

--- a/third_party/fiat/p384_64.h
+++ b/third_party/fiat/p384_64.h
@@ -26,15 +26,6 @@ __extension__ typedef __uint128_t fiat_p384_uint128;
 #error "This code only works on a two's complement system"
 #endif
 
-#if !defined(FIAT_P384_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
-static __inline__ uint64_t fiat_p384_value_barrier_u64(uint64_t a) {
-  __asm__("" : "+r"(a) : /* no inputs */);
-  return a;
-}
-#else
-#  define fiat_p384_value_barrier_u64(x) (x)
-#endif
-
 OPENSSL_UNUSED static void fiat_p384_opp(uint64_t out1[6], const uint64_t arg1[6]);
 OPENSSL_UNUSED static void fiat_p384_set_one(uint64_t out1[6]);
 OPENSSL_UNUSED static void fiat_p384_msat(uint64_t out1[7]);


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Refactoring P-384 implementation for consistency (removing `fiat` prefix from functions, enforcing 80 characters per line, etc.)

### Call-outs:
N/A

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
