### PR TITLE
Add macOS FIPS build to CI.

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   PACKAGE_NAME: aws-lc
+  # Used to enable ASAN test dimension.
+  AWSLC_NO_ASM_FIPS: 1
 
 jobs:
   macOS:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -20,4 +20,10 @@ jobs:
       run: |
         ./tests/ci/run_posix_tests.sh
 
-# TODO(add fips build)
+  macOS-FIPS:
+    runs-on: macos-11 # latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build ${{ env.PACKAGE_NAME }} with FIPS mode
+      run: |
+        ./tests/ci/run_fips_tests.sh

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -22,5 +22,5 @@ if [[ "${AWSLC_NO_ASM_FIPS}" == "1" ]]; then
 fi
 
 echo "Testing shared AWS-LC in FIPS Debug mode in a different folder."
-BUILD_ROOT=$(realpath "${SRC_ROOT}/../aws-lc-external_build")
+BUILD_ROOT=$(mktemp -d)
 fips_build_and_test -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=1

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -5,38 +5,5 @@ set -exo pipefail
 
 source tests/ci/common_posix_setup.sh
 
-echo "Testing AWS-LC in debug mode."
-build_and_test
-
-echo "Testing AWS-LC in release mode."
-build_and_test -DCMAKE_BUILD_TYPE=Release
-
-echo "Testing AWS-LC small compilation."
-build_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release
-
-echo "Testing AWS-LC in no asm mode."
-build_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
-
-echo "Testing building shared lib."
-run_build -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
-
-if [[ "${AWSLC_FIPS}" == "1" ]]; then
-  echo "Testing AWS-LC in FIPS release mode."
-  build_and_test -DFIPS=1 -DCMAKE_BUILD_TYPE=Release
-  "${BUILD_ROOT}/util/fipstools/cavp/test_fips"
-fi
-
-if [[ "${AWSLC_C99_TEST}" == "1" ]]; then
-    echo "Testing the C99 compatability of AWS-LC headers."
-    ./tests/coding_guidelines/c99_gcc_test.sh
-fi
-
-if [[ "${AWSLC_CODING_GUIDELINES_TEST}" == "1" ]]; then
-  echo "Testing that AWS-LC is compliant with the coding guidelines."
-  source ./tests/coding_guidelines/coding_guidelines_test.sh
-fi
-
-if [[ "${AWSLC_FUZZ}" == "1" ]]; then
-  echo "Testing building fuzz tests."
-  run_build -DFUZZ=1
-fi
+echo "Testing failed MacOS build."
+exit 1

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -5,5 +5,38 @@ set -exo pipefail
 
 source tests/ci/common_posix_setup.sh
 
-echo "Testing failed MacOS build."
-exit 1
+echo "Testing AWS-LC in debug mode."
+build_and_test
+
+echo "Testing AWS-LC in release mode."
+build_and_test -DCMAKE_BUILD_TYPE=Release
+
+echo "Testing AWS-LC small compilation."
+build_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release
+
+echo "Testing AWS-LC in no asm mode."
+build_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
+
+echo "Testing building shared lib."
+run_build -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
+
+if [[ "${AWSLC_FIPS}" == "1" ]]; then
+  echo "Testing AWS-LC in FIPS release mode."
+  build_and_test -DFIPS=1 -DCMAKE_BUILD_TYPE=Release
+  "${BUILD_ROOT}/util/fipstools/cavp/test_fips"
+fi
+
+if [[ "${AWSLC_C99_TEST}" == "1" ]]; then
+    echo "Testing the C99 compatability of AWS-LC headers."
+    ./tests/coding_guidelines/c99_gcc_test.sh
+fi
+
+if [[ "${AWSLC_CODING_GUIDELINES_TEST}" == "1" ]]; then
+  echo "Testing that AWS-LC is compliant with the coding guidelines."
+  source ./tests/coding_guidelines/coding_guidelines_test.sh
+fi
+
+if [[ "${AWSLC_FUZZ}" == "1" ]]; then
+  echo "Testing building fuzz tests."
+  run_build -DFUZZ=1
+fi


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-605

### Description of changes: 
This PR added macOS FIPS build to CI. The build runs `./tests/ci/run_fips_tests.sh` on macOS 11.

### Related PR
* https://github.com/awslabs/aws-lc/pull/381

### Call-outs:
TBD

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
