### PR TITLE
Add reason codes for backwards compilation compatibility

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5635,4 +5635,22 @@ BSSL_NAMESPACE_END
 #define SSL_R_TLSV1_ALERT_NO_APPLICATION_PROTOCOL 1120
 #define SSL_R_TLSV1_ALERT_ECH_REQUIRED 1121
 
+// Define some reason codes from OpenSSL to ease compilation against AWS-LC.
+// None of these reason codes are actually returned by AWS-LC.
+// Code paths that condition on these codes might break. Grep for
+// |ERR_GET_REASON| and |ERR_GET_FUNC| to inspect.
+
+// Per C99 standard 6.8.4.2.1 the controlling expression in the switch statement
+// has integer type. Hence it can handle quite large offset values assuming just
+// two bytes. Just pick a somewhat large random value to prevent collisions on
+// later macro definitions from upstream.
+#define SSL_R_BACKWARDS_COMPATABILITY_OFFSET 0x5D21
+
+// See CryptoAlg-954.
+#define SSL_R_NO_PROTOCOLS_AVAILABLE (SSL_R_BACKWARDS_COMPATABILITY_OFFSET + 1)
+#define SSL_R_BAD_PROTOCOL_VERSION_NUMBER (SSL_R_BACKWARDS_COMPATABILITY_OFFSET + 2)
+#define SSL_R_UNSUPPORTED_SSL_VERSION (SSL_R_BACKWARDS_COMPATABILITY_OFFSET + 3)
+#define SSL_R_VERSION_TOO_HIGH (SSL_R_BACKWARDS_COMPATABILITY_OFFSET + 4)
+#define SSL_R_VERSION_TOO_LOW (SSL_R_BACKWARDS_COMPATABILITY_OFFSET + 5)
+
 #endif  // OPENSSL_HEADER_SSL_H


### PR DESCRIPTION
### Issues:
CryptoAlg-954

### Description of changes: 
Add some reason codes from OpenSSL to ease compilation and integration against AWS-LC. Do this under its own "namespace"  for clarity and protect against any upstream merge conflict annoyance.

These will have a different reason code value compared to OpenSSL. But it all works fine if compilation happens against AWS-LC headers, of course!

None of these reason codes are actually returned by AWS-LC. Code paths that condition on these codes might break. Grep for `ERR_GET_REASON` and `ERR_GET_FUNC` to inspect.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
