### PR TITLE
Add macOS CI.

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,0 +1,21 @@
+name: macOS CI
+
+# Workflow syntax.
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+on:
+  pull_request:
+    branches:
+      - 'main'
+      - 'fips-*'
+
+env:
+  PACKAGE_NAME: aws-lc
+
+jobs:
+  macOS:
+    runs-on: macos-11 # latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build ${{ env.PACKAGE_NAME }}
+      run: |
+        ./tests/ci/run_posix_tests.sh

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -19,3 +19,5 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         ./tests/ci/run_posix_tests.sh
+
+# TODO(add fips build)

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -65,12 +65,7 @@ CodeBuild|clang 9.0.1|aarch64|Ubuntu 20.04
 CodeBuild|clang 10.0.0|x86-64|Ubuntu 20.04
 CodeBuild|clang 10.0.0|aarch64|Ubuntu 20.04
 CodeBuild|Visual Studio 2015|x86-64|Windows Server 10
-~~Travis~~|~~Xcode 11*~~|~~x86-64~~|~~macOS 10.14~~
-
-(macOS CI dimension is currently disabled)
-
-\* Apple Xcode 11 supplies what Apple calls clang 11 which is equivalent to llvm
-clang 8.0.0
+GitHub Workflow|AppleClang 13.0.0|x86-64|macOS 11
 
 ### Sanitizer tests
 Runs all tests with:

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -12,7 +12,15 @@ echo "$SRC_ROOT"
 BUILD_ROOT="${SRC_ROOT}/test_build_dir"
 echo "$BUILD_ROOT"
 
-NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
+NUM_CPU_THREADS=''
+KERNEL_NAME=$(uname -s)
+if [[ "${KERNEL_NAME}" == "Darwin" ]]; then
+  # On MacOS, /proc/cpuinfo does not exist.
+  NUM_CPU_THREADS=$(sysctl -n hw.ncpu)
+else
+  # Assume KERNEL_NAME is Linux.
+  NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
+fi
 
 function run_build {
   local cflags=("$@")


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-605

### Description of changes: 
This PR added macOS CI, which uses [GitHub workflow](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore) to run `./tests/ci/run_posix_tests.sh` on macOS 11.

### Call-outs:
* Billing related questions are still being investigated.
* This PR does not cover macOS FIPS build.

### Testing:
https://github.com/bryce-shang/aws-lc/runs/5061261641?check_suite_focus=true

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
