### PR TITLE
Don't double delete mapping

### DIFF
--- a/crypto/fipsmodule/rand/fork_detect.c
+++ b/crypto/fipsmodule/rand/fork_detect.c
@@ -53,7 +53,7 @@ static int init_fork_detect_madv_wipeonfork(void *addr, long page_size) {
   // unknown |advice| values.
   if (madvise(addr, (size_t)page_size, -1) == 0 ||
       madvise(addr, (size_t)page_size, MADV_WIPEONFORK) != 0) {
-    munmap(addr, (size_t)page_size);
+    // The mapping |addr| points to is unmapped by caller.
     return 0;
   }
 
@@ -143,6 +143,7 @@ static void init_fork_detect(void) {
 cleanup:
   if (res == 0 && addr != MAP_FAILED) {
     munmap(addr, (size_t)page_size);
+    addr = NULL;
   }
 }
 


### PR DESCRIPTION
### Issues:

### Description of changes: 
The memory mapping during fork detection initialisation is currently deleted twice:
1. https://github.com/awslabs/aws-lc/blob/main/crypto/fipsmodule/rand/fork_detect.c#L56
2. https://github.com/awslabs/aws-lc/blob/main/crypto/fipsmodule/rand/fork_detect.c#L145

in the error-path.

Only do this once. We choose to do this in (2) because this captures all error-paths encountered from entry into `init_fork_detect()`.

It is not an "error" to unmap twice per https://man7.org/linux/man-pages/man3/munmap.3p.html:
> If there are no mappings in the specifie address range, then munmap() has no effect. 

But it saves work to not do it twice in the error-path.

### Call-outs:
We invalidate the pointer after unmapping for defense-in-depth, because:
> Further references to these [unmapped] pages shall result in the generation of a SIGSEGV signal to the process.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
