### PR TITLE
Import the latest s2n-bignum changes for P-384 and P-521

### DIFF
--- a/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
@@ -25,6 +25,7 @@
 // ----------------------------------------------------------------------------
 
         .globl  bignum_cmul_p384
+        .globl  bignum_cmul_p384_alt
         .text
         .balign 4
 
@@ -55,6 +56,7 @@
 
 
 bignum_cmul_p384:
+bignum_cmul_p384_alt:
 
 // First do the multiply, straightforwardly, getting [h; d5; ...; d0]
 

--- a/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
@@ -27,6 +27,7 @@
 // ----------------------------------------------------------------------------
 
         .globl  bignum_deamont_p384
+        .globl  bignum_deamont_p384_alt
         .text
         .balign 4
 
@@ -88,6 +89,7 @@
 #define w x10
 
 bignum_deamont_p384:
+bignum_deamont_p384_alt:
 
 // Set up an initial window with the input x and an extra leading zero
 

--- a/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
@@ -27,6 +27,7 @@
 // ----------------------------------------------------------------------------
 
         .globl  bignum_demont_p384
+        .globl  bignum_demont_p384_alt
         .text
         .balign 4
 
@@ -88,6 +89,7 @@
 #define w x10
 
 bignum_demont_p384:
+bignum_demont_p384_alt:
 
 // Set up an initial window with the input x and an extra leading zero
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
@@ -26,6 +26,7 @@
 // ----------------------------------------------------------------------------
 
         .globl  bignum_mod_n384
+        .globl  bignum_mod_n384_alt
         .text
         .balign 4
 
@@ -73,6 +74,7 @@
                 movk    nn, n3, lsl #48
 
 bignum_mod_n384:
+bignum_mod_n384_alt:
 
 // If the input is already <= 5 words long, go to a trivial "copy" path
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
@@ -24,6 +24,7 @@
 // ----------------------------------------------------------------------------
 
         .globl  bignum_mod_p384
+        .globl  bignum_mod_p384_alt
         .text
         .balign 4
 
@@ -51,6 +52,7 @@
 
 
 bignum_mod_p384:
+bignum_mod_p384_alt:
 
 // If the input is already <= 5 words long, go to a trivial "copy" path
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
@@ -1,0 +1,349 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^384) mod p_384
+// Inputs x[6], y[6]; output z[6]
+//
+//    extern void bignum_montmul_p384_alt
+//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//
+// Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
+// satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in
+// the "usual" case x < p_384 and y < p_384).
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_montmul_p384_alt
+        .text
+        .balign 4
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+#define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
+/* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
+/* Store it in d6 to make the 2^384 * w contribution already            */  \
+                lsl     t1, d0, #32;                                        \
+                add     d6, t1, d0;                                         \
+/* Now let [t3;t2;t1;-] = (2^384 - p_384) * w                    */         \
+/* We know the lowest word will cancel d0 so we don't need it    */         \
+                mov     t1, #0xffffffff00000001;                            \
+                umulh   t1, t1, d6;                                         \
+                mov     t2, #0x00000000ffffffff;                            \
+                mul     t3, t2, d6;                                         \
+                umulh   t2, t2, d6;                                         \
+                adds    t1, t1, t3;                                         \
+                adcs    t2, t2, d6;                                         \
+                adc     t3, xzr, xzr;                                       \
+/* Now add it, by subtracting from 2^384 * w + x */                         \
+                subs    d1, d1, t1;                                         \
+                sbcs    d2, d2, t2;                                         \
+                sbcs    d3, d3, t3;                                         \
+                sbcs    d4, d4, xzr;                                        \
+                sbcs    d5, d5, xzr;                                        \
+                sbc     d6, d6, xzr
+
+
+#define z x0
+#define x x1
+#define y x2
+
+// These are repeated mod 2 as we load pairs of inputs
+
+#define a0 x3
+#define a1 x4
+#define a2 x3
+#define a3 x4
+#define a4 x3
+#define a5 x4
+
+#define b0 x5
+#define b1 x6
+#define b2 x7
+#define b3 x8
+#define b4 x9
+#define b5 x10
+
+#define l x11
+
+#define u0 x12
+#define u1 x13
+#define u2 x14
+#define u3 x15
+#define u4 x16
+#define u5 x17
+#define u6 x19
+#define u7 x20
+#define u8 x21
+#define u9 x22
+#define u10 x2 // same as y
+#define u11 x1 // same as x
+#define h b5 // same as b5
+
+bignum_montmul_p384_alt:
+
+// Save more registers
+
+                stp     x19, x20, [sp, #-16]!
+                stp     x21, x22, [sp, #-16]!
+
+// Load operands and set up row 0 = [u6;...;u0] = a0 * [b5;...;b0]
+
+                ldp     a0, a1, [x]
+                ldp     b0, b1, [y]
+
+                mul     u0, a0, b0
+                umulh   u1, a0, b0
+                mul     l, a0, b1
+                umulh   u2, a0, b1
+                adds    u1, u1, l
+
+                ldp     b2, b3, [y, #16]
+
+                mul     l, a0, b2
+                umulh   u3, a0, b2
+                adcs    u2, u2, l
+
+                mul     l, a0, b3
+                umulh   u4, a0, b3
+                adcs    u3, u3, l
+
+                ldp     b4, b5, [y, #32]
+
+                mul     l, a0, b4
+                umulh   u5, a0, b4
+                adcs    u4, u4, l
+
+                mul     l, a0, b5
+                umulh   u6, a0, b5
+                adcs    u5, u5, l
+
+                adc     u6, u6, xzr
+
+// Row 1 = [u7;...;u0] = [a1;a0] * [b5;...;b0]
+
+                mul     l, a1, b0
+                adds    u1, u1, l
+                mul     l, a1, b1
+                adcs    u2, u2, l
+                mul     l, a1, b2
+                adcs    u3, u3, l
+                mul     l, a1, b3
+                adcs    u4, u4, l
+                mul     l, a1, b4
+                adcs    u5, u5, l
+                mul     l, a1, b5
+                adcs    u6, u6, l
+                cset    u7, cs
+
+                umulh   l, a1, b0
+                adds    u2, u2, l
+                umulh   l, a1, b1
+                adcs    u3, u3, l
+                umulh   l, a1, b2
+                adcs    u4, u4, l
+                umulh   l, a1, b3
+                adcs    u5, u5, l
+                umulh   l, a1, b4
+                adcs    u6, u6, l
+                umulh   l, a1, b5
+                adc     u7, u7, l
+
+// Row 2 = [u8;...;u0] = [a2;a1;a0] * [b5;...;b0]
+
+                ldp     a2, a3, [x, #16]
+
+                mul     l, a2, b0
+                adds    u2, u2, l
+                mul     l, a2, b1
+                adcs    u3, u3, l
+                mul     l, a2, b2
+                adcs    u4, u4, l
+                mul     l, a2, b3
+                adcs    u5, u5, l
+                mul     l, a2, b4
+                adcs    u6, u6, l
+                mul     l, a2, b5
+                adcs    u7, u7, l
+                cset    u8, cs
+
+                umulh   l, a2, b0
+                adds    u3, u3, l
+                umulh   l, a2, b1
+                adcs    u4, u4, l
+                umulh   l, a2, b2
+                adcs    u5, u5, l
+                umulh   l, a2, b3
+                adcs    u6, u6, l
+                umulh   l, a2, b4
+                adcs    u7, u7, l
+                umulh   l, a2, b5
+                adc     u8, u8, l
+
+// Row 3 = [u9;...;u0] = [a3;a2;a1;a0] * [b5;...;b0]
+
+                mul     l, a3, b0
+                adds    u3, u3, l
+                mul     l, a3, b1
+                adcs    u4, u4, l
+                mul     l, a3, b2
+                adcs    u5, u5, l
+                mul     l, a3, b3
+                adcs    u6, u6, l
+                mul     l, a3, b4
+                adcs    u7, u7, l
+                mul     l, a3, b5
+                adcs    u8, u8, l
+                cset    u9, cs
+
+                umulh   l, a3, b0
+                adds    u4, u4, l
+                umulh   l, a3, b1
+                adcs    u5, u5, l
+                umulh   l, a3, b2
+                adcs    u6, u6, l
+                umulh   l, a3, b3
+                adcs    u7, u7, l
+                umulh   l, a3, b4
+                adcs    u8, u8, l
+                umulh   l, a3, b5
+                adc     u9, u9, l
+
+// Row 4 = [u10;...;u0] = [a4;a3;a2;a1;a0] * [b5;...;b0]
+
+                ldp     a4, a5, [x, #32]
+
+                mul     l, a4, b0
+                adds    u4, u4, l
+                mul     l, a4, b1
+                adcs    u5, u5, l
+                mul     l, a4, b2
+                adcs    u6, u6, l
+                mul     l, a4, b3
+                adcs    u7, u7, l
+                mul     l, a4, b4
+                adcs    u8, u8, l
+                mul     l, a4, b5
+                adcs    u9, u9, l
+                cset    u10, cs
+
+                umulh   l, a4, b0
+                adds    u5, u5, l
+                umulh   l, a4, b1
+                adcs    u6, u6, l
+                umulh   l, a4, b2
+                adcs    u7, u7, l
+                umulh   l, a4, b3
+                adcs    u8, u8, l
+                umulh   l, a4, b4
+                adcs    u9, u9, l
+                umulh   l, a4, b5
+                adc     u10, u10, l
+
+// Row 5 = [u11;...;u0] = [a5;a4;a3;a2;a1;a0] * [b5;...;b0]
+
+                mul     l, a5, b0
+                adds    u5, u5, l
+                mul     l, a5, b1
+                adcs    u6, u6, l
+                mul     l, a5, b2
+                adcs    u7, u7, l
+                mul     l, a5, b3
+                adcs    u8, u8, l
+                mul     l, a5, b4
+                adcs    u9, u9, l
+                mul     l, a5, b5
+                adcs    u10, u10, l
+                cset    u11, cs
+
+                umulh   l, a5, b0
+                adds    u6, u6, l
+                umulh   l, a5, b1
+                adcs    u7, u7, l
+                umulh   l, a5, b2
+                adcs    u8, u8, l
+                umulh   l, a5, b3
+                adcs    u9, u9, l
+                umulh   l, a5, b4
+                adcs    u10, u10, l
+                umulh   l, a5, b5
+                adc     u11, u11, l
+
+// Montgomery rotate the low half
+
+                montreds(u0,u5,u4,u3,u2,u1,u0, b0,b1,b2)
+                montreds(u1,u0,u5,u4,u3,u2,u1, b0,b1,b2)
+                montreds(u2,u1,u0,u5,u4,u3,u2, b0,b1,b2)
+                montreds(u3,u2,u1,u0,u5,u4,u3, b0,b1,b2)
+                montreds(u4,u3,u2,u1,u0,u5,u4, b0,b1,b2)
+                montreds(u5,u4,u3,u2,u1,u0,u5, b0,b1,b2)
+
+// Add up the high and low parts as [h; u5;u4;u3;u2;u1;u0] = z
+
+                adds    u0, u0, u6
+                adcs    u1, u1, u7
+                adcs    u2, u2, u8
+                adcs    u3, u3, u9
+                adcs    u4, u4, u10
+                adcs    u5, u5, u11
+                adc     h, xzr, xzr
+
+// Now add [h; u11;u10;u9;u8;u7;u6] = z + (2^384 - p_384)
+
+                mov     l, #0xffffffff00000001
+                adds    u6, u0, l
+                mov     l, #0x00000000ffffffff
+                adcs    u7, u1, l
+                mov     l, #0x0000000000000001
+                adcs    u8, u2, l
+                adcs    u9, u3, xzr
+                adcs    u10, u4, xzr
+                adcs    u11, u5, xzr
+                adcs    h, h, xzr
+
+// Now z >= p_384 iff h is nonzero, so select accordingly
+
+                csel    u0, u0, u6, eq
+                csel    u1, u1, u7, eq
+                csel    u2, u2, u8, eq
+                csel    u3, u3, u9, eq
+                csel    u4, u4, u10, eq
+                csel    u5, u5, u11, eq
+
+// Store back final result
+
+                stp     u0, u1, [z]
+                stp     u2, u3, [z, #16]
+                stp     u4, u5, [z, #32]
+
+// Restore registers
+
+                ldp     x21, x22, [sp], #16
+                ldp     x19, x20, [sp], #16
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
@@ -1,0 +1,278 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^384) mod p_384
+// Input x[6]; output z[6]
+//
+//    extern void bignum_montsqr_p384_alt
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
+// guaranteed in particular if x < p_384 initially (the "intended" case).
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_montsqr_p384_alt
+        .text
+        .balign 4
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing contents of [d5;d4;d3;d2;d1]. It is fine
+// for d6 to be the same register as d0.
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+// ---------------------------------------------------------------------------
+
+#define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
+/* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
+/* Store it in d6 to make the 2^384 * w contribution already            */  \
+                lsl     t1, d0, #32;                                        \
+                add     d6, t1, d0;                                         \
+/* Now let [t3;t2;t1;-] = (2^384 - p_384) * w                    */         \
+/* We know the lowest word will cancel d0 so we don't need it    */         \
+                mov     t1, #0xffffffff00000001;                            \
+                umulh   t1, t1, d6;                                         \
+                mov     t2, #0x00000000ffffffff;                            \
+                mul     t3, t2, d6;                                         \
+                umulh   t2, t2, d6;                                         \
+                adds    t1, t1, t3;                                         \
+                adcs    t2, t2, d6;                                         \
+                adc     t3, xzr, xzr;                                       \
+/* Now add it, by subtracting from 2^384 * w + x */                         \
+                subs    d1, d1, t1;                                         \
+                sbcs    d2, d2, t2;                                         \
+                sbcs    d3, d3, t3;                                         \
+                sbcs    d4, d4, xzr;                                        \
+                sbcs    d5, d5, xzr;                                        \
+                sbc     d6, d6, xzr
+
+#define z x0
+#define x x1
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define a4 x6
+#define a5 x7
+
+#define l x8
+
+#define u0 x2 // The same as a0, which is safe
+#define u1 x9
+#define u2 x10
+#define u3 x11
+#define u4 x12
+#define u5 x13
+#define u6 x14
+#define u7 x15
+#define u8 x16
+#define u9 x17
+#define u10 x19
+#define u11 x20
+#define h x6 // same as a4
+
+bignum_montsqr_p384_alt:
+
+// It's convenient to have two more registers to play with
+
+                stp     x19, x20, [sp, #-16]!
+
+// Load all the elements as [a5;a4;a3;a2;a1;a0], set up an initial
+// window [u8;u7; u6;u5; u4;u3; u2;u1] = [34;05;03;01], and then
+// chain in the addition of 02 + 12 + 13 + 14 + 15 to that window
+// (no carry-out possible since we add it to the top of a product).
+
+                ldp     a0, a1, [x]
+
+                mul     u1, a0, a1
+                umulh   u2, a0, a1
+
+                ldp     a2, a3, [x, #16]
+
+                mul     l, a0, a2
+                adds    u2, u2, l
+
+                mul     u3, a0, a3
+                mul     l, a1, a2
+                adcs    u3, u3, l
+
+                umulh   u4, a0, a3
+                mul     l, a1, a3
+                adcs    u4, u4, l
+
+                ldp     a4, a5, [x, #32]
+
+                mul     u5, a0, a5
+                mul     l, a1, a4
+                adcs    u5, u5, l
+
+                umulh   u6, a0, a5
+                mul     l, a1, a5
+                adcs    u6, u6, l
+
+                mul     u7, a3, a4
+                adcs    u7, u7, xzr
+
+                umulh   u8, a3, a4
+                adc     u8, u8, xzr
+
+                umulh   l, a0, a2
+                adds    u3, u3, l
+                umulh   l, a1, a2
+                adcs    u4, u4, l
+                umulh   l, a1, a3
+                adcs    u5, u5, l
+                umulh   l, a1, a4
+                adcs    u6, u6, l
+                umulh   l, a1, a5
+                adcs    u7, u7, l
+                adc     u8, u8, xzr
+
+// Now chain in the 04 + 23 + 24 + 25 + 35 + 45 terms
+
+                mul     l, a0, a4
+                adds    u4, u4, l
+                mul     l, a2, a3
+                adcs    u5, u5, l
+                mul     l, a2, a4
+                adcs    u6, u6, l
+                mul     l, a2, a5
+                adcs    u7, u7, l
+                mul     l, a3, a5
+                adcs    u8, u8, l
+                mul     u9, a4, a5
+                adcs    u9, u9, xzr
+                umulh   u10, a4, a5
+                adc     u10, u10, xzr
+
+                umulh   l, a0, a4
+                adds    u5, u5, l
+                umulh   l, a2, a3
+                adcs    u6, u6, l
+                umulh   l, a2, a4
+                adcs    u7, u7, l
+                umulh   l, a2, a5
+                adcs    u8, u8, l
+                umulh   l, a3, a5
+                adcs    u9, u9, l
+                adc     u10, u10, xzr
+
+// Double that, with u11 holding the top carry
+
+                adds    u1, u1, u1
+                adcs    u2, u2, u2
+                adcs    u3, u3, u3
+                adcs    u4, u4, u4
+                adcs    u5, u5, u5
+                adcs    u6, u6, u6
+                adcs    u7, u7, u7
+                adcs    u8, u8, u8
+                adcs    u9, u9, u9
+                adcs    u10, u10, u10
+                cset    u11, cs
+
+// Add the homogeneous terms 00 + 11 + 22 + 33 + 44 + 55
+
+                umulh   l, a0, a0
+                mul     u0, a0, a0
+                adds    u1, u1, l
+
+                mul     l, a1, a1
+                adcs    u2, u2, l
+                umulh   l, a1, a1
+                adcs    u3, u3, l
+
+                mul     l, a2, a2
+                adcs    u4, u4, l
+                umulh   l, a2, a2
+                adcs    u5, u5, l
+
+                mul     l, a3, a3
+                adcs    u6, u6, l
+                umulh   l, a3, a3
+                adcs    u7, u7, l
+
+                mul     l, a4, a4
+                adcs    u8, u8, l
+                umulh   l, a4, a4
+                adcs    u9, u9, l
+
+                mul     l, a5, a5
+                adcs    u10, u10, l
+                umulh   l, a5, a5
+                adc     u11, u11, l
+
+// Montgomery rotate the low half
+
+                montreds(u0,u5,u4,u3,u2,u1,u0, a1,a2,a3)
+                montreds(u1,u0,u5,u4,u3,u2,u1, a1,a2,a3)
+                montreds(u2,u1,u0,u5,u4,u3,u2, a1,a2,a3)
+                montreds(u3,u2,u1,u0,u5,u4,u3, a1,a2,a3)
+                montreds(u4,u3,u2,u1,u0,u5,u4, a1,a2,a3)
+                montreds(u5,u4,u3,u2,u1,u0,u5, a1,a2,a3)
+
+// Add up the high and low parts as [h; u5;u4;u3;u2;u1;u0] = z
+
+                adds    u0, u0, u6
+                adcs    u1, u1, u7
+                adcs    u2, u2, u8
+                adcs    u3, u3, u9
+                adcs    u4, u4, u10
+                adcs    u5, u5, u11
+                adc     h, xzr, xzr
+
+// Now add [h; u11;u10;u9;u8;u7;u6] = z + (2^384 - p_384)
+
+                mov     l, #0xffffffff00000001
+                adds    u6, u0, l
+                mov     l, #0x00000000ffffffff
+                adcs    u7, u1, l
+                mov     l, #0x0000000000000001
+                adcs    u8, u2, l
+                adcs    u9, u3, xzr
+                adcs    u10, u4, xzr
+                adcs    u11, u5, xzr
+                adcs    h, h, xzr
+
+// Now z >= p_384 iff h is nonzero, so select accordingly
+
+                csel    u0, u0, u6, eq
+                csel    u1, u1, u7, eq
+                csel    u2, u2, u8, eq
+                csel    u3, u3, u9, eq
+                csel    u4, u4, u10, eq
+                csel    u5, u5, u11, eq
+
+// Store back final result
+
+                stp     u0, u1, [z]
+                stp     u2, u3, [z, #16]
+                stp     u4, u5, [z, #32]
+
+// Restore registers
+
+                ldp     x19, x20, [sp], #16
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
@@ -24,6 +24,7 @@
 // ----------------------------------------------------------------------------
 
         .globl  bignum_tomont_p384
+        .globl  bignum_tomont_p384_alt
         .text
         .balign 4
 
@@ -70,6 +71,7 @@
                 adc     d5, d5, t3
 
 bignum_tomont_p384:
+bignum_tomont_p384_alt:
 
 #define d0 x2
 #define d1 x3

--- a/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
@@ -27,6 +27,7 @@
 // ----------------------------------------------------------------------------
 
         .globl  bignum_triple_p384
+        .globl  bignum_triple_p384_alt
         .text
         .balign 4
 
@@ -62,6 +63,7 @@
 
 
 bignum_triple_p384:
+bignum_triple_p384_alt:
 
 // Load the inputs
 

--- a/third_party/s2n-bignum/arm/p521/Makefile
+++ b/third_party/s2n-bignum/arm/p521/Makefile
@@ -31,29 +31,27 @@ endif
 
 # List of object files
 
-OBJ = bignum_add_p384.o \
-      bignum_bigendian_6.o \
-      bignum_cmul_p384.o \
-      bignum_deamont_p384.o \
-      bignum_demont_p384.o \
-      bignum_double_p384.o \
-      bignum_half_p384.o \
-      bignum_littleendian_6.o \
-      bignum_mod_n384.o \
-      bignum_mod_n384_6.o \
-      bignum_mod_p384.o \
-      bignum_mod_p384_6.o \
-      bignum_montmul_p384.o \
-      bignum_montmul_p384_alt.o \
-      bignum_montsqr_p384.o \
-      bignum_montsqr_p384_alt.o \
-      bignum_mux_6.o \
-      bignum_neg_p384.o \
-      bignum_nonzero_6.o \
-      bignum_optneg_p384.o \
-      bignum_sub_p384.o \
-      bignum_tomont_p384.o \
-      bignum_triple_p384.o
+OBJ = bignum_add_p521.o \
+      bignum_cmul_p521.o \
+      bignum_deamont_p521.o \
+      bignum_demont_p521.o \
+      bignum_double_p521.o \
+      bignum_half_p521.o \
+      bignum_mod_n521_9.o \
+      bignum_mod_p521_9.o \
+      bignum_montmul_p521.o \
+      bignum_montmul_p521_alt.o \
+      bignum_montsqr_p521.o \
+      bignum_montsqr_p521_alt.o \
+      bignum_mul_p521.o \
+      bignum_mul_p521_alt.o \
+      bignum_neg_p521.o \
+      bignum_optneg_p521.o \
+      bignum_sqr_p521.o \
+      bignum_sqr_p521_alt.o \
+      bignum_sub_p521.o \
+      bignum_tomont_p521.o \
+      bignum_triple_p521.o
 
 %.o : %.S ; cpp $< | $(GAS) -o $@ -
 

--- a/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
@@ -1,0 +1,104 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Add modulo p_521, z := (x + y) mod p_521, assuming x and y reduced
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_add_p521
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_add_p521
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+#define y x2
+#define h x3
+#define l x4
+#define d0 x5
+#define d1 x6
+#define d2 x7
+#define d3 x8
+#define d4 x9
+#define d5 x10
+#define d6 x11
+#define d7 x12
+#define d8 x13
+
+
+bignum_add_p521:
+
+// Force carry-in to get s = [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x + y + 1.
+// We ignore the carry-out, assuming inputs are reduced so there is none.
+
+                subs    xzr, xzr, xzr
+                ldp     d0, d1, [x]
+                ldp     l, h, [y]
+                adcs    d0, d0, l
+                adcs    d1, d1, h
+                ldp     d2, d3, [x, #16]
+                ldp     l, h, [y, #16]
+                adcs    d2, d2, l
+                adcs    d3, d3, h
+                ldp     d4, d5, [x, #32]
+                ldp     l, h, [y, #32]
+                adcs    d4, d4, l
+                adcs    d5, d5, h
+                ldp     d6, d7, [x, #48]
+                ldp     l, h, [y, #48]
+                adcs    d6, d6, l
+                adcs    d7, d7, h
+                ldr     d8, [x, #64]
+                ldr     l, [y, #64]
+                adc     d8, d8, l
+
+// Now x + y >= p_521 <=> s = x + y + 1 >= 2^521
+// Set CF <=> s = x + y + 1 >= 2^521 and make it a mask in l as well
+
+                subs    l, d8, #512
+                csetm   l, cs
+
+// Now if CF is set (and l is all 1s), we want (x + y) - p_521 = s - 2^521
+// while otherwise we want x + y = s - 1 (from existing CF, which is nice)
+
+                sbcs    d0, d0, xzr
+                and     l, l, #512
+                sbcs    d1, d1, xzr
+                sbcs    d2, d2, xzr
+                sbcs    d3, d3, xzr
+                sbcs    d4, d4, xzr
+                sbcs    d5, d5, xzr
+                sbcs    d6, d6, xzr
+                sbcs    d7, d7, xzr
+                sbc     d8, d8, l
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
@@ -1,0 +1,154 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply by a single word modulo p_521, z := (c * x) mod p_521, assuming
+// x reduced
+// Inputs c, x[9]; output z[9]
+//
+//    extern void bignum_cmul_p521
+//     (uint64_t z[static 9], uint64_t c, uint64_t x[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = c, X2 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_cmul_p521
+        .text
+        .balign 4
+
+#define z x0
+#define c x1
+#define x x2
+
+#define d0 x3
+#define d1 x4
+#define d2 x5
+#define d3 x6
+#define d4 x7
+#define d5 x8
+#define d6 x9
+#define d7 x10
+#define d8 x11
+#define d9 x12
+
+// Heavily aliased subject to ordering
+
+#define a0 d3
+#define a1 d4
+#define a2 d5
+#define a3 d6
+#define a4 d7
+#define a5 d8
+#define a6 d9
+#define h d9
+
+// Other variables
+
+#define a7 x13
+#define a8 x14
+#define dd x15
+
+bignum_cmul_p521:
+
+// First do the multiply, getting [d9; ...; d0], and as this is done
+// accumulate an AND "dd" of digits d7,...,d1 for later use
+
+                ldp     a0, a1, [x]
+                mul     d0, c, a0
+                mul     d1, c, a1
+                umulh   a0, c, a0
+                adds    d1, d1, a0
+                umulh   a1, c, a1
+
+                ldp     a2, a3, [x, #16]
+                mul     d2, c, a2
+                mul     d3, c, a3
+                umulh   a2, c, a2
+                adcs    d2, d2, a1
+                and     dd, d1, d2
+                umulh   a3, c, a3
+                adcs    d3, d3, a2
+                and     dd, dd, d3
+
+                ldp     a4, a5, [x, #32]
+                mul     d4, c, a4
+                mul     d5, c, a5
+                umulh   a4, c, a4
+                adcs    d4, d4, a3
+                and     dd, dd, d4
+                umulh   a5, c, a5
+                adcs    d5, d5, a4
+                and     dd, dd, d5
+
+                ldp     a6, a7, [x, #48]
+                mul     d6, c, a6
+                mul     d7, c, a7
+                umulh   a6, c, a6
+                adcs    d6, d6, a5
+                and     dd, dd, d6
+                umulh   a7, c, a7
+                adcs    d7, d7, a6
+                and     dd, dd, d7
+
+                ldr     a8, [x, #64]
+                mul     d8, c, a8
+                adcs    d8, d8, a7
+                umulh   a8, c, a8
+                adc     d9, xzr, a8
+
+// Extract the high part h and mask off the low part l = [d8;d7;...;d0]
+// but stuff d8 with 1 bits at the left to ease a comparison below
+
+                extr    h, d9, d8, #9
+                orr     d8, d8, #~0x1FF
+
+// Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
+// happen if digits d7,...d1 are all 1s, we use the AND of them "dd" to
+// condense the carry chain, and since we stuffed 1 bits into d8 we get
+// the result in CF without an additional comparison.
+
+                subs    xzr, xzr, xzr
+                adcs    xzr, d0, h
+                adcs    xzr, dd, xzr
+                adcs    xzr, d8, xzr
+
+// Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
+// while otherwise we want just h + l. So mask h + l + CF to 521 bits.
+// This masking also gets rid of the stuffing with 1s we did above.
+
+                adcs    d0, d0, h
+                adcs    d1, d1, xzr
+                adcs    d2, d2, xzr
+                adcs    d3, d3, xzr
+                adcs    d4, d4, xzr
+                adcs    d5, d5, xzr
+                adcs    d6, d6, xzr
+                adcs    d7, d7, xzr
+                adc     d8, d8, xzr
+                and     d8, d8, #0x1FF
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
@@ -1,0 +1,125 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert from Montgomery form z := (x / 2^576) mod p_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_deamont_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Convert a 9-digit bignum x out of its (optionally almost) Montgomery form,
+// "almost" meaning any 9-digit input will work, with no range restriction.
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_deamont_p521
+        .text
+        .balign 4
+
+// Input parameters
+
+#define z x0
+#define x x1
+
+// Rotating registers for the intermediate windows
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+#define d6 x8
+#define d7 x9
+#define d8 x10
+
+// Some other variables, not all distinct
+
+#define c x11
+#define h x11
+#define l x12
+#define u x12
+
+bignum_deamont_p521:
+
+// Load all the inputs
+
+                ldp     d0, d1, [x]
+                ldp     d2, d3, [x, #16]
+                ldp     d4, d5, [x, #32]
+                ldp     d6, d7, [x, #48]
+                ldr     d8, [x, #64]
+
+// Stash the lowest 55 bits at the top of c, then shift the whole 576-bit
+// input right by 9*64 - 521 = 576 - 521 = 55 bits. As this is done,
+// accumulate an AND of words d0..d6.
+
+                lsl     c, d0, #9
+                extr    d0, d1, d0, #55
+                extr    d1, d2, d1, #55
+                and     u, d0, d1
+                extr    d2, d3, d2, #55
+                and     u, u, d2
+                extr    d3, d4, d3, #55
+                and     u, u, d3
+                extr    d4, d5, d4, #55
+                and     u, u, d4
+                extr    d5, d6, d5, #55
+                and     u, u, d5
+                extr    d6, d7, d6, #55
+                and     u, u, d6
+                extr    d7, d8, d7, #55
+                lsr     d8, d8, #55
+
+// Now writing x = 2^55 * h + l (so here [d8;..d0] = h and c = 2^9 * l)
+// we want (h + 2^{521-55} * l) mod p_521 = s mod p_521. Since s < 2 * p_521
+// this is just "if s >= p_521 then s - p_521 else s". First get
+// CF <=> s >= p_521, creating the digits [h,l] to add for the l part.
+
+                adds    xzr, u, #1
+                lsl     l, c, #9
+                adcs    xzr, d7, l
+                orr     d8, d8, #~0x1FF
+                lsr     h, c, #55
+                adcs    xzr, d8, h
+
+// Now the result = s mod p_521 = (if s >= p_521 then s - p_521 else s) =
+// (s + CF) mod 2^521. So do the addition inheriting the carry-in.
+
+                adcs    d0, d0, xzr
+                adcs    d1, d1, xzr
+                adcs    d2, d2, xzr
+                adcs    d3, d3, xzr
+                adcs    d4, d4, xzr
+                adcs    d5, d5, xzr
+                adcs    d6, d6, xzr
+                adcs    d7, d7, l
+                adc     d8, d8, h
+                and     d8, d8, #0x1FF
+
+// Store back the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert from Montgomery form z := (x / 2^576) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_demont_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// This assumes the input is < p_521 for correctness. If this is not the case,
+// use the variant "bignum_deamont_p521" instead.
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_demont_p521
+        .text
+        .balign 4
+
+// Input parameters
+
+#define z x0
+#define x x1
+
+// Rotating registers for the intermediate windows
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x2
+#define d5 x3
+#define d6 x4
+#define d7 x5
+#define d8 x2
+#define c x6
+
+bignum_demont_p521:
+
+// Rotate, as a 521-bit quantity, by 9*64 - 521 = 55 bits right.
+
+                ldp     d0, d1, [x]
+                lsl     c, d0, #9
+                extr    d0, d1, d0, #55
+                ldp     d2, d3, [x, #16]
+                extr    d1, d2, d1, #55
+                stp     d0, d1, [z]
+                extr    d2, d3, d2, #55
+                ldp     d4, d5, [x, #32]
+                extr    d3, d4, d3, #55
+                stp     d2, d3, [z, #16]
+                extr    d4, d5, d4, #55
+                ldp     d6, d7, [x, #48]
+                extr    d5, d6, d5, #55
+                stp     d4, d5, [z, #32]
+                extr    d6, d7, d6, #55
+                ldr     d8, [x, #64]
+                orr     d8, d8, c
+                extr    d7, d8, d7, #55
+                stp     d6, d7, [z, #48]
+                lsr     d8, d8, #55
+                str     d8, [z, #64]
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Double modulo p_521, z := (2 * x) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_double_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_double_p521
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define c x2
+#define h x3
+#define l x4
+
+bignum_double_p521:
+
+// We can decide whether 2 * x >= p_521 just by 2 * x >= 2^521, which
+// amounts to whether the top word is >= 256
+
+                ldr     c, [x, #64]
+                subs    xzr, c, #256
+
+// Now if 2 * x >= p_521 we want 2 * x - p_521 = (2 * x + 1) - 2^521
+// and otherwise just 2 * x. Feed in the condition as the carry bit
+// to get 2 * x + [2 * x >= p_521] then just mask it off to 521 bits.
+
+                ldp     l, h, [x]
+                adcs    l, l, l
+                adcs    h, h, h
+                stp     l, h, [z]
+
+                ldp     l, h, [x, #16]
+                adcs    l, l, l
+                adcs    h, h, h
+                stp     l, h, [z, #16]
+
+                ldp     l, h, [x, #32]
+                adcs    l, l, l
+                adcs    h, h, h
+                stp     l, h, [z, #32]
+
+                ldp     l, h, [x, #48]
+                adcs    l, l, l
+                adcs    h, h, h
+                stp     l, h, [z, #48]
+
+                adc     c, c, c
+                and     c, c, #0x1FF
+                str     c, [z, #64]
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Halve modulo p_521, z := (x / 2) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_half_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_half_p521
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+// We use distinct variables for clarity, but these are heavily aliased
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x2
+#define d5 x3
+#define d6 x4
+#define d7 x5
+#define d8 x2
+#define a x6
+
+
+bignum_half_p521:
+
+// We do a 521-bit rotation one bit right, since 2^521 == 1 (mod p_521)
+
+                ldp     d0, d1, [x]
+                and     a, d0, #1
+                extr    d0, d1, d0, #1
+
+                ldp     d2, d3, [x, #16]
+                extr    d1, d2, d1, #1
+                stp     d0, d1, [z]
+                extr    d2, d3, d2, #1
+
+                ldp     d4, d5, [x, #32]
+                extr    d3, d4, d3, #1
+                stp     d2, d3, [z, #16]
+                extr    d4, d5, d4, #1
+
+                ldp     d6, d7, [x, #48]
+                extr    d5, d6, d5, #1
+                stp     d4, d5, [z, #32]
+                extr    d6, d7, d6, #1
+
+                ldr     d8, [x, #64]
+                extr    d7, d8, d7, #1
+                stp     d6, d7, [z, #48]
+                lsl     d8, d8, #55
+                extr    d8, a, d8, #56
+                str     d8, [z, #64]
+
+// Return
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
@@ -1,0 +1,149 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Reduce modulo group order, z := x mod n_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_mod_n521_9
+//      (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Reduction is modulo the group order of the NIST curve P-521.
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_mod_n521_9
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define n0 x2
+#define n1 x3
+#define n2 x4
+#define n3 x5
+
+#define d0 x6
+#define d1 x7
+#define d2 x8
+#define d3 x9
+#define d4 x10
+#define d5 x11
+#define d6 x12
+#define d7 x13
+#define d8 x14
+
+#define q x15
+
+// Re-use d6 and d7 as temporaries before they are needed
+
+#define s d6
+#define t d7
+
+#define movbig(nn,n3,n2,n1,n0)                                              \
+                movz    nn, n0;                                             \
+                movk    nn, n1, lsl #16;                                    \
+                movk    nn, n2, lsl #32;                                    \
+                movk    nn, n3, lsl #48
+
+bignum_mod_n521_9:
+
+// Load the top digit first into d8.
+// The initial quotient estimate is q = h + 1 where x = 2^521 * h + t
+
+                ldr     d8, [x, #64]
+                lsr     q, d8, #9
+                add     q, q, #1
+
+// Let [5; n3; n2; n1; n0] = r_521 = 2^521 - n_521
+// and form [d4;d3;d2;d1;d0] = q * r_521
+
+                movbig( n0, #0x4490, #0x48e1, #0x6ec7, #0x9bf7)
+                mul     d0, n0, q
+                movbig( n1, #0xc44a, #0x3647, #0x7663, #0xb851)
+                mul     d1, n1, q
+                movbig( n2, #0x8033, #0xfeb7, #0x08f6, #0x5a2f)
+                mul     d2, n2, q
+                movbig( n3, #0xae79, #0x787c, #0x40d0, #0x6994)
+                mul     d3, n3, q
+                lsl     d4, q, #2
+                add     d4, d4, q
+                umulh   t, n0, q
+                adds    d1, d1, t
+                umulh   t, n1, q
+                adcs    d2, d2, t
+                umulh   t, n2, q
+                adcs    d3, d3, t
+                umulh   t, n3, q
+                adc     d4, d4, t
+
+// Now load other digits and form r = x - q * n_521 = (q * r_521 + t) - 2^521.
+// But the computed result stuffs in 1s from bit 521 onwards and actually
+// gives r' = (q * r_521 + t) + (2^576 - 2^521) = r + 2^576, including the
+// top carry. Hence CF <=> r >= 0, while r' == r (mod 2^521).
+
+                ldp     s, t, [x]
+                adds    d0, d0, s
+                adcs    d1, d1, t
+                ldp     s, t, [x, #16]
+                adcs    d2, d2, s
+                adcs    d3, d3, t
+                ldp     t, d5, [x, #32]
+                adcs    d4, d4, t
+                adcs    d5, d5, xzr
+                ldp     d6, d7, [x, #48]
+                adcs    d6, d6, xzr
+                adcs    d7, d7, xzr
+                orr     d8, d8, #~0x1FF
+                adcs    d8, d8, xzr
+
+// We already know r < n_521, but if it actually went negative then
+// we need to add back n_521 again. Recycle q as a bitmask for r < n_521,
+// and just subtract r_521 and mask rather than literally adding 2^521.
+// This also gets rid of the bit-stuffing above.
+
+                csetm   q, cc
+                and     n0, n0, q
+                subs    d0, d0, n0
+                and     n1, n1, q
+                sbcs    d1, d1, n1
+                and     n2, n2, q
+                sbcs    d2, d2, n2
+                and     n3, n3, q
+                sbcs    d3, d3, n3
+                mov     n0, #5
+                and     n0, n0, q
+                sbcs    d4, d4, n0
+                sbcs    d5, d5, xzr
+                sbcs    d6, d6, xzr
+                sbcs    d7, d7, xzr
+                sbc     d8, d8, xzr
+                and     d8, d8, #0x1FF
+
+// Store the end result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Reduce modulo field characteristic, z := x mod p_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_mod_p521_9
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_mod_p521_9
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define h x2
+#define t x3
+#define d0 x4
+#define d1 x5
+#define d2 x6
+#define d3 x7
+#define d4 x8
+#define d5 x9
+#define d6 x10
+#define d7 x11
+#define d8 x12
+
+bignum_mod_p521_9:
+
+// Load top digit first and get its upper bits in h so that we
+// separate out x = 2^521 * H + L with h = H. Now x mod p_521 =
+// (H + L) mod p_521 = if H + L >= p_521 then H + L - p_521 else H + L.
+
+                ldr     d8, [x, #64]
+                lsr     h, d8, #9
+
+// Load in the other digits and decide whether H + L >= p_521. This is
+// equivalent to H + L + 1 >= 2^521, and since this can only happen if
+// digits d7,...,d1 consist entirely of 1 bits, we can condense the
+// carry chain by ANDing digits together, perhaps reducing its latency.
+// This condenses only three pairs; the payoff beyond that seems limited.
+// By stuffing in 1 bits from 521 position upwards, get CF directly
+
+                subs    xzr, xzr, xzr
+                ldp     d0, d1, [x]
+                adcs    xzr, d0, h
+                adcs    xzr, d1, xzr
+                ldp     d2, d3, [x, #16]
+                and     t, d2, d3
+                adcs    xzr, t, xzr
+                ldp     d4, d5, [x, #32]
+                and     t, d4, d5
+                adcs    xzr, t, xzr
+                ldp     d6, d7, [x, #48]
+                and     t, d6, d7
+                adcs    xzr, t, xzr
+                orr     t, d8, #~0x1FF
+                adcs    t, t, xzr
+
+// Now H + L >= p_521 <=> H + L + 1 >= 2^521 <=> CF from this comparison.
+// So if CF is set we want (H + L) - p_521 = (H + L + 1) - 2^521
+// while otherwise we want just H + L. So mask H + L + CF to 521 bits.
+
+                adcs    d0, d0, h
+                adcs    d1, d1, xzr
+                adcs    d2, d2, xzr
+                adcs    d3, d3, xzr
+                adcs    d4, d4, xzr
+                adcs    d5, d5, xzr
+                adcs    d6, d6, xzr
+                adcs    d7, d7, xzr
+                adc     d8, d8, xzr
+                and     d8, d8, #0x1FF
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
@@ -1,0 +1,601 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^576) mod p_521
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_montmul_p521
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Does z := (x * y / 2^576) mod p_521, assuming x < p_521, y < p_521. This
+// means the Montgomery base is the "native size" 2^{9*64} = 2^576; since
+// p_521 is a Mersenne prime the basic modular multiplication bignum_mul_p521
+// can be considered a Montgomery operation to base 2^521.
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_montmul_p521
+        .text
+        .balign 4
+
+// ---------------------------------------------------------------------------
+// Macro computing [c,b,a] := [b,a] + (x - y) * (w - z), adding with carry
+// to the [b,a] components but leaving CF aligned with the c term, which is
+// a sign bitmask for (x - y) * (w - z). Continued add-with-carry operations
+// with [c,...,c] will continue the carry chain correctly starting from
+// the c position if desired to add to a longer term of the form [...,b,a].
+//
+// c,h,l,t should all be different and t,h should not overlap w,z.
+// ---------------------------------------------------------------------------
+
+#define muldiffnadd(b,a,x,y,w,z)        \
+        subs    t, x, y;                \
+        cneg    t, t, cc;               \
+        csetm   c, cc;                  \
+        subs    h, w, z;                \
+        cneg    h, h, cc;               \
+        mul     l, t, h;                \
+        umulh   h, t, h;                \
+        cinv    c, c, cc;               \
+        adds    xzr, c, #1;             \
+        eor     l, l, c;                \
+        adcs    a, a, l;                \
+        eor     h, h, c;                \
+        adcs    b, b, h
+
+#define z x0
+#define x x1
+#define y x2
+
+#define a0 x3
+#define a1 x4
+#define a2 x5
+#define a3 x6
+#define b0 x7
+#define b1 x8
+#define b2 x9
+#define b3 x10
+
+#define s0 x11
+#define s1 x12
+#define s2 x13
+#define s3 x14
+#define s4 x15
+#define s5 x16
+#define s6 x17
+#define s7 x19
+#define s8 x20
+
+#define c  x21
+#define h  x22
+#define l  x23
+#define t  x24
+#define s  x25
+#define u  x26
+
+// ---------------------------------------------------------------------------
+// Core 4x4->8 ADK multiplication macro
+// Does [s7,s6,s5,s4,s3,s2,s1,s0] = [a3,a2,a1,a0] * [b3,b2,b1,b0]
+// ---------------------------------------------------------------------------
+
+#define mul4                                                            \
+/*  First accumulate all the "simple" products as [s7,s6,s5,s4,s0] */   \
+                                                                        \
+                mul     s0, a0, b0;                                     \
+                mul     s4, a1, b1;                                     \
+                mul     s5, a2, b2;                                     \
+                mul     s6, a3, b3;                                     \
+                                                                        \
+                umulh   s7, a0, b0;                                     \
+                adds    s4, s4, s7;                                     \
+                umulh   s7, a1, b1;                                     \
+                adcs    s5, s5, s7;                                     \
+                umulh   s7, a2, b2;                                     \
+                adcs    s6, s6, s7;                                     \
+                umulh   s7, a3, b3;                                     \
+                adc     s7, s7, xzr;                                    \
+                                                                        \
+/*  Multiply by B + 1 to get [s7;s6;s5;s4;s1;s0] */                     \
+                                                                        \
+                adds    s1, s4, s0;                                     \
+                adcs    s4, s5, s4;                                     \
+                adcs    s5, s6, s5;                                     \
+                adcs    s6, s7, s6;                                     \
+                adc     s7, xzr, s7;                                    \
+                                                                        \
+/*  Multiply by B^2 + 1 to get [s7;s6;s5;s4;s3;s2;s1;s0] */             \
+                                                                        \
+                adds    s2, s4, s0;                                     \
+                adcs    s3, s5, s1;                                     \
+                adcs    s4, s6, s4;                                     \
+                adcs    s5, s7, s5;                                     \
+                adcs    s6, xzr, s6;                                    \
+                adc     s7, xzr, s7;                                    \
+                                                                        \
+/*  Now add in all the "complicated" terms. */                          \
+                                                                        \
+                muldiffnadd(s6,s5, a2,a3, b3,b2);                       \
+                adc     s7, s7, c;                                      \
+                                                                        \
+                muldiffnadd(s2,s1, a0,a1, b1,b0);                       \
+                adcs    s3, s3, c;                                      \
+                adcs    s4, s4, c;                                      \
+                adcs    s5, s5, c;                                      \
+                adcs    s6, s6, c;                                      \
+                adc     s7, s7, c;                                      \
+                                                                        \
+                muldiffnadd(s5,s4, a1,a3, b3,b1);                       \
+                adcs    s6, s6, c;                                      \
+                adc     s7, s7, c;                                      \
+                                                                        \
+                muldiffnadd(s3,s2, a0,a2, b2,b0);                       \
+                adcs    s4, s4, c;                                      \
+                adcs    s5, s5, c;                                      \
+                adcs    s6, s6, c;                                      \
+                adc     s7, s7, c;                                      \
+                                                                        \
+                muldiffnadd(s4,s3, a0,a3, b3,b0);                       \
+                adcs    s5, s5, c;                                      \
+                adcs    s6, s6, c;                                      \
+                adc     s7, s7, c;                                      \
+                muldiffnadd(s4,s3, a1,a2, b2,b1);                       \
+                adcs    s5, s5, c;                                      \
+                adcs    s6, s6, c;                                      \
+                adc     s7, s7, c                                       \
+
+bignum_montmul_p521:
+
+// Save registers
+
+                stp     x19, x20, [sp, #-16]!
+                stp     x21, x22, [sp, #-16]!
+                stp     x23, x24, [sp, #-16]!
+                stp     x25, x26, [sp, #-16]!
+
+// Load 4-digit low parts and multiply them to get L
+
+                ldp     a0, a1, [x]
+                ldp     a2, a3, [x, #16]
+                ldp     b0, b1, [y]
+                ldp     b2, b3, [y, #16]
+                mul4
+
+// Shift right 256 bits modulo p_521 and stash in output buffer
+
+                lsl     c, s0, #9
+                extr    s0, s1, s0, #55
+                extr    s1, s2, s1, #55
+                extr    s2, s3, s2, #55
+                lsr     s3, s3, #55
+                stp     s4, s5, [z]
+                stp     s6, s7, [z, #16]
+                stp     c, s0, [z, #32]
+                stp     s1, s2, [z, #48]
+                str     s3, [z, #64]
+
+// Load 4-digit low parts and multiply them to get H
+
+                ldp     a0, a1, [x, #32]
+                ldp     a2, a3, [x, #48]
+                ldp     b0, b1, [y, #32]
+                ldp     b2, b3, [y, #48]
+                mul4
+
+// Add to the existing output buffer and re-stash.
+// This gives a result HL congruent to (2^256 * H + L) / 2^256 modulo p_521
+
+                ldp     l, h, [z]
+                adds    s0, s0, l
+                adcs    s1, s1, h
+                stp     s0, s1, [z]
+                ldp     l, h, [z, #16]
+                adcs    s2, s2, l
+                adcs    s3, s3, h
+                stp     s2, s3, [z, #16]
+                ldp     l, h, [z, #32]
+                adcs    s4, s4, l
+                adcs    s5, s5, h
+                stp     s4, s5, [z, #32]
+                ldp     l, h, [z, #48]
+                adcs    s6, s6, l
+                adcs    s7, s7, h
+                stp     s6, s7, [z, #48]
+                ldr     c, [z, #64]
+                adc     c, c, xzr
+                str     c, [z, #64]
+
+// Compute t,[a3,a2,a1,a0] = x_hi - x_lo
+// and     s,[b3,b2,b1,b0] = y_lo - y_hi
+// sign-magnitude differences, then XOR overall sign bitmask into s
+
+                ldp     l, h, [x]
+                subs    a0, a0, l
+                sbcs    a1, a1, h
+                ldp     l, h, [x, #16]
+                sbcs    a2, a2, l
+                sbcs    a3, a3, h
+                csetm   t, cc
+                ldp     l, h, [y]
+                subs    b0, l, b0
+                sbcs    b1, h, b1
+                ldp     l, h, [y, #16]
+                sbcs    b2, l, b2
+                sbcs    b3, h, b3
+                csetm   s, cc
+
+                eor     a0, a0, t
+                subs    a0, a0, t
+                eor     a1, a1, t
+                sbcs    a1, a1, t
+                eor     a2, a2, t
+                sbcs    a2, a2, t
+                eor     a3, a3, t
+                sbc     a3, a3, t
+
+                eor     b0, b0, s
+                subs    b0, b0, s
+                eor     b1, b1, s
+                sbcs    b1, b1, s
+                eor     b2, b2, s
+                sbcs    b2, b2, s
+                eor     b3, b3, s
+                sbc     b3, b3, s
+
+                eor     s, s, t
+
+// Now do yet a third 4x4 multiply to get mid-term product M
+
+                mul4
+
+// We now want, at the 256 position, 2^256 * HL + HL + (-1)^s * M
+// To keep things positive we use M' = p_521 - M in place of -M,
+// and this notion of negation just amounts to complementation in 521 bits.
+// Fold in the re-addition of the appropriately scaled lowest 4 words
+// The initial result is [s8; b3;b2;b1;b0; s7;s6;s5;s4;s3;s2;s1;s0]
+// Rebase it as a 9-word value at the 512 bit position using
+// [s8; b3;b2;b1;b0; s7;s6;s5;s4;s3;s2;s1;s0] ==
+// [s8; b3;b2;b1;b0; s7;s6;s5;s4] + 2^265 * [s3;s2;s1;s0] =
+// ([s8; b3;b2;b1;b0] + 2^9 * [s3;s2;s1;s0]); s7;s6;s5;s4]
+//
+// Accumulate as [s8; b3;b2;b1;b0; s7;s6;s5;s4] but leave out an additional
+// small c (s8 + suspended carry) to add at the 256 position here (512
+// overall). This can be added in the next block (to b0 = sum4).
+
+                ldp     a0, a1, [z]
+                ldp     a2, a3, [z, #16]
+
+                eor     s0, s0, s
+                adds    s0, s0, a0
+                eor     s1, s1, s
+                adcs    s1, s1, a1
+                eor     s2, s2, s
+                adcs    s2, s2, a2
+                eor     s3, s3, s
+                adcs    s3, s3, a3
+                eor     s4, s4, s
+
+                ldp     b0, b1, [z, #32]
+                ldp     b2, b3, [z, #48]
+                ldr     s8, [z, #64]
+
+                adcs    s4, s4, b0
+                eor     s5, s5, s
+                adcs    s5, s5, b1
+                eor     s6, s6, s
+                adcs    s6, s6, b2
+                eor     s7, s7, s
+                adcs    s7, s7, b3
+                adc     c, s8, xzr
+
+                adds    s4, s4, a0
+                adcs    s5, s5, a1
+                adcs    s6, s6, a2
+                adcs    s7, s7, a3
+                and     s, s, #0x1FF
+                lsl     t, s0, #9
+                orr     t, t, s
+                adcs    b0, b0, t
+                extr    t, s1, s0, #55
+                adcs    b1, b1, t
+                extr    t, s2, s1, #55
+                adcs    b2, b2, t
+                extr    t, s3, s2, #55
+                adcs    b3, b3, t
+                lsr     t, s3, #55
+                adc     s8, t, s8
+
+// Augment the total with the contribution from the top little words
+// w and v. If we write the inputs as 2^512 * w + x and 2^512 * v + y
+// then we are otherwise just doing x * y so we actually need to add
+// 2^512 * (2^512 * w * v + w * y + v * x). We do this is an involved
+// way chopping x and y into 52-bit chunks so we can do most of the core
+// arithmetic using only basic muls, no umulh (since w, v are only 9 bits).
+// This does however involve some intricate bit-splicing plus arithmetic.
+// To make things marginally less confusing we introduce some new names
+// at the human level: x = [c7;...;c0] and y = [d7;...d0], which are
+// not all distinct, and [sum8;sum7;...;sum0] for the running sum.
+// Also accumulate u = sum1 AND ... AND sum7 for the later comparison
+
+#define sum0 s4
+#define sum1 s5
+#define sum2 s6
+#define sum3 s7
+#define sum4 b0
+#define sum5 b1
+#define sum6 b2
+#define sum7 b3
+#define sum8 s8
+
+#define c0 a0
+#define c1 a1
+#define c2 a2
+#define c3 a0
+#define c4 a1
+#define c5 a2
+#define c6 a0
+#define c7 a1
+
+#define d0 s0
+#define d1 s1
+#define d2 s2
+#define d3 s0
+#define d4 s1
+#define d5 s2
+#define d6 s0
+#define d7 s1
+
+#define v a3
+#define w s3
+
+// 0 * 52 = 64 * 0 + 0
+
+                ldr     v, [y, #64]
+                ldp     c0, c1, [x]
+                and     l, c0, #0x000fffffffffffff
+                mul     l, v, l
+                ldr     w, [x, #64]
+                ldp     d0, d1, [y]
+                and     t, d0, #0x000fffffffffffff
+                mul     t, w, t
+                add     l, l, t
+
+// 1 * 52 = 64 * 0 + 52
+
+                extr    t, c1, c0, #52
+                and     t, t, #0x000fffffffffffff
+                mul     h, v, t
+                extr    t, d1, d0, #52
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     h, h, t
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #12
+                adds    sum0, sum0, t
+
+// 2 * 52 = 64 * 1 + 40
+
+                ldp     c2, c3, [x, #16]
+                ldp     d2, d3, [y, #16]
+                extr    t, c2, c1, #40
+                and     t, t, #0x000fffffffffffff
+                mul     l, v, t
+                extr    t, d2, d1, #40
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     l, l, t
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #24
+                adcs    sum1, sum1, t
+
+// 3 * 52 = 64 * 2 + 28
+
+                extr    t, c3, c2, #28
+                and     t, t, #0x000fffffffffffff
+                mul     h, v, t
+                extr    t, d3, d2, #28
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     h, h, t
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #36
+                adcs    sum2, sum2, t
+                and     u, sum1, sum2
+
+// 4 * 52 = 64 * 3 + 16
+// At this point we also fold in the addition of c at the right place.
+// Note that 4 * 64 = 4 * 52 + 48 so we shift c left 48 places to align.
+
+                ldp     c4, c5, [x, #32]
+                ldp     d4, d5, [y, #32]
+                extr    t, c4, c3, #16
+                and     t, t, #0x000fffffffffffff
+                mul     l, v, t
+                extr    t, d4, d3, #16
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     l, l, t
+
+                lsl     c, c, #48
+                add     l, l, c
+
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #48
+                adcs    sum3, sum3, t
+                and     u, u, sum3
+
+// 5 * 52 = 64 * 4 + 4
+
+                lsr     t, c4, #4
+                and     t, t, #0x000fffffffffffff
+                mul     h, v, t
+                lsr     t, d4, #4
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     h, h, t
+
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    s, h, l, #60
+
+// 6 * 52 = 64 * 4 + 56
+
+                extr    t, c5, c4, #56
+                and     t, t, #0x000fffffffffffff
+                mul     l, v, t
+                extr    t, d5, d4, #56
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     l, l, t
+
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     s, s, #8
+                extr    t, l, s, #8
+                adcs    sum4, sum4, t
+                and     u, u, sum4
+
+// 7 * 52 = 64 * 5 + 44
+
+                ldp     c6, c7, [x, #48]
+                ldp     d6, d7, [y, #48]
+                extr    t, c6, c5, #44
+                and     t, t, #0x000fffffffffffff
+                mul     h, v, t
+                extr    t, d6, d5, #44
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     h, h, t
+
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #20
+                adcs    sum5, sum5, t
+                and     u, u, sum5
+
+// 8 * 52 = 64 * 6 + 32
+
+                extr    t, c7, c6, #32
+                and     t, t, #0x000fffffffffffff
+                mul     l, v, t
+                extr    t, d7, d6, #32
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     l, l, t
+
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #32
+                adcs    sum6, sum6, t
+                and     u, u, sum6
+
+// 9 * 52 = 64 * 7 + 20
+
+                lsr     t, c7, #20
+                mul     h, v, t
+                lsr     t, d7, #20
+                mul     t, w, t
+                add     h, h, t
+
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #44
+                adcs    sum7, sum7, t
+                and     u, u, sum7
+
+// Top word
+
+                mul     t, v, w
+                lsr     h, h, #44
+                add     t, t, h
+                adc     sum8, sum8, t
+
+// Extract the high part h and mask off the low part l = [sum8;sum7;...;sum0]
+// but stuff sum8 with 1 bits at the left to ease a comparison below
+
+                lsr     h, sum8, #9
+                orr     sum8, sum8, #~0x1FF
+
+// Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
+// happen if digits sum7,...sum1 are all 1s, we use the AND of them "u" to
+// condense the carry chain, and since we stuffed 1 bits into sum8 we get
+// the result in CF without an additional comparison.
+
+                subs    xzr, xzr, xzr
+                adcs    xzr, sum0, h
+                adcs    xzr, u, xzr
+                adcs    xzr, sum8, xzr
+
+// Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
+// while otherwise we want just h + l. So mask h + l + CF to 521 bits.
+// The masking is combined with the writeback in the next block.
+
+                adcs    sum0, sum0, h
+                adcs    sum1, sum1, xzr
+                adcs    sum2, sum2, xzr
+                adcs    sum3, sum3, xzr
+                adcs    sum4, sum4, xzr
+                adcs    sum5, sum5, xzr
+                adcs    sum6, sum6, xzr
+                adcs    sum7, sum7, xzr
+                adc     sum8, sum8, xzr
+
+// The result is actually [sum8;...;sum0] == product / 2^512, since we are
+// in the 512 position. For Montgomery we want product / 2^576, so write
+// back [sum8;...;sum0] rotated right by 64 bits, as a 521-bit quantity.
+
+                stp     sum1, sum2, [z]
+                stp     sum3, sum4, [z, #16]
+                stp     sum5, sum6, [z, #32]
+                lsl     h, sum0, #9
+                and     sum8, sum8, #0x1FF
+                orr     sum8, sum8, h
+                stp     sum7, sum8, [z, #48]
+                lsr     sum0, sum0, #55
+                str     sum0, [z, #64]
+
+// Restore regs and return
+
+                ldp     x25, x26, [sp], #16
+                ldp     x23, x24, [sp], #16
+                ldp     x21, x22, [sp], #16
+                ldp     x19, x20, [sp], #16
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
@@ -1,0 +1,561 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^576) mod p_521
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_montmul_p521_alt
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Does z := (x * y / 2^576) mod p_521, assuming x < p_521, y < p_521. This
+// means the Montgomery base is the "native size" 2^{9*64} = 2^576; since
+// p_521 is a Mersenne prime the basic modular multiplication bignum_mul_p521
+// can be considered a Montgomery operation to base 2^521.
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_montmul_p521_alt
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+#define y x2
+
+// These are repeated mod 2 as we load paris of inputs
+
+#define a0 x3
+#define a1 x4
+#define a2 x3
+#define a3 x4
+#define a4 x3
+#define a5 x4
+#define a6 x3
+#define a7 x4
+#define a8 x3
+
+#define b0 x5
+#define b1 x6
+#define b2 x7
+#define b3 x8
+#define b4 x9
+#define b5 x10
+#define b6 x11
+#define b7 x12
+#define b8 x13
+
+#define t x14
+
+// These repeat mod 11 as we stash some intermediate results in the
+// output buffer.
+
+#define u0 x15
+#define u1 x16
+#define u2 x17
+#define u3 x19
+#define u4 x20
+#define u5 x21
+#define u6 x22
+#define u7 x23
+#define u8 x24
+#define u9 x25
+#define u10 x26
+#define u11 x15
+#define u12 x16
+#define u13 x17
+#define u14 x19
+#define u15 x20
+#define u16 x21
+
+bignum_montmul_p521_alt:
+
+// Save more registers
+
+                stp     x19, x20, [sp, #-16]!
+                stp     x21, x22, [sp, #-16]!
+                stp     x23, x24, [sp, #-16]!
+                stp     x25, x26, [sp, #-16]!
+
+// Load operands and set up row 0 = [u9;...;u0] = a0 * [b8;...;b0]
+
+                ldp     a0, a1, [x]
+                ldp     b0, b1, [y]
+
+                mul     u0, a0, b0
+                umulh   u1, a0, b0
+                mul     t, a0, b1
+                umulh   u2, a0, b1
+                adds    u1, u1, t
+
+                ldp     b2, b3, [y, #16]
+
+                mul     t, a0, b2
+                umulh   u3, a0, b2
+                adcs    u2, u2, t
+
+                mul     t, a0, b3
+                umulh   u4, a0, b3
+                adcs    u3, u3, t
+
+                ldp     b4, b5, [y, #32]
+
+                mul     t, a0, b4
+                umulh   u5, a0, b4
+                adcs    u4, u4, t
+
+                mul     t, a0, b5
+                umulh   u6, a0, b5
+                adcs    u5, u5, t
+
+                ldp     b6, b7, [y, #48]
+
+                mul     t, a0, b6
+                umulh   u7, a0, b6
+                adcs    u6, u6, t
+
+                ldr     b8, [y, #64]
+
+                mul     t, a0, b7
+                umulh   u8, a0, b7
+                adcs    u7, u7, t
+
+                mul     t, a0, b8
+                umulh   u9, a0, b8
+                adcs    u8, u8, t
+
+                adc     u9, u9, xzr
+
+// Row 1 = [u10;...;u0] = [a1;a0] * [b8;...;b0]
+
+                mul     t, a1, b0
+                adds    u1, u1, t
+                mul     t, a1, b1
+                adcs    u2, u2, t
+                mul     t, a1, b2
+                adcs    u3, u3, t
+                mul     t, a1, b3
+                adcs    u4, u4, t
+                mul     t, a1, b4
+                adcs    u5, u5, t
+                mul     t, a1, b5
+                adcs    u6, u6, t
+                mul     t, a1, b6
+                adcs    u7, u7, t
+                mul     t, a1, b7
+                adcs    u8, u8, t
+                mul     t, a1, b8
+                adcs    u9, u9, t
+                cset    u10, cs
+
+                umulh   t, a1, b0
+                adds    u2, u2, t
+                umulh   t, a1, b1
+                adcs    u3, u3, t
+                umulh   t, a1, b2
+                adcs    u4, u4, t
+                umulh   t, a1, b3
+                adcs    u5, u5, t
+                umulh   t, a1, b4
+                adcs    u6, u6, t
+                umulh   t, a1, b5
+                adcs    u7, u7, t
+                umulh   t, a1, b6
+                adcs    u8, u8, t
+                umulh   t, a1, b7
+                adcs    u9, u9, t
+                umulh   t, a1, b8
+                adc     u10, u10, t
+
+                stp     u0, u1, [z]
+
+// Row 2 = [u11;...;u0] = [a2;a1;a0] * [b8;...;b0]
+
+                ldp     a2, a3, [x, #16]
+
+                mul     t, a2, b0
+                adds    u2, u2, t
+                mul     t, a2, b1
+                adcs    u3, u3, t
+                mul     t, a2, b2
+                adcs    u4, u4, t
+                mul     t, a2, b3
+                adcs    u5, u5, t
+                mul     t, a2, b4
+                adcs    u6, u6, t
+                mul     t, a2, b5
+                adcs    u7, u7, t
+                mul     t, a2, b6
+                adcs    u8, u8, t
+                mul     t, a2, b7
+                adcs    u9, u9, t
+                mul     t, a2, b8
+                adcs    u10, u10, t
+                cset    u11, cs
+
+                umulh   t, a2, b0
+                adds    u3, u3, t
+                umulh   t, a2, b1
+                adcs    u4, u4, t
+                umulh   t, a2, b2
+                adcs    u5, u5, t
+                umulh   t, a2, b3
+                adcs    u6, u6, t
+                umulh   t, a2, b4
+                adcs    u7, u7, t
+                umulh   t, a2, b5
+                adcs    u8, u8, t
+                umulh   t, a2, b6
+                adcs    u9, u9, t
+                umulh   t, a2, b7
+                adcs    u10, u10, t
+                umulh   t, a2, b8
+                adc     u11, u11, t
+
+// Row 3 = [u12;...;u0] = [a3;a2;a1;a0] * [b8;...;b0]
+
+                mul     t, a3, b0
+                adds    u3, u3, t
+                mul     t, a3, b1
+                adcs    u4, u4, t
+                mul     t, a3, b2
+                adcs    u5, u5, t
+                mul     t, a3, b3
+                adcs    u6, u6, t
+                mul     t, a3, b4
+                adcs    u7, u7, t
+                mul     t, a3, b5
+                adcs    u8, u8, t
+                mul     t, a3, b6
+                adcs    u9, u9, t
+                mul     t, a3, b7
+                adcs    u10, u10, t
+                mul     t, a3, b8
+                adcs    u11, u11, t
+                cset    u12, cs
+
+                umulh   t, a3, b0
+                adds    u4, u4, t
+                umulh   t, a3, b1
+                adcs    u5, u5, t
+                umulh   t, a3, b2
+                adcs    u6, u6, t
+                umulh   t, a3, b3
+                adcs    u7, u7, t
+                umulh   t, a3, b4
+                adcs    u8, u8, t
+                umulh   t, a3, b5
+                adcs    u9, u9, t
+                umulh   t, a3, b6
+                adcs    u10, u10, t
+                umulh   t, a3, b7
+                adcs    u11, u11, t
+                umulh   t, a3, b8
+                adc     u12, u12, t
+
+                stp     u2, u3, [z, #16]
+
+// Row 4 = [u13;...;u0] = [a4;a3;a2;a1;a0] * [b8;...;b0]
+
+                ldp     a4, a5, [x, #32]
+
+                mul     t, a4, b0
+                adds    u4, u4, t
+                mul     t, a4, b1
+                adcs    u5, u5, t
+                mul     t, a4, b2
+                adcs    u6, u6, t
+                mul     t, a4, b3
+                adcs    u7, u7, t
+                mul     t, a4, b4
+                adcs    u8, u8, t
+                mul     t, a4, b5
+                adcs    u9, u9, t
+                mul     t, a4, b6
+                adcs    u10, u10, t
+                mul     t, a4, b7
+                adcs    u11, u11, t
+                mul     t, a4, b8
+                adcs    u12, u12, t
+                cset    u13, cs
+
+                umulh   t, a4, b0
+                adds    u5, u5, t
+                umulh   t, a4, b1
+                adcs    u6, u6, t
+                umulh   t, a4, b2
+                adcs    u7, u7, t
+                umulh   t, a4, b3
+                adcs    u8, u8, t
+                umulh   t, a4, b4
+                adcs    u9, u9, t
+                umulh   t, a4, b5
+                adcs    u10, u10, t
+                umulh   t, a4, b6
+                adcs    u11, u11, t
+                umulh   t, a4, b7
+                adcs    u12, u12, t
+                umulh   t, a4, b8
+                adc     u13, u13, t
+
+// Row 5 = [u14;...;u0] = [a5;a4;a3;a2;a1;a0] * [b8;...;b0]
+
+                mul     t, a5, b0
+                adds    u5, u5, t
+                mul     t, a5, b1
+                adcs    u6, u6, t
+                mul     t, a5, b2
+                adcs    u7, u7, t
+                mul     t, a5, b3
+                adcs    u8, u8, t
+                mul     t, a5, b4
+                adcs    u9, u9, t
+                mul     t, a5, b5
+                adcs    u10, u10, t
+                mul     t, a5, b6
+                adcs    u11, u11, t
+                mul     t, a5, b7
+                adcs    u12, u12, t
+                mul     t, a5, b8
+                adcs    u13, u13, t
+                cset    u14, cs
+
+                umulh   t, a5, b0
+                adds    u6, u6, t
+                umulh   t, a5, b1
+                adcs    u7, u7, t
+                umulh   t, a5, b2
+                adcs    u8, u8, t
+                umulh   t, a5, b3
+                adcs    u9, u9, t
+                umulh   t, a5, b4
+                adcs    u10, u10, t
+                umulh   t, a5, b5
+                adcs    u11, u11, t
+                umulh   t, a5, b6
+                adcs    u12, u12, t
+                umulh   t, a5, b7
+                adcs    u13, u13, t
+                umulh   t, a5, b8
+                adc     u14, u14, t
+
+                stp     u4, u5, [z, #32]
+
+// Row 6 = [u15;...;u0] = [a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
+
+                ldp     a6, a7, [x, #48]
+
+                mul     t, a6, b0
+                adds    u6, u6, t
+                mul     t, a6, b1
+                adcs    u7, u7, t
+                mul     t, a6, b2
+                adcs    u8, u8, t
+                mul     t, a6, b3
+                adcs    u9, u9, t
+                mul     t, a6, b4
+                adcs    u10, u10, t
+                mul     t, a6, b5
+                adcs    u11, u11, t
+                mul     t, a6, b6
+                adcs    u12, u12, t
+                mul     t, a6, b7
+                adcs    u13, u13, t
+                mul     t, a6, b8
+                adcs    u14, u14, t
+                cset    u15, cs
+
+                umulh   t, a6, b0
+                adds    u7, u7, t
+                umulh   t, a6, b1
+                adcs    u8, u8, t
+                umulh   t, a6, b2
+                adcs    u9, u9, t
+                umulh   t, a6, b3
+                adcs    u10, u10, t
+                umulh   t, a6, b4
+                adcs    u11, u11, t
+                umulh   t, a6, b5
+                adcs    u12, u12, t
+                umulh   t, a6, b6
+                adcs    u13, u13, t
+                umulh   t, a6, b7
+                adcs    u14, u14, t
+                umulh   t, a6, b8
+                adc     u15, u15, t
+
+// Row 7 = [u16;...;u0] = [a7;a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
+
+                mul     t, a7, b0
+                adds    u7, u7, t
+                mul     t, a7, b1
+                adcs    u8, u8, t
+                mul     t, a7, b2
+                adcs    u9, u9, t
+                mul     t, a7, b3
+                adcs    u10, u10, t
+                mul     t, a7, b4
+                adcs    u11, u11, t
+                mul     t, a7, b5
+                adcs    u12, u12, t
+                mul     t, a7, b6
+                adcs    u13, u13, t
+                mul     t, a7, b7
+                adcs    u14, u14, t
+                mul     t, a7, b8
+                adcs    u15, u15, t
+                cset    u16, cs
+
+                umulh   t, a7, b0
+                adds    u8, u8, t
+                umulh   t, a7, b1
+                adcs    u9, u9, t
+                umulh   t, a7, b2
+                adcs    u10, u10, t
+                umulh   t, a7, b3
+                adcs    u11, u11, t
+                umulh   t, a7, b4
+                adcs    u12, u12, t
+                umulh   t, a7, b5
+                adcs    u13, u13, t
+                umulh   t, a7, b6
+                adcs    u14, u14, t
+                umulh   t, a7, b7
+                adcs    u15, u15, t
+                umulh   t, a7, b8
+                adc     u16, u16, t
+
+                stp     u6, u7, [z, #48]
+
+// Row 8 = [u16;...;u0] = [a8;a7;a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
+
+                ldr     a8, [x, #64]
+
+                mul     t, a8, b0
+                adds    u8, u8, t
+                mul     t, a8, b1
+                adcs    u9, u9, t
+                mul     t, a8, b2
+                adcs    u10, u10, t
+                mul     t, a8, b3
+                adcs    u11, u11, t
+                mul     t, a8, b4
+                adcs    u12, u12, t
+                mul     t, a8, b5
+                adcs    u13, u13, t
+                mul     t, a8, b6
+                adcs    u14, u14, t
+                mul     t, a8, b7
+                adcs    u15, u15, t
+                mul     t, a8, b8
+                adc     u16, u16, t
+
+                umulh   t, a8, b0
+                adds    u9, u9, t
+                umulh   t, a8, b1
+                adcs    u10, u10, t
+                umulh   t, a8, b2
+                adcs    u11, u11, t
+                umulh   t, a8, b3
+                adcs    u12, u12, t
+                umulh   t, a8, b4
+                adcs    u13, u13, t
+                umulh   t, a8, b5
+                adcs    u14, u14, t
+                umulh   t, a8, b6
+                adcs    u15, u15, t
+                umulh   t, a8, b7
+                adc     u16, u16, t
+
+// Now we have the full product, which we consider as
+// 2^521 * h + l. Form h + l + 1
+
+                subs    xzr, xzr, xzr
+                ldp     b0, b1, [z]
+                extr    t, u9, u8, #9
+                adcs    b0, b0, t
+                extr    t, u10, u9, #9
+                adcs    b1, b1, t
+                ldp     b2, b3, [z, #16]
+                extr    t, u11, u10, #9
+                adcs    b2, b2, t
+                extr    t, u12, u11, #9
+                adcs    b3, b3, t
+                ldp     b4, b5, [z, #32]
+                extr    t, u13, u12, #9
+                adcs    b4, b4, t
+                extr    t, u14, u13, #9
+                adcs    b5, b5, t
+                ldp     b6, b7, [z, #48]
+                extr    t, u15, u14, #9
+                adcs    b6, b6, t
+                extr    t, u16, u15, #9
+                adcs    b7, b7, t
+                orr     b8, u8, #~0x1FF
+                lsr     t, u16, #9
+                adcs    b8, b8, t
+
+// Now CF is set if h + l + 1 >= 2^521, which means it's already
+// the answer, while if ~CF the answer is h + l so we should subtract
+// 1 (all considered in 521 bits). Hence subtract ~CF and mask.
+
+                sbcs    b0, b0, xzr
+                sbcs    b1, b1, xzr
+                sbcs    b2, b2, xzr
+                sbcs    b3, b3, xzr
+                sbcs    b4, b4, xzr
+                sbcs    b5, b5, xzr
+                sbcs    b6, b6, xzr
+                sbcs    b7, b7, xzr
+                sbc     b8, b8, xzr
+                and     b8, b8, #0x1FF
+
+// So far, this has been the same as a pure modular multiplication.
+// Now finally the Montgomery ingredient, which is just a 521-bit
+// rotation by 9*64 - 521 = 55 bits right.
+
+                lsl     t, b0, #9
+                extr    b0, b1, b0, #55
+                extr    b1, b2, b1, #55
+                extr    b2, b3, b2, #55
+                extr    b3, b4, b3, #55
+                orr     b8, b8, t
+                extr    b4, b5, b4, #55
+                extr    b5, b6, b5, #55
+                extr    b6, b7, b6, #55
+                extr    b7, b8, b7, #55
+                lsr     b8, b8, #55
+
+// Store back digits of final result
+
+                stp     b0, b1, [z]
+                stp     b2, b3, [z, #16]
+                stp     b4, b5, [z, #32]
+                stp     b6, b7, [z, #48]
+                str     b8, [z, #64]
+
+// Restore registers
+
+                ldp     x25, x26, [sp], #16
+                ldp     x23, x24, [sp], #16
+                ldp     x21, x22, [sp], #16
+                ldp     x19, x20, [sp], #16
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
@@ -1,0 +1,635 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^576) mod p_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_montsqr_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Does z := (x^2 / 2^576) mod p_521, assuming x < p_521. This means the
+// Montgomery base is the "native size" 2^{9*64} = 2^576; since p_521 is
+// a Mersenne prime the basic modular squaring bignum_sqr_p521 can be
+// considered a Montgomery operation to base 2^521.
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_montsqr_p521
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define b0 x6
+#define b1 x7
+#define b2 x8
+#define b3 x9
+
+#define s0 x10
+#define s1 x11
+#define s2 x12
+#define s3 x13
+#define s4 x14
+#define s5 x15
+#define s6 x16
+#define s7 x17
+
+#define c  x19
+#define h  x20
+#define l  x21
+#define t  x22
+#define u  x23
+#define v  x24
+
+// Aliased to earlier ones we no longer need
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+#define d6 x8
+#define d7 x9
+#define d8 x10
+
+bignum_montsqr_p521:
+
+// Save registers
+
+                stp     x19, x20, [sp, #-16]!
+                stp     x21, x22, [sp, #-16]!
+                stp     x23, x24, [sp, #-16]!
+
+// Load all the inputs first
+
+                ldp     a0, a1, [x]
+                ldp     a2, a3, [x, #16]
+                ldp     b0, b1, [x, #32]
+                ldp     b2, b3, [x, #48]
+
+// Square the upper half with a register-renamed variant of bignum_sqr_4_8
+
+                mul     s2, b0, b2
+                mul     s7, b1, b3
+                umulh   t, b0, b2
+                subs    u, b0, b1
+                cneg    u, u, cc
+                csetm   s1, cc
+                subs    s0, b3, b2
+                cneg    s0, s0, cc
+                mul     s6, u, s0
+                umulh   s0, u, s0
+                cinv    s1, s1, cc
+                eor     s6, s6, s1
+                eor     s0, s0, s1
+                adds    s3, s2, t
+                adc     t, t, xzr
+                umulh   u, b1, b3
+                adds    s3, s3, s7
+                adcs    t, t, u
+                adc     u, u, xzr
+                adds    t, t, s7
+                adc     u, u, xzr
+                cmn     s1, #0x1
+                adcs    s3, s3, s6
+                adcs    t, t, s0
+                adc     u, u, s1
+                adds    s2, s2, s2
+                adcs    s3, s3, s3
+                adcs    t, t, t
+                adcs    u, u, u
+                adc     c, xzr, xzr
+                mul     s0, b0, b0
+                mul     s6, b1, b1
+                mul     l, b0, b1
+                umulh   s1, b0, b0
+                umulh   s7, b1, b1
+                umulh   h, b0, b1
+                adds    s1, s1, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s1, s1, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s2, s2, s6
+                adcs    s3, s3, s7
+                adcs    t, t, xzr
+                adcs    u, u, xzr
+                adc     c, c, xzr
+                mul     s4, b2, b2
+                mul     s6, b3, b3
+                mul     l, b2, b3
+                umulh   s5, b2, b2
+                umulh   s7, b3, b3
+                umulh   h, b2, b3
+                adds    s5, s5, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s5, s5, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s4, s4, t
+                adcs    s5, s5, u
+                adcs    s6, s6, c
+                adc     s7, s7, xzr
+
+// Augment the high part with the contribution from the top little word C.
+// If we write the input as 2^512 * C + x then we are otherwise just doing
+// x^2, so we need to add to the high part 2^512 * C^2 + (2 * C) * x.
+// Accumulate it as [c;s7;...;s0] = H'. Since 2 * C is only 10 bits long
+// we multiply 52-bit chunks of the x digits by 2 * C and solve the overlap
+// with non-overflowing addition to get 52-bit chunks of the result with
+// similar alignment. Then we stitch these back together and add them into
+// the running total. This is quite a bit of palaver, but it avoids using
+// the standard 2-part multiplications involving umulh, and on target
+// microarchitectures seems to improve performance by about 5%. We could
+// equally well use 53 or 54 since they are still <= 64 - 10, but below
+// 52 we would end up using more multiplications.
+
+                ldr     c, [x, #64]
+                add     u, c, c
+                mul     c, c, c
+
+// 0 * 52 = 64 * 0 + 0
+
+                and     l, a0, #0x000fffffffffffff
+                mul     l, u, l
+
+// 1 * 52 = 64 * 0 + 52
+
+                extr    h, a1, a0, #52
+                and     h, h, #0x000fffffffffffff
+                mul     h, u, h
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #12
+                adds    s0, s0, t
+
+// 2 * 52 = 64 * 1 + 40
+
+                extr    l, a2, a1, #40
+                and     l, l, #0x000fffffffffffff
+                mul     l, u, l
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #24
+                adcs    s1, s1, t
+
+// 3 * 52 = 64 * 2 + 28
+
+                extr    h, a3, a2, #28
+                and     h, h, #0x000fffffffffffff
+                mul     h, u, h
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #36
+                adcs    s2, s2, t
+
+// 4 * 52 = 64 * 3 + 16
+
+                extr    l, b0, a3, #16
+                and     l, l, #0x000fffffffffffff
+                mul     l, u, l
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #48
+                adcs    s3, s3, t
+
+// 5 * 52 = 64 * 4 + 4
+
+                lsr     h, b0, #4
+                and     h, h, #0x000fffffffffffff
+                mul     h, u, h
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    v, h, l, #60
+
+// 6 * 52 = 64 * 4 + 56
+
+                extr    l, b1, b0, #56
+                and     l, l, #0x000fffffffffffff
+                mul     l, u, l
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     v, v, #8
+                extr    t, l, v, #8
+                adcs    s4, s4, t
+
+// 7 * 52 = 64 * 5 + 44
+
+                extr    h, b2, b1, #44
+                and     h, h, #0x000fffffffffffff
+                mul     h, u, h
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #20
+                adcs    s5, s5, t
+
+// 8 * 52 = 64 * 6 + 32
+
+                extr    l, b3, b2, #32
+                and     l, l, #0x000fffffffffffff
+                mul     l, u, l
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #32
+                adcs    s6, s6, t
+
+// 9 * 52 = 64 * 7 + 20
+
+                lsr     h, b3, #20
+                mul     h, u, h
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #44
+                adcs    s7, s7, t
+
+// Top word
+
+                lsr     h, h, #44
+                adc     c, c, h
+
+// Rotate [c;s7;...;s0] before storing in the buffer.
+// We want to add 2^512 * H', which splitting H' at bit 9 is
+// 2^521 * H_top + 2^512 * H_bot == 2^512 * H_bot + H_top (mod p_521)
+
+                extr    l, s1, s0, #9
+                extr    h, s2, s1, #9
+                stp     l, h, [z]
+
+                extr    l, s3, s2, #9
+                extr    h, s4, s3, #9
+                stp     l, h, [z, #16]
+
+                extr    l, s5, s4, #9
+                extr    h, s6, s5, #9
+                stp     l, h, [z, #32]
+
+                extr    l, s7, s6, #9
+                extr    h, c, s7, #9
+                stp     l, h, [z, #48]
+
+                and     t, s0, #0x1FF
+                lsr     c, c, #9
+                add     t, t, c
+                str     t, [z, #64]
+
+// Square the lower half with an analogous variant of bignum_sqr_4_8
+
+                mul     s2, a0, a2
+                mul     s7, a1, a3
+                umulh   t, a0, a2
+                subs    u, a0, a1
+                cneg    u, u, cc
+                csetm   s1, cc
+                subs    s0, a3, a2
+                cneg    s0, s0, cc
+                mul     s6, u, s0
+                umulh   s0, u, s0
+                cinv    s1, s1, cc
+                eor     s6, s6, s1
+                eor     s0, s0, s1
+                adds    s3, s2, t
+                adc     t, t, xzr
+                umulh   u, a1, a3
+                adds    s3, s3, s7
+                adcs    t, t, u
+                adc     u, u, xzr
+                adds    t, t, s7
+                adc     u, u, xzr
+                cmn     s1, #0x1
+                adcs    s3, s3, s6
+                adcs    t, t, s0
+                adc     u, u, s1
+                adds    s2, s2, s2
+                adcs    s3, s3, s3
+                adcs    t, t, t
+                adcs    u, u, u
+                adc     c, xzr, xzr
+                mul     s0, a0, a0
+                mul     s6, a1, a1
+                mul     l, a0, a1
+                umulh   s1, a0, a0
+                umulh   s7, a1, a1
+                umulh   h, a0, a1
+                adds    s1, s1, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s1, s1, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s2, s2, s6
+                adcs    s3, s3, s7
+                adcs    t, t, xzr
+                adcs    u, u, xzr
+                adc     c, c, xzr
+                mul     s4, a2, a2
+                mul     s6, a3, a3
+                mul     l, a2, a3
+                umulh   s5, a2, a2
+                umulh   s7, a3, a3
+                umulh   h, a2, a3
+                adds    s5, s5, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s5, s5, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s4, s4, t
+                adcs    s5, s5, u
+                adcs    s6, s6, c
+                adc     s7, s7, xzr
+
+// Add it directly to the existing buffer
+
+                ldp     l, h, [z]
+                adds    l, l, s0
+                adcs    h, h, s1
+                stp     l, h, [z]
+
+                ldp     l, h, [z, #16]
+                adcs    l, l, s2
+                adcs    h, h, s3
+                stp     l, h, [z, #16]
+
+                ldp     l, h, [z, #32]
+                adcs    l, l, s4
+                adcs    h, h, s5
+                stp     l, h, [z, #32]
+
+                ldp     l, h, [z, #48]
+                adcs    l, l, s6
+                adcs    h, h, s7
+                stp     l, h, [z, #48]
+
+                ldr     t, [z, #64]
+                adc     t, t, xzr
+                str     t, [z, #64]
+
+// Now get the cross-product in [s7,...,s0] with variant of bignum_mul_4_8
+
+                mul     s0, a0, b0
+                mul     s4, a1, b1
+                mul     s5, a2, b2
+                mul     s6, a3, b3
+                umulh   s7, a0, b0
+                adds    s4, s4, s7
+                umulh   s7, a1, b1
+                adcs    s5, s5, s7
+                umulh   s7, a2, b2
+                adcs    s6, s6, s7
+                umulh   s7, a3, b3
+                adc     s7, s7, xzr
+                adds    s1, s4, s0
+                adcs    s4, s5, s4
+                adcs    s5, s6, s5
+                adcs    s6, s7, s6
+                adc     s7, xzr, s7
+                adds    s2, s4, s0
+                adcs    s3, s5, s1
+                adcs    s4, s6, s4
+                adcs    s5, s7, s5
+                adcs    s6, xzr, s6
+                adc     s7, xzr, s7
+                subs    t, a2, a3
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b3, b2
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s5, s5, l
+                eor     h, h, c
+                adcs    s6, s6, h
+                adc     s7, s7, c
+                subs    t, a0, a1
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b1, b0
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s1, s1, l
+                eor     h, h, c
+                adcs    s2, s2, h
+                adcs    s3, s3, c
+                adcs    s4, s4, c
+                adcs    s5, s5, c
+                adcs    s6, s6, c
+                adc     s7, s7, c
+                subs    t, a1, a3
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b3, b1
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s4, s4, l
+                eor     h, h, c
+                adcs    s5, s5, h
+                adcs    s6, s6, c
+                adc     s7, s7, c
+                subs    t, a0, a2
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b2, b0
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s2, s2, l
+                eor     h, h, c
+                adcs    s3, s3, h
+                adcs    s4, s4, c
+                adcs    s5, s5, c
+                adcs    s6, s6, c
+                adc     s7, s7, c
+                subs    t, a0, a3
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b3, b0
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s3, s3, l
+                eor     h, h, c
+                adcs    s4, s4, h
+                adcs    s5, s5, c
+                adcs    s6, s6, c
+                adc     s7, s7, c
+                subs    t, a1, a2
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b2, b1
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s3, s3, l
+                eor     h, h, c
+                adcs    s4, s4, h
+                adcs    s5, s5, c
+                adcs    s6, s6, c
+                adc     s7, s7, c
+
+// Let the cross product be M. We want to add 2^256 * 2 * M to the buffer
+// Split M into M_top (248 bits) and M_bot (264 bits), so we add
+// 2^521 * M_top + 2^257 * M_bot == 2^257 * M_bot + M_top (mod p_521)
+// Accumulate the (non-reduced in general) 9-word answer [d8;...;d0]
+// As this sum is built, accumulate t = AND of words d7...d1 to help
+// in condensing the carry chain in the comparison that comes next
+
+                ldp     l, h, [z]
+                extr    d0, s5, s4, #8
+                adds    d0, d0, l
+                extr    d1, s6, s5, #8
+                adcs    d1, d1, h
+
+                ldp     l, h, [z, #16]
+                extr    d2, s7, s6, #8
+                adcs    d2, d2, l
+                and     t, d1, d2
+                lsr     d3, s7, #8
+                adcs    d3, d3, h
+                and     t, t, d3
+
+                ldp     l, h, [z, #32]
+                lsl     d4, s0, #1
+                adcs    d4, d4, l
+                and     t, t, d4
+                extr    d5, s1, s0, #63
+                adcs    d5, d5, h
+                and     t, t, d5
+
+                ldp     l, h, [z, #48]
+                extr    d6, s2, s1, #63
+                adcs    d6, d6, l
+                and     t, t, d6
+                extr    d7, s3, s2, #63
+                adcs    d7, d7, h
+                and     t, t, d7
+
+                ldr     l, [z, #64]
+                extr    d8, s4, s3, #63
+                and     d8, d8, #0x1FF
+                adc     d8, l, d8
+
+// Extract the high part h and mask off the low part l = [d8;d7;...;d0]
+// but stuff d8 with 1 bits at the left to ease a comparison below
+
+                lsr     h, d8, #9
+                orr     d8, d8, #~0x1FF
+
+// Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
+// happen if digits d7,...d1 are all 1s, we use the AND of them "t" to
+// condense the carry chain, and since we stuffed 1 bits into d8 we get
+// the result in CF without an additional comparison.
+
+                subs    xzr, xzr, xzr
+                adcs    xzr, d0, h
+                adcs    xzr, t, xzr
+                adcs    xzr, d8, xzr
+
+// Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
+// while otherwise we want just h + l. So mask h + l + CF to 521 bits.
+// This masking also gets rid of the stuffing with 1s we did above.
+
+                adcs    d0, d0, h
+                adcs    d1, d1, xzr
+                adcs    d2, d2, xzr
+                adcs    d3, d3, xzr
+                adcs    d4, d4, xzr
+                adcs    d5, d5, xzr
+                adcs    d6, d6, xzr
+                adcs    d7, d7, xzr
+                adc     d8, d8, xzr
+                and     d8, d8, #0x1FF
+
+// So far, this has been the same as a pure modular squaring.
+// Now finally the Montgomery ingredient, which is just a 521-bit
+// rotation by 9*64 - 521 = 55 bits right.
+
+                lsl     c, d0, #9
+                extr    d0, d1, d0, #55
+                extr    d1, d2, d1, #55
+                extr    d2, d3, d2, #55
+                extr    d3, d4, d3, #55
+                orr     d8, d8, c
+                extr    d4, d5, d4, #55
+                extr    d5, d6, d5, #55
+                extr    d6, d7, d6, #55
+                extr    d7, d8, d7, #55
+                lsr     d8, d8, #55
+
+// Store the final result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+
+// Restore regs and return
+
+                ldp     x23, x24, [sp], #16
+                ldp     x21, x22, [sp], #16
+                ldp     x19, x20, [sp], #16
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
@@ -1,0 +1,394 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^576) mod p_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_montsqr_p521_alt
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Does z := (x^2 / 2^576) mod p_521, assuming x < p_521. This means the
+// Montgomery base is the "native size" 2^{9*64} = 2^576; since p_521 is
+// a Mersenne prime the basic modular squaring bignum_sqr_p521 can be
+// considered a Montgomery operation to base 2^521.
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_montsqr_p521_alt
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define a4 x6
+#define a5 x7
+#define a6 x8
+#define a7 x9
+#define a8 x1 // Overwrites input argument at last load
+
+#define l x10
+
+#define u0 x11
+#define u1 x12
+#define u2 x13
+#define u3 x14
+#define u4 x15
+#define u5 x16
+#define u6 x17
+#define u7 x19
+#define u8 x20
+#define u9 x21
+#define u10 x22
+#define u11 x23
+#define u12 x24
+#define u13 x25
+#define u14 x26
+#define u15 x27
+#define u16 x29
+
+bignum_montsqr_p521_alt:
+
+// It's convenient to have more registers to play with
+
+                stp     x19, x20, [sp, #-16]!
+                stp     x21, x22, [sp, #-16]!
+                stp     x23, x24, [sp, #-16]!
+                stp     x25, x26, [sp, #-16]!
+                stp     x27, x29, [sp, #-16]!
+
+// Load low 8 elements as [a7;a6;a5;a4;a3;a2;a1;a0], set up an initial
+// window [u8;u7;u6;u5;u4;u3;u2;u1] =  10 + 20 + 30 + 40 + 50 + 60 + 70
+
+                ldp     a0, a1, [x]
+
+                mul     u1, a0, a1
+                umulh   u2, a0, a1
+
+                ldp     a2, a3, [x, #16]
+
+                mul     l, a0, a2
+                umulh   u3, a0, a2
+                adds    u2, u2, l
+
+                ldp     a4, a5, [x, #32]
+
+                mul     l, a0, a3
+                umulh   u4, a0, a3
+                adcs    u3, u3, l
+
+                ldp     a6, a7, [x, #48]
+
+                mul     l, a0, a4
+                umulh   u5, a0, a4
+                adcs    u4, u4, l
+
+                mul     l, a0, a5
+                umulh   u6, a0, a5
+                adcs    u5, u5, l
+
+                mul     l, a0, a6
+                umulh   u7, a0, a6
+                adcs    u6, u6, l
+
+                mul     l, a0, a7
+                umulh   u8, a0, a7
+                adcs    u7, u7, l
+
+                adc     u8, u8, xzr
+
+// Add in the next diagonal = 21 + 31 + 41 + 51 + 61 + 71 + 54
+
+                mul     l, a1, a2
+                adds    u3, u3, l
+                mul     l, a1, a3
+                adcs    u4, u4, l
+                mul     l, a1, a4
+                adcs    u5, u5, l
+                mul     l, a1, a5
+                adcs    u6, u6, l
+                mul     l, a1, a6
+                adcs    u7, u7, l
+                mul     l, a1, a7
+                adcs    u8, u8, l
+                cset    u9, cs
+
+                umulh   l, a1, a2
+                adds    u4, u4, l
+                umulh   l, a1, a3
+                adcs    u5, u5, l
+                umulh   l, a1, a4
+                adcs    u6, u6, l
+                umulh   l, a1, a5
+                adcs    u7, u7, l
+                umulh   l, a1, a6
+                adcs    u8, u8, l
+                umulh   l, a1, a7
+                adc     u9, u9, l
+                mul     l, a4, a5
+                umulh   u10, a4, a5
+                adds    u9, u9, l
+                adc     u10, u10, xzr
+
+// And the next one = 32 + 42 + 52 + 62 + 72 + 64 + 65
+
+                mul     l, a2, a3
+                adds    u5, u5, l
+                mul     l, a2, a4
+                adcs    u6, u6, l
+                mul     l, a2, a5
+                adcs    u7, u7, l
+                mul     l, a2, a6
+                adcs    u8, u8, l
+                mul     l, a2, a7
+                adcs    u9, u9, l
+                mul     l, a4, a6
+                adcs    u10, u10, l
+                cset    u11, cs
+
+                umulh   l, a2, a3
+                adds    u6, u6, l
+                umulh   l, a2, a4
+                adcs    u7, u7, l
+                umulh   l, a2, a5
+                adcs    u8, u8, l
+                umulh   l, a2, a6
+                adcs    u9, u9, l
+                umulh   l, a2, a7
+                adcs    u10, u10, l
+                umulh   l, a4, a6
+                adc     u11, u11, l
+                mul     l, a5, a6
+                umulh   u12, a5, a6
+                adds    u11, u11, l
+                adc     u12, u12, xzr
+
+// And the final one = 43 + 53 + 63 + 73 + 74 + 75 + 76
+
+                mul     l, a3, a4
+                adds    u7, u7, l
+                mul     l, a3, a5
+                adcs    u8, u8, l
+                mul     l, a3, a6
+                adcs    u9, u9, l
+                mul     l, a3, a7
+                adcs    u10, u10, l
+                mul     l, a4, a7
+                adcs    u11, u11, l
+                mul     l, a5, a7
+                adcs    u12, u12, l
+                cset    u13, cs
+
+                umulh   l, a3, a4
+                adds    u8, u8, l
+                umulh   l, a3, a5
+                adcs    u9, u9, l
+                umulh   l, a3, a6
+                adcs    u10, u10, l
+                umulh   l, a3, a7
+                adcs    u11, u11, l
+                umulh   l, a4, a7
+                adcs    u12, u12, l
+                umulh   l, a5, a7
+                adc     u13, u13, l
+                mul     l, a6, a7
+                umulh   u14, a6, a7
+                adds    u13, u13, l
+                adc     u14, u14, xzr
+
+// Double that, with u15 holding the top carry
+
+                adds    u1, u1, u1
+                adcs    u2, u2, u2
+                adcs    u3, u3, u3
+                adcs    u4, u4, u4
+                adcs    u5, u5, u5
+                adcs    u6, u6, u6
+                adcs    u7, u7, u7
+                adcs    u8, u8, u8
+                adcs    u9, u9, u9
+                adcs    u10, u10, u10
+                adcs    u11, u11, u11
+                adcs    u12, u12, u12
+                adcs    u13, u13, u13
+                adcs    u14, u14, u14
+                cset    u15, cs
+
+// Add the homogeneous terms 00 + 11 + 22 + 33 + 44 + 55 + 66 + 77
+
+                umulh   l, a0, a0
+                mul     u0, a0, a0
+                adds    u1, u1, l
+
+                mul     l, a1, a1
+                adcs    u2, u2, l
+                umulh   l, a1, a1
+                adcs    u3, u3, l
+
+                mul     l, a2, a2
+                adcs    u4, u4, l
+                umulh   l, a2, a2
+                adcs    u5, u5, l
+
+                mul     l, a3, a3
+                adcs    u6, u6, l
+                umulh   l, a3, a3
+                adcs    u7, u7, l
+
+                mul     l, a4, a4
+                adcs    u8, u8, l
+                umulh   l, a4, a4
+                adcs    u9, u9, l
+
+                mul     l, a5, a5
+                adcs    u10, u10, l
+                umulh   l, a5, a5
+                adcs    u11, u11, l
+
+                mul     l, a6, a6
+                adcs    u12, u12, l
+                umulh   l, a6, a6
+                adcs    u13, u13, l
+
+                mul     l, a7, a7
+                adcs    u14, u14, l
+                umulh   l, a7, a7
+                adc     u15, u15, l
+
+// Now load in the top digit a8, and also set up its double and square
+
+                ldr     a8, [x, #64]
+                mul     u16, a8, a8
+                add     a8, a8, a8
+
+// Add a8 * [a7;...;a0] into the top of the buffer
+
+                mul     l, a8, a0
+                adds    u8, u8, l
+                mul     l, a8, a1
+                adcs    u9, u9, l
+                mul     l, a8, a2
+                adcs    u10, u10, l
+                mul     l, a8, a3
+                adcs    u11, u11, l
+                mul     l, a8, a4
+                adcs    u12, u12, l
+                mul     l, a8, a5
+                adcs    u13, u13, l
+                mul     l, a8, a6
+                adcs    u14, u14, l
+                mul     l, a8, a7
+                adcs    u15, u15, l
+                adc     u16, u16, xzr
+
+                umulh   l, a8, a0
+                adds    u9, u9, l
+                umulh   l, a8, a1
+                adcs    u10, u10, l
+                umulh   l, a8, a2
+                adcs    u11, u11, l
+                umulh   l, a8, a3
+                adcs    u12, u12, l
+                umulh   l, a8, a4
+                adcs    u13, u13, l
+                umulh   l, a8, a5
+                adcs    u14, u14, l
+                umulh   l, a8, a6
+                adcs    u15, u15, l
+                umulh   l, a8, a7
+                adc     u16, u16, l
+
+// Now we have the full product, which we consider as
+// 2^521 * h + l. Form h + l + 1
+
+                subs    xzr, xzr, xzr
+                extr    l, u9, u8, #9
+                adcs    u0, u0, l
+                extr    l, u10, u9, #9
+                adcs    u1, u1, l
+                extr    l, u11, u10, #9
+                adcs    u2, u2, l
+                extr    l, u12, u11, #9
+                adcs    u3, u3, l
+                extr    l, u13, u12, #9
+                adcs    u4, u4, l
+                extr    l, u14, u13, #9
+                adcs    u5, u5, l
+                extr    l, u15, u14, #9
+                adcs    u6, u6, l
+                extr    l, u16, u15, #9
+                adcs    u7, u7, l
+                orr     u8, u8, #~0x1FF
+                lsr     l, u16, #9
+                adcs    u8, u8, l
+
+// Now CF is set if h + l + 1 >= 2^521, which means it's already
+// the answer, while if ~CF the answer is h + l so we should subtract
+// 1 (all considered in 521 bits). Hence subtract ~CF and mask.
+
+                sbcs    u0, u0, xzr
+                sbcs    u1, u1, xzr
+                sbcs    u2, u2, xzr
+                sbcs    u3, u3, xzr
+                sbcs    u4, u4, xzr
+                sbcs    u5, u5, xzr
+                sbcs    u6, u6, xzr
+                sbcs    u7, u7, xzr
+                sbc     u8, u8, xzr
+                and     u8, u8, #0x1FF
+
+// So far, this has been the same as a pure modular squaring
+// Now finally the Montgomery ingredient, which is just a 521-bit
+// rotation by 9*64 - 521 = 55 bits right.
+
+                lsl     l, u0, #9
+                extr    u0, u1, u0, #55
+                extr    u1, u2, u1, #55
+                extr    u2, u3, u2, #55
+                extr    u3, u4, u3, #55
+                orr     u8, u8, l
+                extr    u4, u5, u4, #55
+                extr    u5, u6, u5, #55
+                extr    u6, u7, u6, #55
+                extr    u7, u8, u7, #55
+                lsr     u8, u8, #55
+
+// Store back digits of final result
+
+                stp     u0, u1, [z]
+                stp     u2, u3, [z, #16]
+                stp     u4, u5, [z, #32]
+                stp     u6, u7, [z, #48]
+                str     u8, [z, #64]
+
+// Restore registers and return
+
+                ldp     x27, x29, [sp], #16
+                ldp     x25, x26, [sp], #16
+                ldp     x23, x24, [sp], #16
+                ldp     x21, x22, [sp], #16
+                ldp     x19, x20, [sp], #16
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
@@ -1,0 +1,600 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply modulo p_521, z := (x * y) mod p_521, assuming x and y reduced
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_mul_p521
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_mul_p521
+        .text
+        .balign 4
+
+// ---------------------------------------------------------------------------
+// Macro computing [c,b,a] := [b,a] + (x - y) * (w - z), adding with carry
+// to the [b,a] components but leaving CF aligned with the c term, which is
+// a sign bitmask for (x - y) * (w - z). Continued add-with-carry operations
+// with [c,...,c] will continue the carry chain correctly starting from
+// the c position if desired to add to a longer term of the form [...,b,a].
+//
+// c,h,l,t should all be different and t,h should not overlap w,z.
+// ---------------------------------------------------------------------------
+
+#define muldiffnadd(b,a,x,y,w,z)        \
+        subs    t, x, y;                \
+        cneg    t, t, cc;               \
+        csetm   c, cc;                  \
+        subs    h, w, z;                \
+        cneg    h, h, cc;               \
+        mul     l, t, h;                \
+        umulh   h, t, h;                \
+        cinv    c, c, cc;               \
+        adds    xzr, c, #1;             \
+        eor     l, l, c;                \
+        adcs    a, a, l;                \
+        eor     h, h, c;                \
+        adcs    b, b, h
+
+#define z x0
+#define x x1
+#define y x2
+
+#define a0 x3
+#define a1 x4
+#define a2 x5
+#define a3 x6
+#define b0 x7
+#define b1 x8
+#define b2 x9
+#define b3 x10
+
+#define s0 x11
+#define s1 x12
+#define s2 x13
+#define s3 x14
+#define s4 x15
+#define s5 x16
+#define s6 x17
+#define s7 x19
+#define s8 x20
+
+#define c  x21
+#define h  x22
+#define l  x23
+#define t  x24
+#define s  x25
+#define u  x26
+
+// ---------------------------------------------------------------------------
+// Core 4x4->8 ADK multiplication macro
+// Does [s7,s6,s5,s4,s3,s2,s1,s0] = [a3,a2,a1,a0] * [b3,b2,b1,b0]
+// ---------------------------------------------------------------------------
+
+#define mul4                                                            \
+/*  First accumulate all the "simple" products as [s7,s6,s5,s4,s0] */   \
+                                                                        \
+                mul     s0, a0, b0;                                     \
+                mul     s4, a1, b1;                                     \
+                mul     s5, a2, b2;                                     \
+                mul     s6, a3, b3;                                     \
+                                                                        \
+                umulh   s7, a0, b0;                                     \
+                adds    s4, s4, s7;                                     \
+                umulh   s7, a1, b1;                                     \
+                adcs    s5, s5, s7;                                     \
+                umulh   s7, a2, b2;                                     \
+                adcs    s6, s6, s7;                                     \
+                umulh   s7, a3, b3;                                     \
+                adc     s7, s7, xzr;                                    \
+                                                                        \
+/*  Multiply by B + 1 to get [s7;s6;s5;s4;s1;s0] */                     \
+                                                                        \
+                adds    s1, s4, s0;                                     \
+                adcs    s4, s5, s4;                                     \
+                adcs    s5, s6, s5;                                     \
+                adcs    s6, s7, s6;                                     \
+                adc     s7, xzr, s7;                                    \
+                                                                        \
+/*  Multiply by B^2 + 1 to get [s7;s6;s5;s4;s3;s2;s1;s0] */             \
+                                                                        \
+                adds    s2, s4, s0;                                     \
+                adcs    s3, s5, s1;                                     \
+                adcs    s4, s6, s4;                                     \
+                adcs    s5, s7, s5;                                     \
+                adcs    s6, xzr, s6;                                    \
+                adc     s7, xzr, s7;                                    \
+                                                                        \
+/*  Now add in all the "complicated" terms. */                          \
+                                                                        \
+                muldiffnadd(s6,s5, a2,a3, b3,b2);                       \
+                adc     s7, s7, c;                                      \
+                                                                        \
+                muldiffnadd(s2,s1, a0,a1, b1,b0);                       \
+                adcs    s3, s3, c;                                      \
+                adcs    s4, s4, c;                                      \
+                adcs    s5, s5, c;                                      \
+                adcs    s6, s6, c;                                      \
+                adc     s7, s7, c;                                      \
+                                                                        \
+                muldiffnadd(s5,s4, a1,a3, b3,b1);                       \
+                adcs    s6, s6, c;                                      \
+                adc     s7, s7, c;                                      \
+                                                                        \
+                muldiffnadd(s3,s2, a0,a2, b2,b0);                       \
+                adcs    s4, s4, c;                                      \
+                adcs    s5, s5, c;                                      \
+                adcs    s6, s6, c;                                      \
+                adc     s7, s7, c;                                      \
+                                                                        \
+                muldiffnadd(s4,s3, a0,a3, b3,b0);                       \
+                adcs    s5, s5, c;                                      \
+                adcs    s6, s6, c;                                      \
+                adc     s7, s7, c;                                      \
+                muldiffnadd(s4,s3, a1,a2, b2,b1);                       \
+                adcs    s5, s5, c;                                      \
+                adcs    s6, s6, c;                                      \
+                adc     s7, s7, c                                       \
+
+bignum_mul_p521:
+
+// Save registers
+
+                stp     x19, x20, [sp, #-16]!
+                stp     x21, x22, [sp, #-16]!
+                stp     x23, x24, [sp, #-16]!
+                stp     x25, x26, [sp, #-16]!
+
+// Load 4-digit low parts and multiply them to get L
+
+                ldp     a0, a1, [x]
+                ldp     a2, a3, [x, #16]
+                ldp     b0, b1, [y]
+                ldp     b2, b3, [y, #16]
+                mul4
+
+// Shift right 256 bits modulo p_521 and stash in output buffer
+
+                lsl     c, s0, #9
+                extr    s0, s1, s0, #55
+                extr    s1, s2, s1, #55
+                extr    s2, s3, s2, #55
+                lsr     s3, s3, #55
+                stp     s4, s5, [z]
+                stp     s6, s7, [z, #16]
+                stp     c, s0, [z, #32]
+                stp     s1, s2, [z, #48]
+                str     s3, [z, #64]
+
+// Load 4-digit low parts and multiply them to get H
+
+                ldp     a0, a1, [x, #32]
+                ldp     a2, a3, [x, #48]
+                ldp     b0, b1, [y, #32]
+                ldp     b2, b3, [y, #48]
+                mul4
+
+// Add to the existing output buffer and re-stash.
+// This gives a result HL congruent to (2^256 * H + L) / 2^256 modulo p_521
+
+                ldp     l, h, [z]
+                adds    s0, s0, l
+                adcs    s1, s1, h
+                stp     s0, s1, [z]
+                ldp     l, h, [z, #16]
+                adcs    s2, s2, l
+                adcs    s3, s3, h
+                stp     s2, s3, [z, #16]
+                ldp     l, h, [z, #32]
+                adcs    s4, s4, l
+                adcs    s5, s5, h
+                stp     s4, s5, [z, #32]
+                ldp     l, h, [z, #48]
+                adcs    s6, s6, l
+                adcs    s7, s7, h
+                stp     s6, s7, [z, #48]
+                ldr     c, [z, #64]
+                adc     c, c, xzr
+                str     c, [z, #64]
+
+// Compute t,[a3,a2,a1,a0] = x_hi - x_lo
+// and     s,[b3,b2,b1,b0] = y_lo - y_hi
+// sign-magnitude differences, then XOR overall sign bitmask into s
+
+                ldp     l, h, [x]
+                subs    a0, a0, l
+                sbcs    a1, a1, h
+                ldp     l, h, [x, #16]
+                sbcs    a2, a2, l
+                sbcs    a3, a3, h
+                csetm   t, cc
+                ldp     l, h, [y]
+                subs    b0, l, b0
+                sbcs    b1, h, b1
+                ldp     l, h, [y, #16]
+                sbcs    b2, l, b2
+                sbcs    b3, h, b3
+                csetm   s, cc
+
+                eor     a0, a0, t
+                subs    a0, a0, t
+                eor     a1, a1, t
+                sbcs    a1, a1, t
+                eor     a2, a2, t
+                sbcs    a2, a2, t
+                eor     a3, a3, t
+                sbc     a3, a3, t
+
+                eor     b0, b0, s
+                subs    b0, b0, s
+                eor     b1, b1, s
+                sbcs    b1, b1, s
+                eor     b2, b2, s
+                sbcs    b2, b2, s
+                eor     b3, b3, s
+                sbc     b3, b3, s
+
+                eor     s, s, t
+
+// Now do yet a third 4x4 multiply to get mid-term product M
+
+                mul4
+
+// We now want, at the 256 position, 2^256 * HL + HL + (-1)^s * M
+// To keep things positive we use M' = p_521 - M in place of -M,
+// and this notion of negation just amounts to complementation in 521 bits.
+// Fold in the re-addition of the appropriately scaled lowest 4 words
+// The initial result is [s8; b3;b2;b1;b0; s7;s6;s5;s4;s3;s2;s1;s0]
+// Rebase it as a 9-word value at the 512 bit position using
+// [s8; b3;b2;b1;b0; s7;s6;s5;s4;s3;s2;s1;s0] ==
+// [s8; b3;b2;b1;b0; s7;s6;s5;s4] + 2^265 * [s3;s2;s1;s0] =
+// ([s8; b3;b2;b1;b0] + 2^9 * [s3;s2;s1;s0]); s7;s6;s5;s4]
+//
+// Accumulate as [s8; b3;b2;b1;b0; s7;s6;s5;s4] but leave out an additional
+// small c (s8 + suspended carry) to add at the 256 position here (512
+// overall). This can be added in the next block (to b0 = sum4).
+
+                ldp     a0, a1, [z]
+                ldp     a2, a3, [z, #16]
+
+                eor     s0, s0, s
+                adds    s0, s0, a0
+                eor     s1, s1, s
+                adcs    s1, s1, a1
+                eor     s2, s2, s
+                adcs    s2, s2, a2
+                eor     s3, s3, s
+                adcs    s3, s3, a3
+                eor     s4, s4, s
+
+                ldp     b0, b1, [z, #32]
+                ldp     b2, b3, [z, #48]
+                ldr     s8, [z, #64]
+
+                adcs    s4, s4, b0
+                eor     s5, s5, s
+                adcs    s5, s5, b1
+                eor     s6, s6, s
+                adcs    s6, s6, b2
+                eor     s7, s7, s
+                adcs    s7, s7, b3
+                adc     c, s8, xzr
+
+                adds    s4, s4, a0
+                adcs    s5, s5, a1
+                adcs    s6, s6, a2
+                adcs    s7, s7, a3
+                and     s, s, #0x1FF
+                lsl     t, s0, #9
+                orr     t, t, s
+                adcs    b0, b0, t
+                extr    t, s1, s0, #55
+                adcs    b1, b1, t
+                extr    t, s2, s1, #55
+                adcs    b2, b2, t
+                extr    t, s3, s2, #55
+                adcs    b3, b3, t
+                lsr     t, s3, #55
+                adc     s8, t, s8
+
+// Augment the total with the contribution from the top little words
+// w and v. If we write the inputs as 2^512 * w + x and 2^512 * v + y
+// then we are otherwise just doing x * y so we actually need to add
+// 2^512 * (2^512 * w * v + w * y + v * x). We do this is an involved
+// way chopping x and y into 52-bit chunks so we can do most of the core
+// arithmetic using only basic muls, no umulh (since w, v are only 9 bits).
+// This does however involve some intricate bit-splicing plus arithmetic.
+// To make things marginally less confusing we introduce some new names
+// at the human level: x = [c7;...;c0] and y = [d7;...d0], which are
+// not all distinct, and [sum8;sum7;...;sum0] for the running sum.
+// Also accumulate u = sum1 AND ... AND sum7 for the later comparison
+
+#define sum0 s4
+#define sum1 s5
+#define sum2 s6
+#define sum3 s7
+#define sum4 b0
+#define sum5 b1
+#define sum6 b2
+#define sum7 b3
+#define sum8 s8
+
+#define c0 a0
+#define c1 a1
+#define c2 a2
+#define c3 a0
+#define c4 a1
+#define c5 a2
+#define c6 a0
+#define c7 a1
+
+#define d0 s0
+#define d1 s1
+#define d2 s2
+#define d3 s0
+#define d4 s1
+#define d5 s2
+#define d6 s0
+#define d7 s1
+
+#define v a3
+#define w s3
+
+// 0 * 52 = 64 * 0 + 0
+
+                ldr     v, [y, #64]
+                ldp     c0, c1, [x]
+                and     l, c0, #0x000fffffffffffff
+                mul     l, v, l
+                ldr     w, [x, #64]
+                ldp     d0, d1, [y]
+                and     t, d0, #0x000fffffffffffff
+                mul     t, w, t
+                add     l, l, t
+
+// 1 * 52 = 64 * 0 + 52
+
+                extr    t, c1, c0, #52
+                and     t, t, #0x000fffffffffffff
+                mul     h, v, t
+                extr    t, d1, d0, #52
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     h, h, t
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #12
+                adds    sum0, sum0, t
+
+// 2 * 52 = 64 * 1 + 40
+
+                ldp     c2, c3, [x, #16]
+                ldp     d2, d3, [y, #16]
+                extr    t, c2, c1, #40
+                and     t, t, #0x000fffffffffffff
+                mul     l, v, t
+                extr    t, d2, d1, #40
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     l, l, t
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #24
+                adcs    sum1, sum1, t
+
+// 3 * 52 = 64 * 2 + 28
+
+                extr    t, c3, c2, #28
+                and     t, t, #0x000fffffffffffff
+                mul     h, v, t
+                extr    t, d3, d2, #28
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     h, h, t
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #36
+                adcs    sum2, sum2, t
+                and     u, sum1, sum2
+
+// 4 * 52 = 64 * 3 + 16
+// At this point we also fold in the addition of c at the right place.
+// Note that 4 * 64 = 4 * 52 + 48 so we shift c left 48 places to align.
+
+                ldp     c4, c5, [x, #32]
+                ldp     d4, d5, [y, #32]
+                extr    t, c4, c3, #16
+                and     t, t, #0x000fffffffffffff
+                mul     l, v, t
+                extr    t, d4, d3, #16
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     l, l, t
+
+                lsl     c, c, #48
+                add     l, l, c
+
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #48
+                adcs    sum3, sum3, t
+                and     u, u, sum3
+
+// 5 * 52 = 64 * 4 + 4
+
+                lsr     t, c4, #4
+                and     t, t, #0x000fffffffffffff
+                mul     h, v, t
+                lsr     t, d4, #4
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     h, h, t
+
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    s, h, l, #60
+
+// 6 * 52 = 64 * 4 + 56
+
+                extr    t, c5, c4, #56
+                and     t, t, #0x000fffffffffffff
+                mul     l, v, t
+                extr    t, d5, d4, #56
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     l, l, t
+
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     s, s, #8
+                extr    t, l, s, #8
+                adcs    sum4, sum4, t
+                and     u, u, sum4
+
+// 7 * 52 = 64 * 5 + 44
+
+                ldp     c6, c7, [x, #48]
+                ldp     d6, d7, [y, #48]
+                extr    t, c6, c5, #44
+                and     t, t, #0x000fffffffffffff
+                mul     h, v, t
+                extr    t, d6, d5, #44
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     h, h, t
+
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #20
+                adcs    sum5, sum5, t
+                and     u, u, sum5
+
+// 8 * 52 = 64 * 6 + 32
+
+                extr    t, c7, c6, #32
+                and     t, t, #0x000fffffffffffff
+                mul     l, v, t
+                extr    t, d7, d6, #32
+                and     t, t, #0x000fffffffffffff
+                mul     t, w, t
+                add     l, l, t
+
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #32
+                adcs    sum6, sum6, t
+                and     u, u, sum6
+
+// 9 * 52 = 64 * 7 + 20
+
+                lsr     t, c7, #20
+                mul     h, v, t
+                lsr     t, d7, #20
+                mul     t, w, t
+                add     h, h, t
+
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #44
+                adcs    sum7, sum7, t
+                and     u, u, sum7
+
+// Top word
+
+                mul     t, v, w
+                lsr     h, h, #44
+                add     t, t, h
+                adc     sum8, sum8, t
+
+// Extract the high part h and mask off the low part l = [sum8;sum7;...;sum0]
+// but stuff sum8 with 1 bits at the left to ease a comparison below
+
+                lsr     h, sum8, #9
+                orr     sum8, sum8, #~0x1FF
+
+// Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
+// happen if digits sum7,...sum1 are all 1s, we use the AND of them "u" to
+// condense the carry chain, and since we stuffed 1 bits into sum8 we get
+// the result in CF without an additional comparison.
+
+                subs    xzr, xzr, xzr
+                adcs    xzr, sum0, h
+                adcs    xzr, u, xzr
+                adcs    xzr, sum8, xzr
+
+// Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
+// while otherwise we want just h + l. So mask h + l + CF to 521 bits.
+// We don't need to mask away bits above 521 since they disappear below.
+
+                adcs    sum0, sum0, h
+                adcs    sum1, sum1, xzr
+                adcs    sum2, sum2, xzr
+                adcs    sum3, sum3, xzr
+                adcs    sum4, sum4, xzr
+                adcs    sum5, sum5, xzr
+                adcs    sum6, sum6, xzr
+                adcs    sum7, sum7, xzr
+                adc     sum8, sum8, xzr
+
+// The result is actually 2^512 * [sum8;...;sum0] == 2^-9 * [sum8;...;sum0]
+// so we rotate right by 9 bits
+
+                and     h, sum0, #0x1FF
+                extr    sum0, sum1, sum0, #9
+                extr    sum1, sum2, sum1, #9
+                stp     sum0, sum1, [z]
+                extr    sum2, sum3, sum2, #9
+                extr    sum3, sum4, sum3, #9
+                stp     sum2, sum3, [z, #16]
+                extr    sum4, sum5, sum4, #9
+                extr    sum5, sum6, sum5, #9
+                stp     sum4, sum5, [z, #32]
+                extr    sum6, sum7, sum6, #9
+                extr    sum7, sum8, sum7, #9
+                stp     sum6, sum7, [z, #48]
+                str     h, [z, #64]
+
+// Restore regs and return
+
+                ldp     x25, x26, [sp], #16
+                ldp     x23, x24, [sp], #16
+                ldp     x21, x22, [sp], #16
+                ldp     x19, x20, [sp], #16
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
@@ -1,0 +1,540 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply modulo p_521, z := (x * y) mod p_521, assuming x and y reduced
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_mul_p521_alt
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_mul_p521_alt
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+#define y x2
+
+// These are repeated mod 2 as we load paris of inputs
+
+#define a0 x3
+#define a1 x4
+#define a2 x3
+#define a3 x4
+#define a4 x3
+#define a5 x4
+#define a6 x3
+#define a7 x4
+#define a8 x3
+
+#define b0 x5
+#define b1 x6
+#define b2 x7
+#define b3 x8
+#define b4 x9
+#define b5 x10
+#define b6 x11
+#define b7 x12
+#define b8 x13
+
+#define t x14
+
+// These repeat mod 11 as we stash some intermediate results in the
+// output buffer.
+
+#define u0 x15
+#define u1 x16
+#define u2 x17
+#define u3 x19
+#define u4 x20
+#define u5 x21
+#define u6 x22
+#define u7 x23
+#define u8 x24
+#define u9 x25
+#define u10 x26
+#define u11 x15
+#define u12 x16
+#define u13 x17
+#define u14 x19
+#define u15 x20
+#define u16 x21
+
+bignum_mul_p521_alt:
+
+// Save more registers
+
+                stp     x19, x20, [sp, #-16]!
+                stp     x21, x22, [sp, #-16]!
+                stp     x23, x24, [sp, #-16]!
+                stp     x25, x26, [sp, #-16]!
+
+// Load operands and set up row 0 = [u9;...;u0] = a0 * [b8;...;b0]
+
+                ldp     a0, a1, [x]
+                ldp     b0, b1, [y]
+
+                mul     u0, a0, b0
+                umulh   u1, a0, b0
+                mul     t, a0, b1
+                umulh   u2, a0, b1
+                adds    u1, u1, t
+
+                ldp     b2, b3, [y, #16]
+
+                mul     t, a0, b2
+                umulh   u3, a0, b2
+                adcs    u2, u2, t
+
+                mul     t, a0, b3
+                umulh   u4, a0, b3
+                adcs    u3, u3, t
+
+                ldp     b4, b5, [y, #32]
+
+                mul     t, a0, b4
+                umulh   u5, a0, b4
+                adcs    u4, u4, t
+
+                mul     t, a0, b5
+                umulh   u6, a0, b5
+                adcs    u5, u5, t
+
+                ldp     b6, b7, [y, #48]
+
+                mul     t, a0, b6
+                umulh   u7, a0, b6
+                adcs    u6, u6, t
+
+                ldr     b8, [y, #64]
+
+                mul     t, a0, b7
+                umulh   u8, a0, b7
+                adcs    u7, u7, t
+
+                mul     t, a0, b8
+                umulh   u9, a0, b8
+                adcs    u8, u8, t
+
+                adc     u9, u9, xzr
+
+// Row 1 = [u10;...;u0] = [a1;a0] * [b8;...;b0]
+
+                mul     t, a1, b0
+                adds    u1, u1, t
+                mul     t, a1, b1
+                adcs    u2, u2, t
+                mul     t, a1, b2
+                adcs    u3, u3, t
+                mul     t, a1, b3
+                adcs    u4, u4, t
+                mul     t, a1, b4
+                adcs    u5, u5, t
+                mul     t, a1, b5
+                adcs    u6, u6, t
+                mul     t, a1, b6
+                adcs    u7, u7, t
+                mul     t, a1, b7
+                adcs    u8, u8, t
+                mul     t, a1, b8
+                adcs    u9, u9, t
+                cset    u10, cs
+
+                umulh   t, a1, b0
+                adds    u2, u2, t
+                umulh   t, a1, b1
+                adcs    u3, u3, t
+                umulh   t, a1, b2
+                adcs    u4, u4, t
+                umulh   t, a1, b3
+                adcs    u5, u5, t
+                umulh   t, a1, b4
+                adcs    u6, u6, t
+                umulh   t, a1, b5
+                adcs    u7, u7, t
+                umulh   t, a1, b6
+                adcs    u8, u8, t
+                umulh   t, a1, b7
+                adcs    u9, u9, t
+                umulh   t, a1, b8
+                adc     u10, u10, t
+
+                stp     u0, u1, [z]
+
+// Row 2 = [u11;...;u0] = [a2;a1;a0] * [b8;...;b0]
+
+                ldp     a2, a3, [x, #16]
+
+                mul     t, a2, b0
+                adds    u2, u2, t
+                mul     t, a2, b1
+                adcs    u3, u3, t
+                mul     t, a2, b2
+                adcs    u4, u4, t
+                mul     t, a2, b3
+                adcs    u5, u5, t
+                mul     t, a2, b4
+                adcs    u6, u6, t
+                mul     t, a2, b5
+                adcs    u7, u7, t
+                mul     t, a2, b6
+                adcs    u8, u8, t
+                mul     t, a2, b7
+                adcs    u9, u9, t
+                mul     t, a2, b8
+                adcs    u10, u10, t
+                cset    u11, cs
+
+                umulh   t, a2, b0
+                adds    u3, u3, t
+                umulh   t, a2, b1
+                adcs    u4, u4, t
+                umulh   t, a2, b2
+                adcs    u5, u5, t
+                umulh   t, a2, b3
+                adcs    u6, u6, t
+                umulh   t, a2, b4
+                adcs    u7, u7, t
+                umulh   t, a2, b5
+                adcs    u8, u8, t
+                umulh   t, a2, b6
+                adcs    u9, u9, t
+                umulh   t, a2, b7
+                adcs    u10, u10, t
+                umulh   t, a2, b8
+                adc     u11, u11, t
+
+// Row 3 = [u12;...;u0] = [a3;a2;a1;a0] * [b8;...;b0]
+
+                mul     t, a3, b0
+                adds    u3, u3, t
+                mul     t, a3, b1
+                adcs    u4, u4, t
+                mul     t, a3, b2
+                adcs    u5, u5, t
+                mul     t, a3, b3
+                adcs    u6, u6, t
+                mul     t, a3, b4
+                adcs    u7, u7, t
+                mul     t, a3, b5
+                adcs    u8, u8, t
+                mul     t, a3, b6
+                adcs    u9, u9, t
+                mul     t, a3, b7
+                adcs    u10, u10, t
+                mul     t, a3, b8
+                adcs    u11, u11, t
+                cset    u12, cs
+
+                umulh   t, a3, b0
+                adds    u4, u4, t
+                umulh   t, a3, b1
+                adcs    u5, u5, t
+                umulh   t, a3, b2
+                adcs    u6, u6, t
+                umulh   t, a3, b3
+                adcs    u7, u7, t
+                umulh   t, a3, b4
+                adcs    u8, u8, t
+                umulh   t, a3, b5
+                adcs    u9, u9, t
+                umulh   t, a3, b6
+                adcs    u10, u10, t
+                umulh   t, a3, b7
+                adcs    u11, u11, t
+                umulh   t, a3, b8
+                adc     u12, u12, t
+
+                stp     u2, u3, [z, #16]
+
+// Row 4 = [u13;...;u0] = [a4;a3;a2;a1;a0] * [b8;...;b0]
+
+                ldp     a4, a5, [x, #32]
+
+                mul     t, a4, b0
+                adds    u4, u4, t
+                mul     t, a4, b1
+                adcs    u5, u5, t
+                mul     t, a4, b2
+                adcs    u6, u6, t
+                mul     t, a4, b3
+                adcs    u7, u7, t
+                mul     t, a4, b4
+                adcs    u8, u8, t
+                mul     t, a4, b5
+                adcs    u9, u9, t
+                mul     t, a4, b6
+                adcs    u10, u10, t
+                mul     t, a4, b7
+                adcs    u11, u11, t
+                mul     t, a4, b8
+                adcs    u12, u12, t
+                cset    u13, cs
+
+                umulh   t, a4, b0
+                adds    u5, u5, t
+                umulh   t, a4, b1
+                adcs    u6, u6, t
+                umulh   t, a4, b2
+                adcs    u7, u7, t
+                umulh   t, a4, b3
+                adcs    u8, u8, t
+                umulh   t, a4, b4
+                adcs    u9, u9, t
+                umulh   t, a4, b5
+                adcs    u10, u10, t
+                umulh   t, a4, b6
+                adcs    u11, u11, t
+                umulh   t, a4, b7
+                adcs    u12, u12, t
+                umulh   t, a4, b8
+                adc     u13, u13, t
+
+// Row 5 = [u14;...;u0] = [a5;a4;a3;a2;a1;a0] * [b8;...;b0]
+
+                mul     t, a5, b0
+                adds    u5, u5, t
+                mul     t, a5, b1
+                adcs    u6, u6, t
+                mul     t, a5, b2
+                adcs    u7, u7, t
+                mul     t, a5, b3
+                adcs    u8, u8, t
+                mul     t, a5, b4
+                adcs    u9, u9, t
+                mul     t, a5, b5
+                adcs    u10, u10, t
+                mul     t, a5, b6
+                adcs    u11, u11, t
+                mul     t, a5, b7
+                adcs    u12, u12, t
+                mul     t, a5, b8
+                adcs    u13, u13, t
+                cset    u14, cs
+
+                umulh   t, a5, b0
+                adds    u6, u6, t
+                umulh   t, a5, b1
+                adcs    u7, u7, t
+                umulh   t, a5, b2
+                adcs    u8, u8, t
+                umulh   t, a5, b3
+                adcs    u9, u9, t
+                umulh   t, a5, b4
+                adcs    u10, u10, t
+                umulh   t, a5, b5
+                adcs    u11, u11, t
+                umulh   t, a5, b6
+                adcs    u12, u12, t
+                umulh   t, a5, b7
+                adcs    u13, u13, t
+                umulh   t, a5, b8
+                adc     u14, u14, t
+
+                stp     u4, u5, [z, #32]
+
+// Row 6 = [u15;...;u0] = [a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
+
+                ldp     a6, a7, [x, #48]
+
+                mul     t, a6, b0
+                adds    u6, u6, t
+                mul     t, a6, b1
+                adcs    u7, u7, t
+                mul     t, a6, b2
+                adcs    u8, u8, t
+                mul     t, a6, b3
+                adcs    u9, u9, t
+                mul     t, a6, b4
+                adcs    u10, u10, t
+                mul     t, a6, b5
+                adcs    u11, u11, t
+                mul     t, a6, b6
+                adcs    u12, u12, t
+                mul     t, a6, b7
+                adcs    u13, u13, t
+                mul     t, a6, b8
+                adcs    u14, u14, t
+                cset    u15, cs
+
+                umulh   t, a6, b0
+                adds    u7, u7, t
+                umulh   t, a6, b1
+                adcs    u8, u8, t
+                umulh   t, a6, b2
+                adcs    u9, u9, t
+                umulh   t, a6, b3
+                adcs    u10, u10, t
+                umulh   t, a6, b4
+                adcs    u11, u11, t
+                umulh   t, a6, b5
+                adcs    u12, u12, t
+                umulh   t, a6, b6
+                adcs    u13, u13, t
+                umulh   t, a6, b7
+                adcs    u14, u14, t
+                umulh   t, a6, b8
+                adc     u15, u15, t
+
+// Row 7 = [u16;...;u0] = [a7;a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
+
+                mul     t, a7, b0
+                adds    u7, u7, t
+                mul     t, a7, b1
+                adcs    u8, u8, t
+                mul     t, a7, b2
+                adcs    u9, u9, t
+                mul     t, a7, b3
+                adcs    u10, u10, t
+                mul     t, a7, b4
+                adcs    u11, u11, t
+                mul     t, a7, b5
+                adcs    u12, u12, t
+                mul     t, a7, b6
+                adcs    u13, u13, t
+                mul     t, a7, b7
+                adcs    u14, u14, t
+                mul     t, a7, b8
+                adcs    u15, u15, t
+                cset    u16, cs
+
+                umulh   t, a7, b0
+                adds    u8, u8, t
+                umulh   t, a7, b1
+                adcs    u9, u9, t
+                umulh   t, a7, b2
+                adcs    u10, u10, t
+                umulh   t, a7, b3
+                adcs    u11, u11, t
+                umulh   t, a7, b4
+                adcs    u12, u12, t
+                umulh   t, a7, b5
+                adcs    u13, u13, t
+                umulh   t, a7, b6
+                adcs    u14, u14, t
+                umulh   t, a7, b7
+                adcs    u15, u15, t
+                umulh   t, a7, b8
+                adc     u16, u16, t
+
+                stp     u6, u7, [z, #48]
+
+// Row 8 = [u16;...;u0] = [a8;a7;a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
+
+                ldr     a8, [x, #64]
+
+                mul     t, a8, b0
+                adds    u8, u8, t
+                mul     t, a8, b1
+                adcs    u9, u9, t
+                mul     t, a8, b2
+                adcs    u10, u10, t
+                mul     t, a8, b3
+                adcs    u11, u11, t
+                mul     t, a8, b4
+                adcs    u12, u12, t
+                mul     t, a8, b5
+                adcs    u13, u13, t
+                mul     t, a8, b6
+                adcs    u14, u14, t
+                mul     t, a8, b7
+                adcs    u15, u15, t
+                mul     t, a8, b8
+                adc     u16, u16, t
+
+                umulh   t, a8, b0
+                adds    u9, u9, t
+                umulh   t, a8, b1
+                adcs    u10, u10, t
+                umulh   t, a8, b2
+                adcs    u11, u11, t
+                umulh   t, a8, b3
+                adcs    u12, u12, t
+                umulh   t, a8, b4
+                adcs    u13, u13, t
+                umulh   t, a8, b5
+                adcs    u14, u14, t
+                umulh   t, a8, b6
+                adcs    u15, u15, t
+                umulh   t, a8, b7
+                adc     u16, u16, t
+
+// Now we have the full product, which we consider as
+// 2^521 * h + l. Form h + l + 1
+
+                subs    xzr, xzr, xzr
+                ldp     b0, b1, [z]
+                extr    t, u9, u8, #9
+                adcs    b0, b0, t
+                extr    t, u10, u9, #9
+                adcs    b1, b1, t
+                ldp     b2, b3, [z, #16]
+                extr    t, u11, u10, #9
+                adcs    b2, b2, t
+                extr    t, u12, u11, #9
+                adcs    b3, b3, t
+                ldp     b4, b5, [z, #32]
+                extr    t, u13, u12, #9
+                adcs    b4, b4, t
+                extr    t, u14, u13, #9
+                adcs    b5, b5, t
+                ldp     b6, b7, [z, #48]
+                extr    t, u15, u14, #9
+                adcs    b6, b6, t
+                extr    t, u16, u15, #9
+                adcs    b7, b7, t
+                orr     b8, u8, #~0x1FF
+                lsr     t, u16, #9
+                adcs    b8, b8, t
+
+// Now CF is set if h + l + 1 >= 2^521, which means it's already
+// the answer, while if ~CF the answer is h + l so we should subtract
+// 1 (all considered in 521 bits). Hence subtract ~CF and mask.
+
+                sbcs    b0, b0, xzr
+                sbcs    b1, b1, xzr
+                sbcs    b2, b2, xzr
+                sbcs    b3, b3, xzr
+                sbcs    b4, b4, xzr
+                sbcs    b5, b5, xzr
+                sbcs    b6, b6, xzr
+                sbcs    b7, b7, xzr
+                sbc     b8, b8, xzr
+                and     b8, b8, #0x1FF
+
+// Store back digits of final result
+
+                stp     b0, b1, [z]
+                stp     b2, b3, [z, #16]
+                stp     b4, b5, [z, #32]
+                stp     b6, b7, [z, #48]
+                str     b8, [z, #64]
+
+// Restore registers
+
+                ldp     x25, x26, [sp], #16
+                ldp     x23, x24, [sp], #16
+                ldp     x21, x22, [sp], #16
+                ldp     x19, x20, [sp], #16
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Negate modulo p_521, z := (-x) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_neg_p521 (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_neg_p521
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define p x2
+
+#define d0 x3
+#define d1 x4
+#define d2 x5
+#define d3 x6
+#define d4 x7
+#define d5 x8
+#define d6 x9
+#define d7 x10
+#define d8 x11
+
+bignum_neg_p521:
+
+// Load the 9 digits of x and generate p = the OR of them all
+
+                ldp     d0, d1, [x]
+                orr     d6, d0, d1
+                ldp     d2, d3, [x, #16]
+                orr     d7, d2, d3
+                orr     p, d6, d7
+                ldp     d4, d5, [x, #32]
+                orr     d8, d4, d5
+                orr     p, p, d8
+                ldp     d6, d7, [x, #48]
+                orr     d8, d6, d7
+                orr     p, p, d8
+                ldr     d8, [x, #64]
+                orr     p, p, d8
+
+// Turn p into a bitmask for "input is nonzero", so that we avoid doing
+// -0 = p_521 and hence maintain strict modular reduction
+
+                cmp     p, #0
+                csetm   p, ne
+
+// Since p_521 is all 1s, the subtraction is just an exclusive-or with p
+// to give an optional inversion, with a slight fiddle for the top digit.
+
+                eor     d0, d0, p
+                eor     d1, d1, p
+                eor     d2, d2, p
+                eor     d3, d3, p
+                eor     d4, d4, p
+                eor     d5, d5, p
+                eor     d6, d6, p
+                eor     d7, d7, p
+                and     p, p, #0x1FF
+                eor     d8, d8, p
+
+// Write back the result and return
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Optionally negate modulo p_521, z := (-x) mod p_521 (if p nonzero) or
+// z := x (if p zero), assuming x reduced
+// Inputs p, x[9]; output z[9]
+//
+//    extern void bignum_optneg_p521
+//      (uint64_t z[static 9], uint64_t p, uint64_t x[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = p, X2 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_optneg_p521
+        .text
+        .balign 4
+
+#define z x0
+#define p x1
+#define x x2
+#define q x3
+
+#define d0 x4
+#define d1 x5
+#define d2 x6
+#define d3 x7
+#define d4 x8
+#define d5 x9
+#define d6 x10
+#define d7 x11
+#define d8 x12
+
+bignum_optneg_p521:
+
+// Load the 9 digits of x and generate q = the OR of them all
+
+                ldp     d0, d1, [x]
+                orr     d6, d0, d1
+                ldp     d2, d3, [x, #16]
+                orr     d7, d2, d3
+                orr     q, d6, d7
+                ldp     d4, d5, [x, #32]
+                orr     d8, d4, d5
+                orr     q, q, d8
+                ldp     d6, d7, [x, #48]
+                orr     d8, d6, d7
+                orr     q, q, d8
+                ldr     d8, [x, #64]
+                orr     q, q, d8
+
+// Turn q into a bitmask for "input is nonzero and p is nonzero", so that
+// we avoid doing -0 = p_521 and hence maintain strict modular reduction
+
+                cmp     q, #0
+                csetm   q, ne
+                cmp     p, #0
+                csel    q, xzr, q, eq
+
+// Since p_521 is all 1s, the subtraction is just an exclusive-or with q
+// to give an optional inversion, with a slight fiddle for the top digit.
+
+                eor     d0, d0, q
+                eor     d1, d1, q
+                eor     d2, d2, q
+                eor     d3, d3, q
+                eor     d4, d4, q
+                eor     d5, d5, q
+                eor     d6, d6, q
+                eor     d7, d7, q
+                and     q, q, #0x1FF
+                eor     d8, d8, q
+
+// Write back the result and return
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
@@ -1,0 +1,613 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Square modulo p_521, z := (x^2) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_sqr_p521 (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_sqr_p521
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define b0 x6
+#define b1 x7
+#define b2 x8
+#define b3 x9
+
+#define s0 x10
+#define s1 x11
+#define s2 x12
+#define s3 x13
+#define s4 x14
+#define s5 x15
+#define s6 x16
+#define s7 x17
+
+#define c  x19
+#define h  x20
+#define l  x21
+#define t  x22
+#define u  x23
+#define v  x24
+
+// Aliased to earlier ones we no longer need
+
+#define d0 x2
+#define d1 x3
+#define d2 x4
+#define d3 x5
+#define d4 x6
+#define d5 x7
+#define d6 x8
+#define d7 x9
+#define d8 x10
+
+bignum_sqr_p521:
+
+// Save registers
+
+                stp     x19, x20, [sp, #-16]!
+                stp     x21, x22, [sp, #-16]!
+                stp     x23, x24, [sp, #-16]!
+
+// Load all the inputs first
+
+                ldp     a0, a1, [x]
+                ldp     a2, a3, [x, #16]
+                ldp     b0, b1, [x, #32]
+                ldp     b2, b3, [x, #48]
+
+// Square the upper half with a register-renamed variant of bignum_sqr_4_8
+
+                mul     s2, b0, b2
+                mul     s7, b1, b3
+                umulh   t, b0, b2
+                subs    u, b0, b1
+                cneg    u, u, cc
+                csetm   s1, cc
+                subs    s0, b3, b2
+                cneg    s0, s0, cc
+                mul     s6, u, s0
+                umulh   s0, u, s0
+                cinv    s1, s1, cc
+                eor     s6, s6, s1
+                eor     s0, s0, s1
+                adds    s3, s2, t
+                adc     t, t, xzr
+                umulh   u, b1, b3
+                adds    s3, s3, s7
+                adcs    t, t, u
+                adc     u, u, xzr
+                adds    t, t, s7
+                adc     u, u, xzr
+                cmn     s1, #0x1
+                adcs    s3, s3, s6
+                adcs    t, t, s0
+                adc     u, u, s1
+                adds    s2, s2, s2
+                adcs    s3, s3, s3
+                adcs    t, t, t
+                adcs    u, u, u
+                adc     c, xzr, xzr
+                mul     s0, b0, b0
+                mul     s6, b1, b1
+                mul     l, b0, b1
+                umulh   s1, b0, b0
+                umulh   s7, b1, b1
+                umulh   h, b0, b1
+                adds    s1, s1, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s1, s1, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s2, s2, s6
+                adcs    s3, s3, s7
+                adcs    t, t, xzr
+                adcs    u, u, xzr
+                adc     c, c, xzr
+                mul     s4, b2, b2
+                mul     s6, b3, b3
+                mul     l, b2, b3
+                umulh   s5, b2, b2
+                umulh   s7, b3, b3
+                umulh   h, b2, b3
+                adds    s5, s5, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s5, s5, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s4, s4, t
+                adcs    s5, s5, u
+                adcs    s6, s6, c
+                adc     s7, s7, xzr
+
+// Augment the high part with the contribution from the top little word C.
+// If we write the input as 2^512 * C + x then we are otherwise just doing
+// x^2, so we need to add to the high part 2^512 * C^2 + (2 * C) * x.
+// Accumulate it as [c;s7;...;s0] = H'. Since 2 * C is only 10 bits long
+// we multiply 52-bit chunks of the x digits by 2 * C and solve the overlap
+// with non-overflowing addition to get 52-bit chunks of the result with
+// similar alignment. Then we stitch these back together and add them into
+// the running total. This is quite a bit of palaver, but it avoids using
+// the standard 2-part multiplications involving umulh, and on target
+// microarchitectures seems to improve performance by about 5%. We could
+// equally well use 53 or 54 since they are still <= 64 - 10, but below
+// 52 we would end up using more multiplications.
+
+                ldr     c, [x, #64]
+                add     u, c, c
+                mul     c, c, c
+
+// 0 * 52 = 64 * 0 + 0
+
+                and     l, a0, #0x000fffffffffffff
+                mul     l, u, l
+
+// 1 * 52 = 64 * 0 + 52
+
+                extr    h, a1, a0, #52
+                and     h, h, #0x000fffffffffffff
+                mul     h, u, h
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #12
+                adds    s0, s0, t
+
+// 2 * 52 = 64 * 1 + 40
+
+                extr    l, a2, a1, #40
+                and     l, l, #0x000fffffffffffff
+                mul     l, u, l
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #24
+                adcs    s1, s1, t
+
+// 3 * 52 = 64 * 2 + 28
+
+                extr    h, a3, a2, #28
+                and     h, h, #0x000fffffffffffff
+                mul     h, u, h
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #36
+                adcs    s2, s2, t
+
+// 4 * 52 = 64 * 3 + 16
+
+                extr    l, b0, a3, #16
+                and     l, l, #0x000fffffffffffff
+                mul     l, u, l
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #48
+                adcs    s3, s3, t
+
+// 5 * 52 = 64 * 4 + 4
+
+                lsr     h, b0, #4
+                and     h, h, #0x000fffffffffffff
+                mul     h, u, h
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    v, h, l, #60
+
+// 6 * 52 = 64 * 4 + 56
+
+                extr    l, b1, b0, #56
+                and     l, l, #0x000fffffffffffff
+                mul     l, u, l
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     v, v, #8
+                extr    t, l, v, #8
+                adcs    s4, s4, t
+
+// 7 * 52 = 64 * 5 + 44
+
+                extr    h, b2, b1, #44
+                and     h, h, #0x000fffffffffffff
+                mul     h, u, h
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #20
+                adcs    s5, s5, t
+
+// 8 * 52 = 64 * 6 + 32
+
+                extr    l, b3, b2, #32
+                and     l, l, #0x000fffffffffffff
+                mul     l, u, l
+                lsr     t, h, #52
+                add     l, l, t
+
+                lsl     h, h, #12
+                extr    t, l, h, #32
+                adcs    s6, s6, t
+
+// 9 * 52 = 64 * 7 + 20
+
+                lsr     h, b3, #20
+                mul     h, u, h
+                lsr     t, l, #52
+                add     h, h, t
+
+                lsl     l, l, #12
+                extr    t, h, l, #44
+                adcs    s7, s7, t
+
+// Top word
+
+                lsr     h, h, #44
+                adc     c, c, h
+
+// Rotate [c;s7;...;s0] before storing in the buffer.
+// We want to add 2^512 * H', which splitting H' at bit 9 is
+// 2^521 * H_top + 2^512 * H_bot == 2^512 * H_bot + H_top (mod p_521)
+
+                extr    l, s1, s0, #9
+                extr    h, s2, s1, #9
+                stp     l, h, [z]
+
+                extr    l, s3, s2, #9
+                extr    h, s4, s3, #9
+                stp     l, h, [z, #16]
+
+                extr    l, s5, s4, #9
+                extr    h, s6, s5, #9
+                stp     l, h, [z, #32]
+
+                extr    l, s7, s6, #9
+                extr    h, c, s7, #9
+                stp     l, h, [z, #48]
+
+                and     t, s0, #0x1FF
+                lsr     c, c, #9
+                add     t, t, c
+                str     t, [z, #64]
+
+// Square the lower half with an analogous variant of bignum_sqr_4_8
+
+                mul     s2, a0, a2
+                mul     s7, a1, a3
+                umulh   t, a0, a2
+                subs    u, a0, a1
+                cneg    u, u, cc
+                csetm   s1, cc
+                subs    s0, a3, a2
+                cneg    s0, s0, cc
+                mul     s6, u, s0
+                umulh   s0, u, s0
+                cinv    s1, s1, cc
+                eor     s6, s6, s1
+                eor     s0, s0, s1
+                adds    s3, s2, t
+                adc     t, t, xzr
+                umulh   u, a1, a3
+                adds    s3, s3, s7
+                adcs    t, t, u
+                adc     u, u, xzr
+                adds    t, t, s7
+                adc     u, u, xzr
+                cmn     s1, #0x1
+                adcs    s3, s3, s6
+                adcs    t, t, s0
+                adc     u, u, s1
+                adds    s2, s2, s2
+                adcs    s3, s3, s3
+                adcs    t, t, t
+                adcs    u, u, u
+                adc     c, xzr, xzr
+                mul     s0, a0, a0
+                mul     s6, a1, a1
+                mul     l, a0, a1
+                umulh   s1, a0, a0
+                umulh   s7, a1, a1
+                umulh   h, a0, a1
+                adds    s1, s1, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s1, s1, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s2, s2, s6
+                adcs    s3, s3, s7
+                adcs    t, t, xzr
+                adcs    u, u, xzr
+                adc     c, c, xzr
+                mul     s4, a2, a2
+                mul     s6, a3, a3
+                mul     l, a2, a3
+                umulh   s5, a2, a2
+                umulh   s7, a3, a3
+                umulh   h, a2, a3
+                adds    s5, s5, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s5, s5, l
+                adcs    s6, s6, h
+                adc     s7, s7, xzr
+                adds    s4, s4, t
+                adcs    s5, s5, u
+                adcs    s6, s6, c
+                adc     s7, s7, xzr
+
+// Add it directly to the existing buffer
+
+                ldp     l, h, [z]
+                adds    l, l, s0
+                adcs    h, h, s1
+                stp     l, h, [z]
+
+                ldp     l, h, [z, #16]
+                adcs    l, l, s2
+                adcs    h, h, s3
+                stp     l, h, [z, #16]
+
+                ldp     l, h, [z, #32]
+                adcs    l, l, s4
+                adcs    h, h, s5
+                stp     l, h, [z, #32]
+
+                ldp     l, h, [z, #48]
+                adcs    l, l, s6
+                adcs    h, h, s7
+                stp     l, h, [z, #48]
+
+                ldr     t, [z, #64]
+                adc     t, t, xzr
+                str     t, [z, #64]
+
+// Now get the cross-product in [s7,...,s0] with variant of bignum_mul_4_8
+
+                mul     s0, a0, b0
+                mul     s4, a1, b1
+                mul     s5, a2, b2
+                mul     s6, a3, b3
+                umulh   s7, a0, b0
+                adds    s4, s4, s7
+                umulh   s7, a1, b1
+                adcs    s5, s5, s7
+                umulh   s7, a2, b2
+                adcs    s6, s6, s7
+                umulh   s7, a3, b3
+                adc     s7, s7, xzr
+                adds    s1, s4, s0
+                adcs    s4, s5, s4
+                adcs    s5, s6, s5
+                adcs    s6, s7, s6
+                adc     s7, xzr, s7
+                adds    s2, s4, s0
+                adcs    s3, s5, s1
+                adcs    s4, s6, s4
+                adcs    s5, s7, s5
+                adcs    s6, xzr, s6
+                adc     s7, xzr, s7
+                subs    t, a2, a3
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b3, b2
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s5, s5, l
+                eor     h, h, c
+                adcs    s6, s6, h
+                adc     s7, s7, c
+                subs    t, a0, a1
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b1, b0
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s1, s1, l
+                eor     h, h, c
+                adcs    s2, s2, h
+                adcs    s3, s3, c
+                adcs    s4, s4, c
+                adcs    s5, s5, c
+                adcs    s6, s6, c
+                adc     s7, s7, c
+                subs    t, a1, a3
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b3, b1
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s4, s4, l
+                eor     h, h, c
+                adcs    s5, s5, h
+                adcs    s6, s6, c
+                adc     s7, s7, c
+                subs    t, a0, a2
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b2, b0
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s2, s2, l
+                eor     h, h, c
+                adcs    s3, s3, h
+                adcs    s4, s4, c
+                adcs    s5, s5, c
+                adcs    s6, s6, c
+                adc     s7, s7, c
+                subs    t, a0, a3
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b3, b0
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s3, s3, l
+                eor     h, h, c
+                adcs    s4, s4, h
+                adcs    s5, s5, c
+                adcs    s6, s6, c
+                adc     s7, s7, c
+                subs    t, a1, a2
+                cneg    t, t, cc
+                csetm   c, cc
+                subs    h, b2, b1
+                cneg    h, h, cc
+                mul     l, t, h
+                umulh   h, t, h
+                cinv    c, c, cc
+                cmn     c, #0x1
+                eor     l, l, c
+                adcs    s3, s3, l
+                eor     h, h, c
+                adcs    s4, s4, h
+                adcs    s5, s5, c
+                adcs    s6, s6, c
+                adc     s7, s7, c
+
+// Let the cross product be M. We want to add 2^256 * 2 * M to the buffer
+// Split M into M_top (248 bits) and M_bot (264 bits), so we add
+// 2^521 * M_top + 2^257 * M_bot == 2^257 * M_bot + M_top (mod p_521)
+// Accumulate the (non-reduced in general) 9-word answer [d8;...;d0]
+// As this sum is built, accumulate t = AND of words d7...d1 to help
+// in condensing the carry chain in the comparison that comes next
+
+                ldp     l, h, [z]
+                extr    d0, s5, s4, #8
+                adds    d0, d0, l
+                extr    d1, s6, s5, #8
+                adcs    d1, d1, h
+
+                ldp     l, h, [z, #16]
+                extr    d2, s7, s6, #8
+                adcs    d2, d2, l
+                and     t, d1, d2
+                lsr     d3, s7, #8
+                adcs    d3, d3, h
+                and     t, t, d3
+
+                ldp     l, h, [z, #32]
+                lsl     d4, s0, #1
+                adcs    d4, d4, l
+                and     t, t, d4
+                extr    d5, s1, s0, #63
+                adcs    d5, d5, h
+                and     t, t, d5
+
+                ldp     l, h, [z, #48]
+                extr    d6, s2, s1, #63
+                adcs    d6, d6, l
+                and     t, t, d6
+                extr    d7, s3, s2, #63
+                adcs    d7, d7, h
+                and     t, t, d7
+
+                ldr     l, [z, #64]
+                extr    d8, s4, s3, #63
+                and     d8, d8, #0x1FF
+                adc     d8, l, d8
+
+// Extract the high part h and mask off the low part l = [d8;d7;...;d0]
+// but stuff d8 with 1 bits at the left to ease a comparison below
+
+                lsr     h, d8, #9
+                orr     d8, d8, #~0x1FF
+
+// Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
+// happen if digits d7,...d1 are all 1s, we use the AND of them "t" to
+// condense the carry chain, and since we stuffed 1 bits into d8 we get
+// the result in CF without an additional comparison.
+
+                subs    xzr, xzr, xzr
+                adcs    xzr, d0, h
+                adcs    xzr, t, xzr
+                adcs    xzr, d8, xzr
+
+// Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
+// while otherwise we want just h + l. So mask h + l + CF to 521 bits.
+// This masking also gets rid of the stuffing with 1s we did above.
+
+                adcs    d0, d0, h
+                adcs    d1, d1, xzr
+                adcs    d2, d2, xzr
+                adcs    d3, d3, xzr
+                adcs    d4, d4, xzr
+                adcs    d5, d5, xzr
+                adcs    d6, d6, xzr
+                adcs    d7, d7, xzr
+                adc     d8, d8, xzr
+                and     d8, d8, #0x1FF
+
+// Store the final result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+
+// Restore regs and return
+
+                ldp     x23, x24, [sp], #16
+                ldp     x21, x22, [sp], #16
+                ldp     x19, x20, [sp], #16
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
@@ -1,0 +1,372 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Square modulo p_521, z := (x^2) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_sqr_p521_alt (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_sqr_p521_alt
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+#define a4 x6
+#define a5 x7
+#define a6 x8
+#define a7 x9
+#define a8 x1 // Overwrites input argument at last load
+
+#define l x10
+
+#define u0 x11
+#define u1 x12
+#define u2 x13
+#define u3 x14
+#define u4 x15
+#define u5 x16
+#define u6 x17
+#define u7 x19
+#define u8 x20
+#define u9 x21
+#define u10 x22
+#define u11 x23
+#define u12 x24
+#define u13 x25
+#define u14 x26
+#define u15 x27
+#define u16 x29
+
+bignum_sqr_p521_alt:
+
+// It's convenient to have more registers to play with
+
+                stp     x19, x20, [sp, #-16]!
+                stp     x21, x22, [sp, #-16]!
+                stp     x23, x24, [sp, #-16]!
+                stp     x25, x26, [sp, #-16]!
+                stp     x27, x29, [sp, #-16]!
+
+// Load low 8 elements as [a7;a6;a5;a4;a3;a2;a1;a0], set up an initial
+// window [u8;u7;u6;u5;u4;u3;u2;u1] =  10 + 20 + 30 + 40 + 50 + 60 + 70
+
+                ldp     a0, a1, [x]
+
+                mul     u1, a0, a1
+                umulh   u2, a0, a1
+
+                ldp     a2, a3, [x, #16]
+
+                mul     l, a0, a2
+                umulh   u3, a0, a2
+                adds    u2, u2, l
+
+                ldp     a4, a5, [x, #32]
+
+                mul     l, a0, a3
+                umulh   u4, a0, a3
+                adcs    u3, u3, l
+
+                ldp     a6, a7, [x, #48]
+
+                mul     l, a0, a4
+                umulh   u5, a0, a4
+                adcs    u4, u4, l
+
+                mul     l, a0, a5
+                umulh   u6, a0, a5
+                adcs    u5, u5, l
+
+                mul     l, a0, a6
+                umulh   u7, a0, a6
+                adcs    u6, u6, l
+
+                mul     l, a0, a7
+                umulh   u8, a0, a7
+                adcs    u7, u7, l
+
+                adc     u8, u8, xzr
+
+// Add in the next diagonal = 21 + 31 + 41 + 51 + 61 + 71 + 54
+
+                mul     l, a1, a2
+                adds    u3, u3, l
+                mul     l, a1, a3
+                adcs    u4, u4, l
+                mul     l, a1, a4
+                adcs    u5, u5, l
+                mul     l, a1, a5
+                adcs    u6, u6, l
+                mul     l, a1, a6
+                adcs    u7, u7, l
+                mul     l, a1, a7
+                adcs    u8, u8, l
+                cset    u9, cs
+
+                umulh   l, a1, a2
+                adds    u4, u4, l
+                umulh   l, a1, a3
+                adcs    u5, u5, l
+                umulh   l, a1, a4
+                adcs    u6, u6, l
+                umulh   l, a1, a5
+                adcs    u7, u7, l
+                umulh   l, a1, a6
+                adcs    u8, u8, l
+                umulh   l, a1, a7
+                adc     u9, u9, l
+                mul     l, a4, a5
+                umulh   u10, a4, a5
+                adds    u9, u9, l
+                adc     u10, u10, xzr
+
+// And the next one = 32 + 42 + 52 + 62 + 72 + 64 + 65
+
+                mul     l, a2, a3
+                adds    u5, u5, l
+                mul     l, a2, a4
+                adcs    u6, u6, l
+                mul     l, a2, a5
+                adcs    u7, u7, l
+                mul     l, a2, a6
+                adcs    u8, u8, l
+                mul     l, a2, a7
+                adcs    u9, u9, l
+                mul     l, a4, a6
+                adcs    u10, u10, l
+                cset    u11, cs
+
+                umulh   l, a2, a3
+                adds    u6, u6, l
+                umulh   l, a2, a4
+                adcs    u7, u7, l
+                umulh   l, a2, a5
+                adcs    u8, u8, l
+                umulh   l, a2, a6
+                adcs    u9, u9, l
+                umulh   l, a2, a7
+                adcs    u10, u10, l
+                umulh   l, a4, a6
+                adc     u11, u11, l
+                mul     l, a5, a6
+                umulh   u12, a5, a6
+                adds    u11, u11, l
+                adc     u12, u12, xzr
+
+// And the final one = 43 + 53 + 63 + 73 + 74 + 75 + 76
+
+                mul     l, a3, a4
+                adds    u7, u7, l
+                mul     l, a3, a5
+                adcs    u8, u8, l
+                mul     l, a3, a6
+                adcs    u9, u9, l
+                mul     l, a3, a7
+                adcs    u10, u10, l
+                mul     l, a4, a7
+                adcs    u11, u11, l
+                mul     l, a5, a7
+                adcs    u12, u12, l
+                cset    u13, cs
+
+                umulh   l, a3, a4
+                adds    u8, u8, l
+                umulh   l, a3, a5
+                adcs    u9, u9, l
+                umulh   l, a3, a6
+                adcs    u10, u10, l
+                umulh   l, a3, a7
+                adcs    u11, u11, l
+                umulh   l, a4, a7
+                adcs    u12, u12, l
+                umulh   l, a5, a7
+                adc     u13, u13, l
+                mul     l, a6, a7
+                umulh   u14, a6, a7
+                adds    u13, u13, l
+                adc     u14, u14, xzr
+
+// Double that, with u15 holding the top carry
+
+                adds    u1, u1, u1
+                adcs    u2, u2, u2
+                adcs    u3, u3, u3
+                adcs    u4, u4, u4
+                adcs    u5, u5, u5
+                adcs    u6, u6, u6
+                adcs    u7, u7, u7
+                adcs    u8, u8, u8
+                adcs    u9, u9, u9
+                adcs    u10, u10, u10
+                adcs    u11, u11, u11
+                adcs    u12, u12, u12
+                adcs    u13, u13, u13
+                adcs    u14, u14, u14
+                cset    u15, cs
+
+// Add the homogeneous terms 00 + 11 + 22 + 33 + 44 + 55 + 66 + 77
+
+                umulh   l, a0, a0
+                mul     u0, a0, a0
+                adds    u1, u1, l
+
+                mul     l, a1, a1
+                adcs    u2, u2, l
+                umulh   l, a1, a1
+                adcs    u3, u3, l
+
+                mul     l, a2, a2
+                adcs    u4, u4, l
+                umulh   l, a2, a2
+                adcs    u5, u5, l
+
+                mul     l, a3, a3
+                adcs    u6, u6, l
+                umulh   l, a3, a3
+                adcs    u7, u7, l
+
+                mul     l, a4, a4
+                adcs    u8, u8, l
+                umulh   l, a4, a4
+                adcs    u9, u9, l
+
+                mul     l, a5, a5
+                adcs    u10, u10, l
+                umulh   l, a5, a5
+                adcs    u11, u11, l
+
+                mul     l, a6, a6
+                adcs    u12, u12, l
+                umulh   l, a6, a6
+                adcs    u13, u13, l
+
+                mul     l, a7, a7
+                adcs    u14, u14, l
+                umulh   l, a7, a7
+                adc     u15, u15, l
+
+// Now load in the top digit a8, and also set up its double and square
+
+                ldr     a8, [x, #64]
+                mul     u16, a8, a8
+                add     a8, a8, a8
+
+// Add a8 * [a7;...;a0] into the top of the buffer
+
+                mul     l, a8, a0
+                adds    u8, u8, l
+                mul     l, a8, a1
+                adcs    u9, u9, l
+                mul     l, a8, a2
+                adcs    u10, u10, l
+                mul     l, a8, a3
+                adcs    u11, u11, l
+                mul     l, a8, a4
+                adcs    u12, u12, l
+                mul     l, a8, a5
+                adcs    u13, u13, l
+                mul     l, a8, a6
+                adcs    u14, u14, l
+                mul     l, a8, a7
+                adcs    u15, u15, l
+                adc     u16, u16, xzr
+
+                umulh   l, a8, a0
+                adds    u9, u9, l
+                umulh   l, a8, a1
+                adcs    u10, u10, l
+                umulh   l, a8, a2
+                adcs    u11, u11, l
+                umulh   l, a8, a3
+                adcs    u12, u12, l
+                umulh   l, a8, a4
+                adcs    u13, u13, l
+                umulh   l, a8, a5
+                adcs    u14, u14, l
+                umulh   l, a8, a6
+                adcs    u15, u15, l
+                umulh   l, a8, a7
+                adc     u16, u16, l
+
+// Now we have the full product, which we consider as
+// 2^521 * h + l. Form h + l + 1
+
+                subs    xzr, xzr, xzr
+                extr    l, u9, u8, #9
+                adcs    u0, u0, l
+                extr    l, u10, u9, #9
+                adcs    u1, u1, l
+                extr    l, u11, u10, #9
+                adcs    u2, u2, l
+                extr    l, u12, u11, #9
+                adcs    u3, u3, l
+                extr    l, u13, u12, #9
+                adcs    u4, u4, l
+                extr    l, u14, u13, #9
+                adcs    u5, u5, l
+                extr    l, u15, u14, #9
+                adcs    u6, u6, l
+                extr    l, u16, u15, #9
+                adcs    u7, u7, l
+                orr     u8, u8, #~0x1FF
+                lsr     l, u16, #9
+                adcs    u8, u8, l
+
+// Now CF is set if h + l + 1 >= 2^521, which means it's already
+// the answer, while if ~CF the answer is h + l so we should subtract
+// 1 (all considered in 521 bits). Hence subtract ~CF and mask.
+
+                sbcs    u0, u0, xzr
+                sbcs    u1, u1, xzr
+                sbcs    u2, u2, xzr
+                sbcs    u3, u3, xzr
+                sbcs    u4, u4, xzr
+                sbcs    u5, u5, xzr
+                sbcs    u6, u6, xzr
+                sbcs    u7, u7, xzr
+                sbc     u8, u8, xzr
+                and     u8, u8, #0x1FF
+
+// Store back digits of final result
+
+                stp     u0, u1, [z]
+                stp     u2, u3, [z, #16]
+                stp     u4, u5, [z, #32]
+                stp     u6, u7, [z, #48]
+                str     u8, [z, #64]
+
+// Restore registers and return
+
+                ldp     x27, x29, [sp], #16
+                ldp     x25, x26, [sp], #16
+                ldp     x23, x24, [sp], #16
+                ldp     x21, x22, [sp], #16
+                ldp     x19, x20, [sp], #16
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Subtract modulo p_521, z := (x - y) mod p_521
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_sub_p521
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_sub_p521
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+#define y x2
+#define h x3
+#define l x4
+#define d0 x5
+#define d1 x6
+#define d2 x7
+#define d3 x8
+#define d4 x9
+#define d5 x10
+#define d6 x11
+#define d7 x12
+#define d8 x13
+
+
+bignum_sub_p521:
+
+// First just subtract the numbers as [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x - y
+
+                ldp     d0, d1, [x]
+                ldp     l, h, [y]
+                subs    d0, d0, l
+                sbcs    d1, d1, h
+                ldp     d2, d3, [x, #16]
+                ldp     l, h, [y, #16]
+                sbcs    d2, d2, l
+                sbcs    d3, d3, h
+                ldp     d4, d5, [x, #32]
+                ldp     l, h, [y, #32]
+                sbcs    d4, d4, l
+                sbcs    d5, d5, h
+                ldp     d6, d7, [x, #48]
+                ldp     l, h, [y, #48]
+                sbcs    d6, d6, l
+                sbcs    d7, d7, h
+                ldr     d8, [x, #64]
+                ldr     l, [y, #64]
+                sbcs    d8, d8, l
+
+// Now if x < y we want (x - y) + p_521 == (x - y) - 1 (mod 2^521)
+// Otherwise we just want the existing x - y result. So subtract
+// 1 iff the initial subtraction carried, then mask to 521 bits.
+
+                sbcs    d0, d0, xzr
+                sbcs    d1, d1, xzr
+                sbcs    d2, d2, xzr
+                sbcs    d3, d3, xzr
+                sbcs    d4, d4, xzr
+                sbcs    d5, d5, xzr
+                sbcs    d6, d6, xzr
+                sbcs    d7, d7, xzr
+                sbcs    d8, d8, xzr
+                and     d8, d8, #0x1FF
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert to Montgomery form z := (2^576 * x) mod p_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_tomont_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_tomont_p521
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define h x2
+#define t x3
+#define d0 x4
+#define d1 x5
+#define d2 x6
+#define d3 x7
+#define d4 x8
+#define d5 x9
+#define d6 x10
+#define d7 x11
+#define d8 x12
+
+bignum_tomont_p521:
+
+// Load top digit first and get its upper bits in h so that we
+// separate out x = 2^521 * H + L with h = H. Now x mod p_521 =
+// (H + L) mod p_521 = if H + L >= p_521 then H + L - p_521 else H + L.
+
+                ldr     d8, [x, #64]
+                lsr     h, d8, #9
+
+// Load in the other digits and decide whether H + L >= p_521. This is
+// equivalent to H + L + 1 >= 2^521, and since this can only happen if
+// digits d7,...,d1 consist entirely of 1 bits, we can condense the
+// carry chain by ANDing digits together, perhaps reducing its latency.
+// This condenses only three pairs; the payoff beyond that seems limited.
+// By stuffing in 1 bits from 521 position upwards, get CF directly
+
+                subs    xzr, xzr, xzr
+                ldp     d0, d1, [x]
+                adcs    xzr, d0, h
+                adcs    xzr, d1, xzr
+                ldp     d2, d3, [x, #16]
+                and     t, d2, d3
+                adcs    xzr, t, xzr
+                ldp     d4, d5, [x, #32]
+                and     t, d4, d5
+                adcs    xzr, t, xzr
+                ldp     d6, d7, [x, #48]
+                and     t, d6, d7
+                adcs    xzr, t, xzr
+                orr     t, d8, #~0x1FF
+                adcs    t, t, xzr
+
+// Now H + L >= p_521 <=> H + L + 1 >= 2^521 <=> CF from this comparison.
+// So if CF is set we want (H + L) - p_521 = (H + L + 1) - 2^521
+// while otherwise we want just H + L. So mask H + L + CF to 521 bits.
+
+                adcs    d0, d0, h
+                adcs    d1, d1, xzr
+                adcs    d2, d2, xzr
+                adcs    d3, d3, xzr
+                adcs    d4, d4, xzr
+                adcs    d5, d5, xzr
+                adcs    d6, d6, xzr
+                adcs    d7, d7, xzr
+                adc     d8, d8, xzr
+
+// So far, this is just a modular reduction as in bignum_mod_p521_9,
+// except that the final masking of d8 is skipped since that comes out
+// in the wash anyway from the next block, which is the Montgomery map,
+// multiplying by 2^576 modulo p_521. Because 2^521 == 1 (mod p_521)
+// this is just rotation left by 576 - 521 = 55 bits. To rotate in a
+// right-to-left fashion, which might blend better with the carry
+// chain above, the digit register indices themselves get shuffled up.
+
+                lsl     t, d0, #55
+                extr    d0, d1, d0, #9
+                extr    d1, d2, d1, #9
+                extr    d2, d3, d2, #9
+                extr    d3, d4, d3, #9
+                extr    d4, d5, d4, #9
+                extr    d5, d6, d5, #9
+                extr    d6, d7, d6, #9
+                extr    d7, d8, d7, #9
+                lsr     d8, d7, #9
+                orr     t, t, d8
+                and     d7, d7, #0x1FF
+
+// Store the result from the shuffled registers [d7;d6;...;d1;d0;t]
+
+                stp     t, d0, [z]
+                stp     d1, d2, [z, #16]
+                stp     d3, d4, [z, #32]
+                stp     d5, d6, [z, #48]
+                str     d7, [z, #64]
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Triple modulo p_521, z := (3 * x) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_triple_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_triple_p521
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define h x2
+#define l x3
+
+#define d0 x4
+#define d1 x5
+#define d2 x6
+#define d3 x7
+#define d4 x8
+#define d5 x9
+#define d6 x10
+#define d7 x11
+#define d8 x12
+
+
+bignum_triple_p521:
+
+// Pick out top bit to wrap to the zero position in the doubling step
+
+                ldr     d8, [x, #64]
+                lsl     l, d8, #55
+
+// Rotate left to get x' == 2 * x (mod p_521) and add to x + 1 (carryin) to get
+// s = [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x + x' + 1 == 3 * x + 1 (mod p_521)
+
+                subs    xzr, xzr, xzr
+
+                ldp     d0, d1, [x]
+                extr    l, d0, l, #63
+                extr    h, d1, d0, #63
+                adcs    d0, d0, l
+
+                ldp     d2, d3, [x, #16]
+                extr    l, d2, d1, #63
+                adcs    d1, d1, h
+                extr    h, d3, d2, #63
+                adcs    d2, d2, l
+
+                ldp     d4, d5, [x, #32]
+                extr    l, d4, d3, #63
+                adcs    d3, d3, h
+                extr    h, d5, d4, #63
+                adcs    d4, d4, l
+
+                ldp     d6, d7, [x, #48]
+                extr    l, d6, d5, #63
+                adcs    d5, d5, h
+                extr    h, d7, d6, #63
+                adcs    d6, d6, l
+
+                extr    l, d8, d7, #63
+                adcs    d7, d7, h
+                and     l, l, #0x1FF
+                adcs    d8, d8, l
+
+// We know x, x' < p_521 (they are the same bits except for the positions)
+// so x + x' + 1 <= 2 * (p_521 - 1) + 1 < 2 * p_521.
+// Note that x + x' >= p_521 <=> s = x + x' + 1 >= 2^521
+// Set CF <=> s = x + x' + 1 >= 2^521 and make it a mask in l as well
+
+                subs    l, d8, #512
+                csetm   l, cs
+
+// Now if CF is set (and l is all 1s), we want (x + x') - p_521 = s - 2^521
+// while otherwise we want x + x' = s - 1 (from existing CF, which is nice)
+
+                sbcs    d0, d0, xzr
+                and     l, l, #512
+                sbcs    d1, d1, xzr
+                sbcs    d2, d2, xzr
+                sbcs    d3, d3, xzr
+                sbcs    d4, d4, xzr
+                sbcs    d5, d5, xzr
+                sbcs    d6, d6, xzr
+                sbcs    d7, d7, xzr
+                sbc     d8, d8, l
+
+// Store the result
+
+                stp     d0, d1, [z]
+                stp     d2, d3, [z, #16]
+                stp     d4, d5, [z, #32]
+                stp     d6, d7, [z, #48]
+                str     d8, [z, #64]
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
@@ -1,0 +1,171 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply by a single word modulo p_384, z := (c * x) mod p_384, assuming
+// x reduced
+// Inputs c, x[6]; output z[6]
+//
+//    extern void bignum_cmul_p384_alt
+//     (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_cmul_p384_alt
+        .text
+
+#define z %rdi
+
+// Temporarily moved here for initial multiply
+#define x %rcx
+
+// Likewise this is thrown away after initial multiply
+#define m %rsi
+
+#define a %rax
+#define c %rcx
+#define d %rdx
+
+#define d0 %r8
+#define d1 %r9
+#define d2 %r10
+#define d3 %r11
+#define d4 %r12
+#define d5 %rsi
+
+// Multiplier again for second stage
+#define q %rcx
+
+#define ashort %eax
+#define dshort %edx
+
+#define cshort %ecx
+#define qshort %ecx
+
+bignum_cmul_p384_alt:
+
+// We seem to need (just!) one extra register, which we need to save and restore
+
+                pushq   %r12
+
+// Shuffle inputs (since we want %rdx for the high parts of products)
+
+                movq    %rdx, x
+
+// Multiply, accumulating the result as 2^384 * h + [d5;d4;d3;d2;d1;d0]
+// but actually immediately producing q = h + 1, our quotient approximation,
+// by adding 1 to it. Note that by hypothesis x is reduced mod p_384, so our
+// product is <= (2^64 - 1) * (p_384 - 1) and hence  h <= 2^64 - 2, meaning
+// there is no danger this addition of 1 could wrap.
+
+                movq    (x), a
+                mulq    m
+                movq    a, d0
+                movq    d, d1
+
+                movq    8(x), a
+                mulq    m
+                xorq    d2, d2
+                addq    a, d1
+                adcq    d, d2
+
+                movq    16(x), a
+                mulq    m
+                xorq    d3, d3
+                addq    a, d2
+                adcq    d, d3
+
+                movq    24(x), a
+                mulq    m
+                xorq    d4, d4
+                addq    a, d3
+                adcq    d, d4
+
+                movq    32(x), a
+                mulq    m
+                addq    a, d4
+                adcq    $0, d
+
+                movq    m, a
+                movq    d, d5
+                mulq     40(x)
+                movl    $1, qshort
+
+                addq    a, d5
+                adcq    d, q
+
+// It's easy to see -p_384 <= z - q * p_384 < p_384, so we just need to
+// subtract q * p_384 and then correct if that is negative by adding p_384.
+//
+// Write p_384 = 2^384 - r where r = 2^128 + 2^96 - 2^32 + 1
+//
+// We want z - q * (2^384 - r)
+//       = (2^384 * h + l) - q * (2^384 - r)
+//       = 2^384 * (h - q) + (l + q * r)
+//       = 2^384 * (-1) + (l + q * r)
+
+                movq    $0xffffffff00000001, a
+                mulq    q
+                addq    a, d0
+                adcq    d, d1
+                adcq    q, d2
+                movq    q, a
+                sbbq    c, c
+                movl    $0x00000000ffffffff, dshort
+                negq    c
+                mulq    d
+                addq    a, d1
+                adcq    d, d2
+                adcq    c, d3
+                adcq    $0, d4
+                adcq    $0, d5
+                sbbq    c, c
+                notq    c
+
+// The net c value is now the top word of the 7-word answer, hence will
+// be -1 if we need a corrective addition, 0 otherwise, usable as a mask.
+// Now use that mask for a masked addition of p_384, which again is in
+// fact done by a masked subtraction of 2^384 - p_384, so that we only
+// have three nonzero digits and so can avoid using another register.
+
+                movl    $0x00000000ffffffff, dshort
+                xorq    a, a
+                andq    c, d
+                subq    d, a
+                andq    $1, c
+
+                subq    a, d0
+                movq    d0, (z)
+                sbbq    d, d1
+                movq    d1, 8(z)
+                sbbq    c, d2
+                movq    d2, 16(z)
+                sbbq    $0, d3
+                movq    d3, 24(z)
+                sbbq    $0, d4
+                movq    d4, 32(z)
+                sbbq    $0, d5
+                movq    d5, 40(z)
+
+// Return
+
+                popq    %r12
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
@@ -1,0 +1,176 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
+// Input x[6]; output z[6]
+//
+//    extern void bignum_deamont_p384_alt
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Convert a 6-digit bignum x out of its (optionally almost) Montgomery form,
+// "almost" meaning any 6-digit input will work, with no range restriction.
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_deamont_p384_alt
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// Additional temps in the correction phase
+
+#define u %rax
+#define v %rcx
+#define w %rdx
+
+#define vshort %ecx
+
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing [d5;d4;d3;d2;d1] and re-using d0 as a
+// temporary internally, as well as %rax, %rcx and %rdx.
+// It is OK for d6 and d0 to be the same register (they often are)
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+//
+//       montreds(d6,d5,d4,d3,d2,d1,d0)
+
+#define montreds(d6,d5,d4,d3,d2,d1,d0)                                  \
+/* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
+                movq    d0, %rcx ;                                        \
+                shlq    $32, %rcx ;                                        \
+                addq    d0, %rcx ;                                        \
+/* Construct [%rax;%rdx;d0;-] = (2^384 - p_384) * w            */         \
+/* We know the lowest word will cancel so we can re-use d0   */         \
+/* and %rcx as temps.                                         */         \
+                movq    $0xffffffff00000001, %rax ;                        \
+                mulq    %rcx;                                            \
+                movq    %rdx, d0 ;                                        \
+                movq    $0x00000000ffffffff, %rax ;                        \
+                mulq    %rcx;                                            \
+                addq    %rax, d0 ;                                        \
+                movl    $0, %eax ;                                         \
+                adcq    %rcx, %rdx ;                                       \
+                adcl    %eax, %eax ;                                       \
+/* Now subtract that and add 2^384 * w                       */         \
+                subq    d0, d1 ;                                         \
+                sbbq    %rdx, d2 ;                                        \
+                sbbq    %rax, d3 ;                                        \
+                sbbq    $0, d4 ;                                          \
+                sbbq    $0, d5 ;                                          \
+                movq    %rcx, d6 ;                                        \
+                sbbq    $0, d6
+
+bignum_deamont_p384_alt:
+
+// Save more registers to play with
+
+        pushq   %r12
+        pushq   %r13
+
+// Set up an initial window [%r13,%r12,%r11,%r10,%r9,%r8] = x
+
+        movq    (x), %r8
+        movq    8(x), %r9
+        movq    16(x), %r10
+        movq    24(x), %r11
+        movq    32(x), %r12
+        movq    40(x), %r13
+
+// Montgomery reduce window 0
+
+        montreds(%r8,%r13,%r12,%r11,%r10,%r9,%r8)
+
+// Montgomery reduce window 1
+
+        montreds(%r9,%r8,%r13,%r12,%r11,%r10,%r9)
+
+// Montgomery reduce window 2
+
+        montreds(%r10,%r9,%r8,%r13,%r12,%r11,%r10)
+
+// Montgomery reduce window 3
+
+        montreds(%r11,%r10,%r9,%r8,%r13,%r12,%r11)
+
+// Montgomery reduce window 4
+
+        montreds(%r12,%r11,%r10,%r9,%r8,%r13,%r12)
+
+// Montgomery reduce window 5
+
+        montreds(%r13,%r12,%r11,%r10,%r9,%r8,%r13)
+
+// Do a test addition of dd = [%r13;%r12;%r11;%r10;%r9;%r8] and
+// 2^384 - p_384 = [0;0;0;1;v;u], hence setting CF iff
+// dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384.
+
+        movq    $0xffffffff00000001, u
+        movl    $0x00000000ffffffff, vshort
+
+        movq    %r8, w
+        addq    u, w
+        movq    %r9, w
+        adcq    v, w
+        movq    %r10, w
+        adcq    $1, w
+        movq    %r11, w
+        adcq    $0, w
+        movq    %r12, w
+        adcq    $0, w
+        movq    %r13, w
+        adcq    $0, w
+
+// Convert CF to a bitmask in w
+
+        sbbq    w, w
+
+// Masked addition of 2^384 - p_384, hence subtraction of p_384
+
+        andq    w, u
+        andq    w, v
+        andq    $1, w
+
+        addq   u, %r8
+        adcq   v, %r9
+        adcq   w, %r10
+        adcq   $0, %r11
+        adcq   $0, %r12
+        adcq   $0, %r13
+
+// Write back the result
+
+        movq    %r8, (z)
+        movq    %r9, 8(z)
+        movq    %r10, 16(z)
+        movq    %r11, 24(z)
+        movq    %r12, 32(z)
+        movq    %r13, 40(z)
+
+// Restore registers and return
+
+        popq    %r13
+        popq    %r12
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
@@ -1,0 +1,131 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
+// Input x[6]; output z[6]
+//
+//    extern void bignum_demont_p384_alt
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// This assumes the input is < p_384 for correctness. If this is not the case,
+// use the variant "bignum_deamont_p384" instead.
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_demont_p384_alt
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing [d5;d4;d3;d2;d1] and re-using d0 as a
+// temporary internally, as well as %rax, %rcx and %rdx.
+// It is OK for d6 and d0 to be the same register (they often are)
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+//
+//       montreds(d6,d5,d4,d3,d2,d1,d0)
+
+#define montreds(d6,d5,d4,d3,d2,d1,d0)                                  \
+/* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
+                movq    d0, %rcx ;                                        \
+                shlq    $32, %rcx ;                                        \
+                addq    d0, %rcx ;                                        \
+/* Construct [%rax;%rdx;d0;-] = (2^384 - p_384) * w            */         \
+/* We know the lowest word will cancel so we can re-use d0   */         \
+/* and %rcx as temps.                                         */         \
+                movq    $0xffffffff00000001, %rax ;                        \
+                mulq    %rcx;                                            \
+                movq    %rdx, d0 ;                                        \
+                movq    $0x00000000ffffffff, %rax ;                        \
+                mulq    %rcx;                                            \
+                addq    %rax, d0 ;                                        \
+                movl    $0, %eax ;                                         \
+                adcq    %rcx, %rdx ;                                       \
+                adcl    %eax, %eax ;                                       \
+/* Now subtract that and add 2^384 * w                       */         \
+                subq    d0, d1 ;                                         \
+                sbbq    %rdx, d2 ;                                        \
+                sbbq    %rax, d3 ;                                        \
+                sbbq    $0, d4 ;                                          \
+                sbbq    $0, d5 ;                                          \
+                movq    %rcx, d6 ;                                        \
+                sbbq    $0, d6
+
+bignum_demont_p384_alt:
+
+// Save more registers to play with
+
+        pushq   %r12
+        pushq   %r13
+
+// Set up an initial window [%r13,%r12,%r11,%r10,%r9,%r8] = x
+
+        movq    (x), %r8
+        movq    8(x), %r9
+        movq    16(x), %r10
+        movq    24(x), %r11
+        movq    32(x), %r12
+        movq    40(x), %r13
+
+// Montgomery reduce window 0
+
+        montreds(%r8,%r13,%r12,%r11,%r10,%r9,%r8)
+
+// Montgomery reduce window 1
+
+        montreds(%r9,%r8,%r13,%r12,%r11,%r10,%r9)
+
+// Montgomery reduce window 2
+
+        montreds(%r10,%r9,%r8,%r13,%r12,%r11,%r10)
+
+// Montgomery reduce window 3
+
+        montreds(%r11,%r10,%r9,%r8,%r13,%r12,%r11)
+
+// Montgomery reduce window 4
+
+        montreds(%r12,%r11,%r10,%r9,%r8,%r13,%r12)
+
+// Montgomery reduce window 5
+
+        montreds(%r13,%r12,%r11,%r10,%r9,%r8,%r13)
+
+// Write back the result
+
+        movq    %r8, (z)
+        movq    %r9, 8(z)
+        movq    %r10, 16(z)
+        movq    %r11, 24(z)
+        movq    %r12, 32(z)
+        movq    %r13, 40(z)
+
+// Restore registers and return
+
+        popq    %r13
+        popq    %r12
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
@@ -1,0 +1,226 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Reduce modulo group order, z := x mod n_384
+// Input x[k]; output z[6]
+//
+//    extern void bignum_mod_n384_alt
+//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//
+// Reduction is modulo the group order of the NIST curve P-384.
+//
+// Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_mod_n384_alt
+        .text
+
+#define z %rdi
+#define k %rsi
+#define x %rcx
+
+#define m0 %r8
+#define m1 %r9
+#define m2 %r10
+#define m3 %r11
+#define m4 %r12
+#define m5 %r13
+#define d %r14
+
+#define n0 %rax
+#define n1 %rbx
+#define n2 %rdx
+
+#define q %rbp
+#define c %rbx
+
+#define n0short %eax
+#define qshort %ebp
+
+bignum_mod_n384_alt:
+
+// Save extra registers
+
+                pushq   %rbp
+                pushq   %rbx
+                pushq   %r12
+                pushq   %r13
+                pushq   %r14
+
+// If the input is already <= 5 words long, go to a trivial "copy" path
+
+                cmpq    $6, k
+                jc      shortinput
+
+// Otherwise load the top 6 digits (top-down) and reduce k by 6
+
+                subq    $6, k
+                movq    40(%rdx,k,8), m5
+                movq    32(%rdx,k,8), m4
+                movq    24(%rdx,k,8), m3
+                movq    16(%rdx,k,8), m2
+                movq    8(%rdx,k,8), m1
+                movq    (%rdx,k,8), m0
+
+// Move x into another register to leave %rdx free for multiplies and use of n2
+
+                movq    %rdx, x
+
+// Reduce the top 6 digits mod n_384 (a conditional subtraction of n_384)
+
+                movq    $0x1313e695333ad68d, n0
+                movq    $0xa7e5f24db74f5885, n1
+                movq    $0x389cb27e0bc8d220, n2
+
+                addq    n0, m0
+                adcq    n1, m1
+                adcq    n2, m2
+                adcq    $0, m3
+                adcq    $0, m4
+                adcq    $0, m5
+                sbbq    d, d
+                notq    d
+                andq    d, n0
+                andq    d, n1
+                andq    d, n2
+                subq    n0, m0
+                sbbq    n1, m1
+                sbbq    n2, m2
+                sbbq    $0, m3
+                sbbq    $0, m4
+                sbbq    $0, m5
+
+// Now do (k-6) iterations of 7->6 word modular reduction
+
+                testq   k, k
+                jz      writeback
+
+loop:
+
+// Compute q = min (m5 + 1) (2^64 - 1)
+
+                movl    $1, qshort
+                addq    m5, q
+                sbbq    d, d
+                orq     d, q
+
+// Load the next digit so current m to reduce = [m5;m4;m3;m2;m1;m0;d]
+
+                movq    -8(x,k,8), d
+
+// Now form [m5;m4;m3;m2;m1;m0;d] = m - q * n_384
+
+                subq    q, m5
+                movq    $0x1313e695333ad68d, %rax
+                mulq    q
+                addq    %rax, d
+                adcq    %rdx, m0
+                sbbq    c, c
+                movq    $0xa7e5f24db74f5885, %rax
+                mulq    q
+                subq    c, %rdx
+                addq    %rax, m0
+                adcq    %rdx, m1
+                sbbq    c, c
+                movq    $0x389cb27e0bc8d220, n0
+                mulq    q
+                subq    c, %rdx
+                addq    %rax, m1
+                adcq    %rdx, m2
+                adcq    $0, m3
+                adcq    $0, m4
+                adcq    $0, m5
+
+// Now our top word m5 is either zero or all 1s. Use it for a masked
+// addition of n_384, which we can do by a *subtraction* of
+// 2^384 - n_384 from our portion
+
+                movq    $0x1313e695333ad68d, n0
+                andq    m5, n0
+                movq    $0xa7e5f24db74f5885, n1
+                andq    m5, n1
+                movq    $0x389cb27e0bc8d220, n2
+                andq    m5, n2
+
+                subq    n0, d
+                sbbq    n1, m0
+                sbbq    n2, m1
+                sbbq    $0, m2
+                sbbq    $0, m3
+                sbbq    $0, m4
+
+// Now shuffle registers up and loop
+
+                movq    m4, m5
+                movq    m3, m4
+                movq    m2, m3
+                movq    m1, m2
+                movq    m0, m1
+                movq    d, m0
+
+                decq    k
+                jnz     loop
+
+// Write back
+
+writeback:
+
+                movq    m0, (z)
+                movq    m1, 8(z)
+                movq    m2, 16(z)
+                movq    m3, 24(z)
+                movq    m4, 32(z)
+                movq    m5, 40(z)
+
+// Restore registers and return
+
+                popq    %r14
+                popq    %r13
+                popq    %r12
+                popq    %rbx
+                popq    %rbp
+                ret
+
+shortinput:
+
+                xorq    m0, m0
+                xorq    m1, m1
+                xorq    m2, m2
+                xorq    m3, m3
+                xorq    m4, m4
+                xorq    m5, m5
+
+                testq   k, k
+                jz      writeback
+                movq    (%rdx), m0
+                decq    k
+                jz      writeback
+                movq    8(%rdx), m1
+                decq    k
+                jz      writeback
+                movq    16(%rdx), m2
+                decq    k
+                jz      writeback
+                movq    24(%rdx), m3
+                decq    k
+                jz      writeback
+                movq    32(%rdx), m4
+                jmp     writeback
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
@@ -1,0 +1,225 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Reduce modulo field characteristic, z := x mod p_384
+// Input x[k]; output z[6]
+//
+//    extern void bignum_mod_p384_alt
+//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//
+// Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_mod_p384_alt
+        .text
+
+#define z %rdi
+#define k %rsi
+#define x %rcx
+
+#define m0 %r8
+#define m1 %r9
+#define m2 %r10
+#define m3 %r11
+#define m4 %r12
+#define m5 %r13
+#define d %r14
+
+#define n0 %rax
+#define n1 %rbx
+#define n2 %rdx
+
+// Both alias n1
+
+#define q %rbx
+#define c %rbx
+
+#define n0short %eax
+#define n1short %ebx
+#define qshort %ebx
+
+
+bignum_mod_p384_alt:
+
+// Save extra registers
+
+                pushq   %rbx
+                pushq   %r12
+                pushq   %r13
+                pushq   %r14
+
+// If the input is already <= 5 words long, go to a trivial "copy" path
+
+                cmpq    $6, k
+                jc      shortinput
+
+// Otherwise load the top 6 digits (top-down) and reduce k by 6
+
+                subq    $6, k
+                movq    40(%rdx,k,8), m5
+                movq    32(%rdx,k,8), m4
+                movq    24(%rdx,k,8), m3
+                movq    16(%rdx,k,8), m2
+                movq    8(%rdx,k,8), m1
+                movq    (%rdx,k,8), m0
+
+// Move x into another register to leave %rdx free for multiplies and use of n2
+
+                movq    %rdx, x
+
+// Reduce the top 6 digits mod p_384 (a conditional subtraction of p_384)
+
+                movl    $0x00000000ffffffff, n0short
+                movq    $0xffffffff00000000, n1
+                movq    $0xfffffffffffffffe, n2
+
+                subq    n0, m0
+                sbbq    n1, m1
+                sbbq    n2, m2
+                sbbq    $-1, m3
+                sbbq    $-1, m4
+                sbbq    $-1, m5
+
+                sbbq    d, d
+                andq    d, n0
+                andq    d, n1
+                andq    d, n2
+                addq    n0, m0
+                adcq    n1, m1
+                adcq    n2, m2
+                adcq    d, m3
+                adcq    d, m4
+                adcq    d, m5
+
+// Now do (k-6) iterations of 7->6 word modular reduction
+
+                testq   k, k
+                jz      writeback
+
+loop:
+
+// Compute q = min (m5 + 1) (2^64 - 1)
+
+                movl    $1, qshort
+                addq    m5, q
+                sbbq    d, d
+                orq     d, q
+
+// Load the next digit so current m to reduce = [m5;m4;m3;m2;m1;m0;d]
+
+                movq    -8(x,k,8), d
+
+// Now form [m5;m4;m3;m2;m1;m0;d] = m - q * p_384. To use an addition for
+// the main calculation we do (m - 2^384 * q) + q * (2^384 - p_384)
+// where 2^384 - p_384 = [0;0;0;1;0x00000000ffffffff;0xffffffff00000001].
+// The extra subtraction of 2^384 * q is the first instruction.
+
+                subq    q, m5
+                movq    $0xffffffff00000001, %rax
+                mulq    q
+                addq    %rax, d
+                adcq    %rdx, m0
+                adcq    q, m1
+                movq    q, %rax
+                sbbq    c, c
+                movl    $0x00000000ffffffff, %edx
+                negq    c
+                mulq    %rdx
+                addq    %rax, m0
+                adcq    %rdx, m1
+                adcq    c, m2
+                adcq    $0, m3
+                adcq    $0, m4
+                adcq    $0, m5
+
+// Now our top word m5 is either zero or all 1s. Use it for a masked
+// addition of p_384, which we can do by a *subtraction* of
+// 2^384 - p_384 from our portion
+
+                movq    $0xffffffff00000001, n0
+                andq    m5, n0
+                movl    $0x00000000ffffffff, n1short
+                andq    m5, n1
+                andq    $1, m5
+
+                subq    n0, d
+                sbbq    n1, m0
+                sbbq    m5, m1
+                sbbq    $0, m2
+                sbbq    $0, m3
+                sbbq    $0, m4
+
+// Now shuffle registers up and loop
+
+                movq    m4, m5
+                movq    m3, m4
+                movq    m2, m3
+                movq    m1, m2
+                movq    m0, m1
+                movq    d, m0
+
+                decq    k
+                jnz     loop
+
+// Write back
+
+writeback:
+
+                movq    m0, (z)
+                movq    m1, 8(z)
+                movq    m2, 16(z)
+                movq    m3, 24(z)
+                movq    m4, 32(z)
+                movq    m5, 40(z)
+
+// Restore registers and return
+
+                popq    %r14
+                popq    %r13
+                popq    %r12
+                popq    %rbx
+                ret
+
+shortinput:
+
+                xorq    m0, m0
+                xorq    m1, m1
+                xorq    m2, m2
+                xorq    m3, m3
+                xorq    m4, m4
+                xorq    m5, m5
+
+                testq   k, k
+                jz      writeback
+                movq    (%rdx), m0
+                decq    k
+                jz      writeback
+                movq    8(%rdx), m1
+                decq    k
+                jz      writeback
+                movq    16(%rdx), m2
+                decq    k
+                jz      writeback
+                movq    24(%rdx), m3
+                decq    k
+                jz      writeback
+                movq    32(%rdx), m4
+                jmp     writeback
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
@@ -1,0 +1,306 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^384) mod p_384
+// Inputs x[6], y[6]; output z[6]
+//
+//    extern void bignum_montmul_p384_alt
+//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//
+// Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
+// satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in
+// the "usual" case x < p_384 and y < p_384).
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// -----------------------------------------------------------------------------
+
+
+        .globl  bignum_montmul_p384_alt
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// We move the y argument here so we can use %rdx for multipliers
+
+#define y %rcx
+
+// Some temp registers for the last correction stage
+
+#define d %rax
+#define u %rdx
+#define v %rcx
+#define w %rbx
+
+// Add %rbx * m into a register-pair (high,low) maintaining consistent
+// carry-catching with carry (negated, as bitmask) and using %rax and %rdx
+// as temporaries
+
+#define mulpadd(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        subq    carry, %rdx ;             \
+        addq    %rax, low ;               \
+        adcq    %rdx, high ;              \
+        sbbq    carry, carry
+
+// Initial version assuming no carry-in
+
+#define mulpadi(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        addq    %rax, low ;               \
+        adcq    %rdx, high ;              \
+        sbbq    carry, carry
+
+// End version not catching the top carry-out
+
+#define mulpade(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        subq    carry, %rdx ;             \
+        addq    %rax, low ;               \
+        adcq    %rdx, high
+
+// Core one-step Montgomery reduction macro. Takes input in
+// [d7;d6;d5;d4;d3;d2;d1;d0] and returns result in [d7;d6;d5;d4;d3;d2;d1],
+// adding to the existing contents, re-using d0 as a temporary internally
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+//
+//       montredc(d7,d6,d5,d4,d3,d2,d1,d0)
+//
+// This particular variant, with its mix of addition and subtraction
+// at the top, is not intended to maintain a coherent carry or borrow out.
+// It is assumed the final result would fit in [d7;d6;d5;d4;d3;d2;d1].
+// which is always the case here as the top word is even always in {0,1}
+
+#define montredc(d7,d6,d5,d4,d3,d2,d1,d0)                               \
+/* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
+                movq    d0, %rbx ;                                        \
+                shlq    $32, %rbx ;                                        \
+                addq    d0, %rbx ;                                        \
+/* Construct [%rbp;%rdx;%rax;-] = (2^384 - p_384) * w */                   \
+/* We know the lowest word will cancel so we can re-use d0 as a temp */ \
+                xorl    %ebp, %ebp ;                                       \
+                movq    $0xffffffff00000001, %rax ;                        \
+                mulq    %rbx;                                            \
+                movq    %rdx, d0 ;                                        \
+                movq    $0x00000000ffffffff, %rax ;                        \
+                mulq    %rbx;                                            \
+                addq    d0, %rax ;                                        \
+                adcq    %rbx, %rdx ;                                       \
+                adcl    %ebp, %ebp ;                                       \
+/*  Now subtract that and add 2^384 * w */                              \
+                subq    %rax, d1 ;                                        \
+                sbbq    %rdx, d2 ;                                        \
+                sbbq    %rbp, d3 ;                                        \
+                sbbq    $0, d4 ;                                          \
+                sbbq    $0, d5 ;                                          \
+                sbbq    $0, %rbx ;                                         \
+                addq    %rbx, d6 ;                                        \
+                adcq    $0, d7
+
+bignum_montmul_p384_alt:
+
+// Save more registers to play with
+
+        pushq   %rbx
+        pushq   %rbp
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Copy y into a safe register to start with
+
+        movq    %rdx, y
+
+// Do row 0 computation, which is a bit different:
+// set up initial window [%r14,%r13,%r12,%r11,%r10,%r9,%r8] = y[0] * x
+// Unlike later, we only need a single carry chain
+
+        movq    (y), %rbx
+        movq    (x), %rax
+        mulq    %rbx
+        movq    %rax, %r8
+        movq    %rdx, %r9
+
+        movq    8(x), %rax
+        mulq    %rbx
+        xorl    %r10d, %r10d
+        addq    %rax, %r9
+        adcq    %rdx, %r10
+
+        movq    16(x), %rax
+        mulq    %rbx
+        xorl    %r11d, %r11d
+        addq    %rax, %r10
+        adcq    %rdx, %r11
+
+        movq    24(x), %rax
+        mulq    %rbx
+        xorl    %r12d, %r12d
+        addq    %rax, %r11
+        adcq    %rdx, %r12
+
+        movq    32(x), %rax
+        mulq    %rbx
+        xorl    %r13d, %r13d
+        addq    %rax, %r12
+        adcq    %rdx, %r13
+
+        movq    40(x), %rax
+        mulq    %rbx
+        xorl    %r14d, %r14d
+        addq    %rax, %r13
+        adcq    %rdx, %r14
+
+        xorl    %r15d, %r15d
+
+// Montgomery reduce the zeroth window
+
+        montredc(%r15, %r14,%r13,%r12,%r11,%r10,%r9,%r8)
+
+// Add row 1
+
+        movq    8(y), %rbx
+        mulpadi(%r8,%r10,%r9,(x))
+        mulpadd(%r8,%r11,%r10,8(x))
+        mulpadd(%r8,%r12,%r11,16(x))
+        mulpadd(%r8,%r13,%r12,24(x))
+        mulpadd(%r8,%r14,%r13,32(x))
+        mulpadd(%r8,%r15,%r14,40(x))
+        negq    %r8
+
+// Montgomery reduce window 1
+
+        montredc(%r8, %r15,%r14,%r13,%r12,%r11,%r10,%r9)
+
+// Add row 2
+
+        movq    16(y), %rbx
+        mulpadi(%r9,%r11,%r10,(x))
+        mulpadd(%r9,%r12,%r11,8(x))
+        mulpadd(%r9,%r13,%r12,16(x))
+        mulpadd(%r9,%r14,%r13,24(x))
+        mulpadd(%r9,%r15,%r14,32(x))
+        mulpadd(%r9,%r8,%r15,40(x))
+        negq    %r9
+
+// Montgomery reduce window 2
+
+        montredc(%r9, %r8,%r15,%r14,%r13,%r12,%r11,%r10)
+
+// Add row 3
+
+        movq    24(y), %rbx
+        mulpadi(%r10,%r12,%r11,(x))
+        mulpadd(%r10,%r13,%r12,8(x))
+        mulpadd(%r10,%r14,%r13,16(x))
+        mulpadd(%r10,%r15,%r14,24(x))
+        mulpadd(%r10,%r8,%r15,32(x))
+        mulpadd(%r10,%r9,%r8,40(x))
+        negq    %r10
+
+// Montgomery reduce window 3
+
+        montredc(%r10, %r9,%r8,%r15,%r14,%r13,%r12,%r11)
+
+// Add row 4
+
+        movq    32(y), %rbx
+        mulpadi(%r11,%r13,%r12,(x))
+        mulpadd(%r11,%r14,%r13,8(x))
+        mulpadd(%r11,%r15,%r14,16(x))
+        mulpadd(%r11,%r8,%r15,24(x))
+        mulpadd(%r11,%r9,%r8,32(x))
+        mulpadd(%r11,%r10,%r9,40(x))
+        negq    %r11
+
+// Montgomery reduce window 4
+
+        montredc(%r11, %r10,%r9,%r8,%r15,%r14,%r13,%r12)
+
+// Add row 5
+
+        movq    40(y), %rbx
+        mulpadi(%r12,%r14,%r13,(x))
+        mulpadd(%r12,%r15,%r14,8(x))
+        mulpadd(%r12,%r8,%r15,16(x))
+        mulpadd(%r12,%r9,%r8,24(x))
+        mulpadd(%r12,%r10,%r9,32(x))
+        mulpadd(%r12,%r11,%r10,40(x))
+        negq    %r12
+
+// Montgomery reduce window 5
+
+        montredc(%r12, %r11,%r10,%r9,%r8,%r15,%r14,%r13)
+
+// We now have a pre-reduced 7-word form z = [%r12; %r11;%r10;%r9;%r8;%r15;%r14]
+// Next, accumulate in different registers z - p_384, or more precisely
+//
+//   [%r12; %r13;%rbp;%rdx;%rcx;%rbx;%rax] = z + (2^384 - p_384)
+
+        xorl    %edx, %edx
+        xorl    %ebp, %ebp
+        xorl    %r13d, %r13d
+
+        movq    $0xffffffff00000001, %rax
+        addq    %r14, %rax
+        movl    $0x00000000ffffffff, %ebx
+        adcq    %r15, %rbx
+        movl    $0x0000000000000001, %ecx
+        adcq    %r8, %rcx
+        adcq    %r9, %rdx
+        adcq    %r10, %rbp
+        adcq    %r11, %r13
+        adcq    $0, %r12
+
+// ~ZF <=> %r12 >= 1 <=> z + (2^384 - p_384) >= 2^384 <=> z >= p_384, which
+// determines whether to use the further reduced argument or the original z.
+
+        cmovnzq %rax, %r14
+        cmovnzq %rbx, %r15
+        cmovnzq %rcx, %r8
+        cmovnzq %rdx, %r9
+        cmovnzq %rbp, %r10
+        cmovnzq %r13, %r11
+
+// Write back the result
+
+        movq    %r14, (z)
+        movq    %r15, 8(z)
+        movq    %r8, 16(z)
+        movq    %r9, 24(z)
+        movq    %r10, 32(z)
+        movq    %r11, 40(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbp
+        popq    %rbx
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
@@ -1,0 +1,331 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^384) mod p_384
+// Input x[6]; output z[6]
+//
+//    extern void bignum_montsqr_p384_alt
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
+// guaranteed in particular if x < p_384 initially (the "intended" case).
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_montsqr_p384_alt
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// Some temp registers for the last correction stage
+
+#define d %rax
+#define u %rdx
+#define v %r10
+#define w %r11
+
+// A zero register, very often
+
+#define zero %rbp
+#define zeroe %ebp
+
+// Add %rbx * m into a register-pair (high,low) maintaining consistent
+// carry-catching with carry (negated, as bitmask) and using %rax and %rdx
+// as temporaries
+
+#define mulpadd(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        subq    carry, %rdx ;             \
+        addq    %rax, low ;               \
+        adcq    %rdx, high ;              \
+        sbbq    carry, carry
+
+// Initial version assuming no carry-in
+
+#define mulpadi(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        addq    %rax, low ;               \
+        adcq    %rdx, high ;              \
+        sbbq    carry, carry
+
+// End version not catching the top carry-out
+
+#define mulpade(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        subq    carry, %rdx ;             \
+        addq    %rax, low ;               \
+        adcq    %rdx, high
+
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d5;d4;d3;d2;d1;d0] and returns result in [d6;d5;d4;d3;d2;d1],
+// adding to the existing [d5;d4;d3;d2;d1] and re-using d0 as a
+// temporary internally, as well as %rax, %rbx and %rdx.
+// It is OK for d6 and d0 to be the same register (they often are)
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+//
+//       montreds(d6,d5,d4,d3,d2,d1,d0)
+
+#define montreds(d6,d5,d4,d3,d2,d1,d0)                                  \
+/* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
+                movq    d0, %rbx ;                                        \
+                shlq    $32, %rbx ;                                        \
+                addq    d0, %rbx ;                                        \
+/* Construct [%rax;%rdx;d0;-] = (2^384 - p_384) * w            */         \
+/* We know the lowest word will cancel so we can re-use d0   */         \
+/* and %rbx as temps.                                         */         \
+                movq    $0xffffffff00000001, %rax ;                        \
+                mulq    %rbx;                                            \
+                movq    %rdx, d0 ;                                        \
+                movq    $0x00000000ffffffff, %rax ;                        \
+                mulq    %rbx;                                            \
+                addq    %rax, d0 ;                                        \
+                movl    $0, %eax ;                                         \
+                adcq    %rbx, %rdx ;                                       \
+                adcl    %eax, %eax ;                                       \
+/* Now subtract that and add 2^384 * w                       */         \
+                subq    d0, d1 ;                                         \
+                sbbq    %rdx, d2 ;                                        \
+                sbbq    %rax, d3 ;                                        \
+                sbbq    $0, d4 ;                                          \
+                sbbq    $0, d5 ;                                          \
+                movq    %rbx, d6 ;                                        \
+                sbbq    $0, d6
+
+bignum_montsqr_p384_alt:
+
+// Save more registers to play with
+
+        pushq   %rbx
+        pushq   %rbp
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Set up an initial window [%rcx;%r15;...%r9] = [34;05;03;01]
+// Note that we are using %rcx as the first step past the rotating window
+
+        movq    (x), %rbx
+        movq    8(x), %rax
+        mulq    %rbx
+        movq    %rax, %r9
+        movq    %rdx, %r10
+
+        movq    24(x), %rax
+        mulq    %rbx
+        movq    %rax, %r11
+        movq    %rdx, %r12
+
+        movq    40(x), %rax
+        mulq    %rbx
+        movq    %rax, %r13
+        movq    %rdx, %r14
+
+        movq    24(x), %rax
+        mulq     32(x)
+        movq    %rax, %r15
+        movq    %rdx, %rcx
+
+// Chain in the addition of 02 + 12 + 13 + 14 + 15 to that window
+// (no carry-out possible)
+
+        movq    16(x), %rbx
+        mulpadi(%rbp,%r11,%r10,(x))
+        mulpadd(%rbp,%r12,%r11,8(x))
+        movq    8(x), %rbx
+        mulpadd(%rbp,%r13,%r12,24(x))
+        mulpadd(%rbp,%r14,%r13,32(x))
+        mulpade(%rbp,%r15,%r14,40(x))
+        adcq    $0, %rcx
+
+// Now chain in the 04 + 23 + 24 + 25 + 35 + 45 terms
+// We are running out of registers in our rotating window, so we start
+// using %rbx (and hence need care with using mulpadd after this). Thus
+// our result so far is in [%rbp;%rbx;%rcx;%r15;...%r9]
+
+        movq    32(x), %rbx
+        mulpadi(%rbp,%r13,%r12,(x))
+        movq    16(x), %rbx
+        mulpadd(%rbp,%r14,%r13,24(x))
+        mulpadd(%rbp,%r15,%r14,32(x))
+        mulpadd(%rbp,%rcx,%r15,40(x))
+
+        xorl    %ebx, %ebx
+        movq    24(x), %rax
+        mulq     40(x)
+        subq    %rbp, %rdx
+        xorl    %ebp, %ebp
+        addq    %rax, %rcx
+        adcq    %rdx, %rbx
+        adcl    %ebp, %ebp
+        movq    32(x), %rax
+        mulq     40(x)
+        addq    %rax, %rbx
+        adcq    %rdx, %rbp
+
+// Double the window as [%r8;%rbp;%rbx;%rcx;%r15;...%r9]
+
+        xorl    %r8d, %r8d
+        addq    %r9, %r9
+        adcq    %r10, %r10
+        adcq    %r11, %r11
+        adcq    %r12, %r12
+        adcq    %r13, %r13
+        adcq    %r14, %r14
+        adcq    %r15, %r15
+        adcq    %rcx, %rcx
+        adcq    %rbx, %rbx
+        adcq    %rbp, %rbp
+        adcl    %r8d, %r8d
+
+// Add the doubled window to the 00 + 11 + 22 + 33 + 44 + 55 terms
+// For one glorious moment the entire squaring result is all in the
+// register file as [%rsi;%rbp;%rbx;%rcx;%r15;...;%r8]
+// (since we've now finished with x we can re-use %rsi). But since
+// we are so close to running out of registers, we do a bit of
+// reshuffling and temporary storage in the output buffer.
+
+        movq    (x), %rax
+        mulq    %rax
+        movq    %r8, (z)
+        movq    %rax, %r8
+        movq    8(x), %rax
+        movq    %rbp, 8(z)
+        addq    %rdx, %r9
+        sbbq    %rbp, %rbp
+
+        mulq    %rax
+        negq    %rbp
+        adcq    %rax, %r10
+        adcq    %rdx, %r11
+        sbbq    %rbp, %rbp
+
+        movq    16(x), %rax
+        mulq    %rax
+        negq    %rbp
+        adcq    %rax, %r12
+        adcq    %rdx, %r13
+        sbbq    %rbp, %rbp
+
+        movq    24(x), %rax
+        mulq    %rax
+        negq    %rbp
+        adcq    %rax, %r14
+        adcq    %rdx, %r15
+        sbbq    %rbp, %rbp
+
+        movq    32(x), %rax
+        mulq    %rax
+        negq    %rbp
+        adcq    %rax, %rcx
+        adcq    %rdx, %rbx
+        sbbq    %rbp, %rbp
+
+        movq    40(x), %rax
+        mulq    %rax
+        negq    %rbp
+        adcq    8(z), %rax
+        adcq    (z), %rdx
+        movq    %rax, %rbp
+        movq    %rdx, %rsi
+
+// We need just *one* more register as a temp for the Montgomery steps.
+// Since we are writing to the z buffer anyway, make use of that again
+// to stash %rbx.
+
+        movq    %rbx, (z)
+
+// Montgomery reduce the %r13,...,%r8 window 6 times
+
+        montreds(%r8,%r13,%r12,%r11,%r10,%r9,%r8)
+        montreds(%r9,%r8,%r13,%r12,%r11,%r10,%r9)
+        montreds(%r10,%r9,%r8,%r13,%r12,%r11,%r10)
+        montreds(%r11,%r10,%r9,%r8,%r13,%r12,%r11)
+        montreds(%r12,%r11,%r10,%r9,%r8,%r13,%r12)
+        montreds(%r13,%r12,%r11,%r10,%r9,%r8,%r13)
+
+// Now we can safely restore %rbx before accumulating
+
+        movq    (z), %rbx
+
+        addq    %r8, %r14
+        adcq    %r9, %r15
+        adcq    %r10, %rcx
+        adcq    %r11, %rbx
+        adcq    %r12, %rbp
+        adcq    %r13, %rsi
+        movl    $0, %r8d
+        adcq    %r8, %r8
+
+// We now have a pre-reduced 7-word form z = [%r8; %rsi;%rbp;%rbx;%rcx;%r15;%r14]
+// Next, accumulate in different registers z - p_384, or more precisely
+//
+//   [%r8; %r13;%r12;%r11;%r10;%r9;%rax] = z + (2^384 - p_384)
+
+        xorq    %r11, %r11
+        xorq    %r12, %r12
+        xorq    %r13, %r13
+        movq    $0xffffffff00000001, %rax
+        addq    %r14, %rax
+        movl    $0x00000000ffffffff, %r9d
+        adcq    %r15, %r9
+        movl    $0x0000000000000001, %r10d
+        adcq    %rcx, %r10
+        adcq    %rbx, %r11
+        adcq    %rbp, %r12
+        adcq    %rsi, %r13
+        adcq    $0, %r8
+
+// ~ZF <=> %r12 >= 1 <=> z + (2^384 - p_384) >= 2^384 <=> z >= p_384, which
+// determines whether to use the further reduced argument or the original z.
+
+        cmovnzq %rax, %r14
+        cmovnzq %r9, %r15
+        cmovnzq %r10, %rcx
+        cmovnzq %r11, %rbx
+        cmovnzq %r12, %rbp
+        cmovnzq %r13, %rsi
+
+// Write back the result
+
+        movq    %r14, (z)
+        movq    %r15, 8(z)
+        movq    %rcx, 16(z)
+        movq    %rbx, 24(z)
+        movq    %rbp, 32(z)
+        movq    %rsi, 40(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbp
+        popq    %rbx
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
@@ -1,0 +1,316 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert to Montgomery form z := (2^384 * x) mod p_384
+// Input x[6]; output z[6]
+//
+//    extern void bignum_tomont_p384_alt
+//     (uint64_t z[static 6], uint64_t x[static 6]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_tomont_p384_alt
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// Some temp registers for the last correction stage
+
+#define d %rax
+#define u %rdx
+#define v %rcx
+#define w %rsi
+
+#define vshort %ecx
+#define wshort %esi
+
+// Add %rbx * m into a register-pair (high,low) maintaining consistent
+// carry-catching with carry (negated, as bitmask) and using %rax and %rdx
+// as temporaries
+
+#define mulpadd(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        subq    carry, %rdx ;             \
+        addq    %rax, low ;               \
+        adcq    %rdx, high ;              \
+        sbbq    carry, carry
+
+// Initial version assuming no carry-in
+
+#define mulpadi(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        addq    %rax, low ;               \
+        adcq    %rdx, high ;              \
+        sbbq    carry, carry
+
+// End version not catching the top carry-out
+
+#define mulpade(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        subq    carry, %rdx ;             \
+        addq    %rax, low ;               \
+        adcq    %rdx, high
+
+// Core one-step Montgomery reduction macro. Takes input in
+// [d7;d6;d5;d4;d3;d2;d1;d0] and returns result in [d7;d6;d5;d4;d3;d2;d1],
+// adding to the existing contents, re-using d0 as a temporary internally
+//
+// We want to add (2^384 - 2^128 - 2^96 + 2^32 - 1) * w
+// where w = [d0 + (d0<<32)] mod 2^64
+//
+//       montredc(d7,d6,d5,d4,d3,d2,d1,d0)
+//
+// This particular variant, with its mix of addition and subtraction
+// at the top, is not intended to maintain a coherent carry or borrow out.
+// It is assumed the final result would fit in [d7;d6;d5;d4;d3;d2;d1].
+// which is always the case here as the top word is even always in {0,1}
+
+#define montredc(d7,d6,d5,d4,d3,d2,d1,d0)                               \
+/* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
+                movq    d0, %rbx ;                                        \
+                shlq    $32, %rbx ;                                        \
+                addq    d0, %rbx ;                                        \
+/* Construct [%rcx;%rdx;%rax;-] = (2^384 - p_384) * w */                   \
+/* We know the lowest word will cancel so we can re-use d0 as a temp */ \
+                xorl    %ecx, %ecx ;                                       \
+                movq    $0xffffffff00000001, %rax ;                        \
+                mulq    %rbx;                                            \
+                movq    %rdx, d0 ;                                        \
+                movq    $0x00000000ffffffff, %rax ;                        \
+                mulq    %rbx;                                            \
+                addq    d0, %rax ;                                        \
+                adcq    %rbx, %rdx ;                                       \
+                adcl    %ecx, %ecx ;                                       \
+/*  Now subtract that and add 2^384 * w */                              \
+                subq    %rax, d1 ;                                        \
+                sbbq    %rdx, d2 ;                                        \
+                sbbq    %rcx, d3 ;                                        \
+                sbbq    $0, d4 ;                                          \
+                sbbq    $0, d5 ;                                          \
+                sbbq    $0, %rbx ;                                         \
+                addq    %rbx, d6 ;                                        \
+                adcq    $0, d7
+
+bignum_tomont_p384_alt:
+
+// We are essentially just doing a Montgomery multiplication of x and the
+// precomputed constant y = 2^768 mod p, so the code is almost the same
+// modulo a few registers and the change from loading y[i] to using constants,
+// plus the easy digits y[4] = 1 and y[5] = 0 being treated specially.
+// Because there is no y pointer to keep, we use one register less.
+
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Do row 0 computation, which is a bit different:
+// set up initial window [%r14,%r13,%r12,%r11,%r10,%r9,%r8] = y[0] * x
+// Unlike later, we only need a single carry chain
+
+        movq    $0xfffffffe00000001, %rbx
+        movq    (x), %rax
+        mulq    %rbx
+        movq    %rax, %r8
+        movq    %rdx, %r9
+
+        movq    8(x), %rax
+        mulq    %rbx
+        xorl    %r10d, %r10d
+        addq    %rax, %r9
+        adcq    %rdx, %r10
+
+        movq    16(x), %rax
+        mulq    %rbx
+        xorl    %r11d, %r11d
+        addq    %rax, %r10
+        adcq    %rdx, %r11
+
+        movq    24(x), %rax
+        mulq    %rbx
+        xorl    %r12d, %r12d
+        addq    %rax, %r11
+        adcq    %rdx, %r12
+
+        movq    32(x), %rax
+        mulq    %rbx
+        xorl    %r13d, %r13d
+        addq    %rax, %r12
+        adcq    %rdx, %r13
+
+        movq    40(x), %rax
+        mulq    %rbx
+        xorl    %r14d, %r14d
+        addq    %rax, %r13
+        adcq    %rdx, %r14
+
+        xorl    %r15d, %r15d
+
+// Montgomery reduce the zeroth window
+
+        montredc(%r15, %r14,%r13,%r12,%r11,%r10,%r9,%r8)
+
+// Add row 1
+
+        movq    $0x0000000200000000, %rbx
+        mulpadi(%r8,%r10,%r9,(x))
+        mulpadd(%r8,%r11,%r10,8(x))
+        mulpadd(%r8,%r12,%r11,16(x))
+        mulpadd(%r8,%r13,%r12,24(x))
+        mulpadd(%r8,%r14,%r13,32(x))
+        mulpadd(%r8,%r15,%r14,40(x))
+        negq    %r8
+
+// Montgomery reduce window 1
+
+        montredc(%r8, %r15,%r14,%r13,%r12,%r11,%r10,%r9)
+
+// Add row 2
+
+        movq    $0xfffffffe00000000, %rbx
+        mulpadi(%r9,%r11,%r10,(x))
+        mulpadd(%r9,%r12,%r11,8(x))
+        mulpadd(%r9,%r13,%r12,16(x))
+        mulpadd(%r9,%r14,%r13,24(x))
+        mulpadd(%r9,%r15,%r14,32(x))
+        mulpadd(%r9,%r8,%r15,40(x))
+        negq    %r9
+
+// Montgomery reduce window 2
+
+        montredc(%r9, %r8,%r15,%r14,%r13,%r12,%r11,%r10)
+
+// Add row 3
+
+        movq    $0x0000000200000000, %rbx
+        mulpadi(%r10,%r12,%r11,(x))
+        mulpadd(%r10,%r13,%r12,8(x))
+        mulpadd(%r10,%r14,%r13,16(x))
+        mulpadd(%r10,%r15,%r14,24(x))
+        mulpadd(%r10,%r8,%r15,32(x))
+        mulpadd(%r10,%r9,%r8,40(x))
+        negq    %r10
+
+// Montgomery reduce window 3
+
+        montredc(%r10, %r9,%r8,%r15,%r14,%r13,%r12,%r11)
+
+// Add row 4. The multiplier y[4] = 1, so we just add x to the window
+// while extending it with one more digit, initially this carry
+
+        xorq    %r11, %r11
+        addq    (x), %r12
+        adcq    8(x), %r13
+        adcq    16(x), %r14
+        adcq    24(x), %r15
+        adcq    32(x), %r8
+        adcq    40(x), %r9
+        adcq    %r11, %r10
+        adcq    %r11, %r11
+
+// Montgomery reduce window 4
+
+        montredc(%r11, %r10,%r9,%r8,%r15,%r14,%r13,%r12)
+
+// Add row 5, The multiplier y[5] = 0, so this is trivial: all we do is
+// bring down another zero digit into the window.
+
+        xorq    %r12, %r12
+
+// Montgomery reduce window 5
+
+        montredc(%r12, %r11,%r10,%r9,%r8,%r15,%r14,%r13)
+
+// We now have a pre-reduced 7-word form [%r12;%r11;%r10;%r9;%r8;%r15;%r14]
+
+// We know, writing B = 2^{6*64} that the full implicit result is
+// B^2 c <= z + (B - 1) * p < B * p + (B - 1) * p < 2 * B * p,
+// so the top half is certainly < 2 * p. If c = 1 already, we know
+// subtracting p will give the reduced modulus. But now we do a
+// comparison to catch cases where the residue is >= p.
+// First set [0;0;0;w;v;u] = 2^384 - p_384
+
+        movq    $0xffffffff00000001, u
+        movl    $0x00000000ffffffff, vshort
+        movl    $0x0000000000000001, wshort
+
+// Let dd = [%r11;%r10;%r9;%r8;%r15;%r14] be the topless 6-word intermediate result.
+// Set CF if the addition dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384.
+
+        movq    %r14, d
+        addq    u, d
+        movq    %r15, d
+        adcq    v, d
+        movq    %r8, d
+        adcq    w, d
+        movq    %r9, d
+        adcq    $0, d
+        movq    %r10, d
+        adcq    $0, d
+        movq    %r11, d
+        adcq    $0, d
+
+// Now just add this new carry into the existing %r12. It's easy to see they
+// can't both be 1 by our range assumptions, so this gives us a {0,1} flag
+
+        adcq    $0, %r12
+
+// Now convert it into a bitmask
+
+        negq    %r12
+
+// Masked addition of 2^384 - p_384, hence subtraction of p_384
+
+        andq    %r12, u
+        andq    %r12, v
+        andq    %r12, w
+
+        addq   u, %r14
+        adcq   v, %r15
+        adcq   w, %r8
+        adcq   $0, %r9
+        adcq   $0, %r10
+        adcq   $0, %r11
+
+// Write back the result
+
+        movq    %r14, (z)
+        movq    %r15, 8(z)
+        movq    %r8, 16(z)
+        movq    %r9, 24(z)
+        movq    %r10, 32(z)
+        movq    %r11, 40(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
@@ -17,7 +17,7 @@
 // Triple modulo p_384, z := (3 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_triple_p384
+//    extern void bignum_triple_p384_alt
 //     (uint64_t z[static 6], uint64_t x[static 6]);
 //
 // The input x can be any 6-digit bignum, not necessarily reduced modulo p_384,
@@ -27,7 +27,7 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_triple_p384
+        .globl  bignum_triple_p384_alt
         .text
 
 #define z %rdi
@@ -42,12 +42,15 @@
 
 #define a %rax
 #define c %rcx
-#define q %rdx
+#define q %rcx
+#define d %rdx
 
 #define ashort %eax
-#define qshort %edx
+#define cshort %ecx
+#define qshort %ecx
+#define dshort %edx
 
-bignum_triple_p384:
+bignum_triple_p384_alt:
 
 // We seem to need (just!) one extra register, which we need to save and restore
 
@@ -57,56 +60,63 @@ bignum_triple_p384:
 // but actually immediately producing q = h + 1, our quotient approximation,
 // by adding 1 to it.
 
-                xorl    ashort, ashort
+                movl    $3, cshort
 
-                movq    (x), q
-                movq    q, d0
-                adcxq   q, q
-                adoxq   q, d0
-                movq    8(x), q
-                movq    q, d1
-                adcxq   q, q
-                adoxq   q, d1
-                movq    16(x), q
-                movq    q, d2
-                adcxq   q, q
-                adoxq   q, d2
-                movq    24(x), q
-                movq    q, d3
-                adcxq   q, q
-                adoxq   q, d3
-                movq    32(x), q
-                movq    q, d4
-                adcxq   q, q
-                adoxq   q, d4
-                movq    40(x), q
-                movq    q, d5
-                adcxq   q, q
-                adoxq   q, d5
+                movq    (x), a
+                mulq    c
+                movq    a, d0
+                movq    d, d1
+
+                movq    8(x), a
+                xorq    d2, d2
+                mulq    c
+                addq    a, d1
+                adcq    d, d2
+
+                movq    16(x), a
+                xorq    d3, d3
+                mulq    c
+                addq    a, d2
+                adcq    d, d3
+
+                movq    24(x), a
+                xorq    d4, d4
+                mulq    c
+                addq    a, d3
+                adcq    d, d4
+
+                movq    32(x), a
+                mulq    c
+                addq    a, d4
+                adcq    $0, d
+
+                movq    40(x), a
+                movq    d, d5
+                mulq    c
+                addq    a, d5
 
                 movl    $1, qshort
-                adcxq   a, q
-                adoxq   a, q
+                adcq    d, q
 
 // Initial subtraction of z - q * p_384, with bitmask c for the carry
 // Actually done as an addition of (z - 2^384 * h) + q * (2^384 - p_384)
 // which, because q = h + 1, is exactly 2^384 + (z - q * p_384), and
 // therefore CF <=> 2^384 + (z - q * p_384) >= 2^384 <=> z >= q * p_384.
 
-                movq    q, c
-                shlq    $32, c
+                movq    q, d
+                shlq    $32, d
                 movq    q, a
-                subq    c, a
-                sbbq    $0, c
+                subq    d, a
+                sbbq    $0, d
 
                 addq    a, d0
-                adcq    c, d1
+                adcq    d, d1
                 adcq    q, d2
                 adcq    $0, d3
                 adcq    $0, d4
                 adcq    $0, d5
-                sbbq    c, c
-                notq    c
+                sbbq    d, d
+                notq    d
 
 // Now use that mask for a masked addition of p_384, which again is in
 // fact done by a masked subtraction of 2^384 - p_384, so that we only
@@ -114,15 +124,15 @@ bignum_triple_p384:
 
                 movl    $0x00000000ffffffff, qshort
                 xorl    ashort, ashort
-                andq    c, q
+                andq    d, q
                 subq    q, a
-                negq    c
+                negq    d
 
                 subq    a, d0
                 movq    d0, (z)
                 sbbq    q, d1
                 movq    d1, 8(z)
-                sbbq    c, d2
+                sbbq    d, d2
                 movq    d2, 16(z)
                 sbbq    $0, d3
                 movq    d3, 24(z)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Add modulo p_521, z := (x + y) mod p_521, assuming x and y reduced
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_add_p521
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_add_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+#define y %rdx
+
+#define d0 %rax
+#define d1 %rcx
+#define d2 %r8
+#define d3 %r9
+#define d4 %r10
+#define d5 %r11
+#define d6 %r12
+#define d7 %rbx
+
+// Re-use the input pointers as other variables once safe to do so
+
+#define d8 %rsi
+#define m %rdx
+
+
+
+bignum_add_p521:
+
+// Save more registers to play with
+
+        pushq   %rbx
+        pushq   %r12
+
+// Force carry-in to get s = [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x + y + 1.
+// We ignore the carry-out, assuming inputs are reduced so there is none.
+
+        stc
+        movq    (x), d0
+        adcq    (y), d0
+        movq    8(x), d1
+        adcq    8(y), d1
+        movq    16(x), d2
+        adcq    16(y), d2
+        movq    24(x), d3
+        adcq    24(y), d3
+        movq    32(x), d4
+        adcq    32(y), d4
+        movq    40(x), d5
+        adcq    40(y), d5
+        movq    48(x), d6
+        adcq    48(y), d6
+        movq    56(x), d7
+        adcq    56(y), d7
+        movq    64(x), d8
+        adcq    64(y), d8
+
+// Now x + y >= p_521 <=> s = x + y + 1 >= 2^521
+// Make m = 512 * [x + y >= p_521]
+
+        movq    $512, m
+        andq    d8, m
+
+// Now if x + y >= p_521, we want (x + y) - p_521 = s - 2^521
+// while otherwise we want x + y = s - 1
+// We use the mask m both as an operand and to generate the dual carry
+// Write back the results as generated
+
+        cmpq    $512, m
+
+        sbbq    $0, d0
+        movq    d0, (z)
+        sbbq    $0, d1
+        movq    d1, 8(z)
+        sbbq    $0, d2
+        movq    d2, 16(z)
+        sbbq    $0, d3
+        movq    d3, 24(z)
+        sbbq    $0, d4
+        movq    d4, 32(z)
+        sbbq    $0, d5
+        movq    d5, 40(z)
+        sbbq    $0, d6
+        movq    d6, 48(z)
+        sbbq    $0, d7
+        movq    d7, 56(z)
+        sbbq    m, d8
+        movq    d8, 64(z)
+
+// Restore registers and return
+
+        popq    %r12
+        popq    %rbx
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
@@ -1,0 +1,167 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply by a single word modulo p_521, z := (c * x) mod p_521, assuming
+// x reduced
+// Inputs c, x[9]; output z[9]
+//
+//    extern void bignum_cmul_p521
+//     (uint64_t z[static 9], uint64_t c, uint64_t x[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_cmul_p521
+        .text
+
+#define z %rdi
+
+// Temporarily moved here for initial multiply
+
+#define x %rcx
+
+// Likewise this is thrown away after initial multiply
+
+#define c %rdx
+#define cshort %edx
+
+#define a %rax
+#define dd %rax
+
+// Digits: last one aliased to the local x pointer that's no longer needed
+
+#define d0 %rsi
+#define d1 %r8
+#define d2 %r9
+#define d3 %r10
+#define d4 %r11
+#define d5 %rbx
+#define d6 %rbp
+#define d7 %r12
+#define d8 %r13
+#define d9 %rcx
+
+// Same as d9
+
+#define h d9
+
+bignum_cmul_p521:
+
+// Save additional registers to use
+
+                pushq   %rbx
+                pushq   %rbp
+                pushq   %r12
+                pushq   %r13
+
+// Shuffle inputs (since we want the multiplier in %rdx)
+
+                movq    %rdx, x
+                movq    %rsi, c
+
+// Multiply as [d9; ...; d0] = c * x.
+
+                mulxq   (x), d0, d1
+                mulxq   8(x), a, d2
+                addq    a, d1
+                mulxq   16(x), a, d3
+                adcq    a, d2
+                mulxq   24(x), a, d4
+                adcq    a, d3
+                mulxq   32(x), a, d5
+                adcq    a, d4
+                mulxq   40(x), a, d6
+                adcq    a, d5
+                mulxq   48(x), a, d7
+                adcq    a, d6
+                mulxq   56(x), a, d8
+                adcq    a, d7
+                mulxq   64(x), a, d9
+                adcq    a, d8
+                adcq    $0, d9
+
+// Create an AND "dd" of digits d7,...,d1, a computation we hope will
+// get nicely interleaved with the multiplication chain above.
+// From the point of view of architectural dependencies we have to
+// bunch it up here since AND destroys the flags and we overwrite the
+// register used as a stage temporary variable for the multiplications.
+
+                movq    d1, dd
+                andq    d2, dd
+                andq    d3, dd
+                andq    d4, dd
+                andq    d5, dd
+                andq    d6, dd
+                andq    d7, dd
+
+// Extract the high part h==d9 and mask off the low part l = [d8;d7;...;d0]
+// but stuff d8 with 1 bits at the left to ease a comparison below
+
+                shldq   $55, d8, h
+                orq     $~0x1FF, d8
+
+// Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
+// happen if digits d7,...d1 are all 1s, we use the AND of them "dd" to
+// condense the carry chain, and since we stuffed 1 bits into d8 we get
+// the result in CF without an additional comparison. Hereafter we use c = 0.
+// Since x was assumed reduced, h cannot be maximal, so the "lea" is safe,
+// i.e. does not carry or wrap round.
+
+                leaq    1(h), c
+                addq    d0, c
+                movl    $0, cshort
+                adcq    c, dd
+                movq    d8, a
+                adcq    c, a
+
+// Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
+// while otherwise we want just h + l. So mask h + l + CF to 521 bits.
+// This masking also gets rid of the stuffing with 1s we did above.
+// Write back the digits as they are generated.
+
+                adcq    h, d0
+                movq    d0, (z)
+                adcq    c, d1
+                movq    d1, 8(z)
+                adcq    c, d2
+                movq    d2, 16(z)
+                adcq    c, d3
+                movq    d3, 24(z)
+                adcq    c, d4
+                movq    d4, 32(z)
+                adcq    c, d5
+                movq    d5, 40(z)
+                adcq    c, d6
+                movq    d6, 48(z)
+                adcq    c, d7
+                movq    d7, 56(z)
+                adcq    c, d8
+                andq    $0x1FF, d8
+                movq    d8, 64(z)
+
+// Restore registers and return
+
+                popq    %r13
+                popq    %r12
+                popq    %rbp
+                popq    %rbx
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
@@ -1,0 +1,139 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert from Montgomery form z := (x / 2^576) mod p_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_deamont_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Convert a 9-digit bignum x out of its (optionally almost) Montgomery form,
+// "almost" meaning any 9-digit input will work, with no range restriction.
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_deamont_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+#define c %rax
+#define h %rax
+#define l %rbx
+
+#define d0 %rdx
+#define d1 %rcx
+#define d2 %r8
+#define d3 %r9
+#define d4 %r10
+#define d5 %r11
+#define d6 %r12
+#define d7 %r13
+#define d8 %rbp
+
+bignum_deamont_p521:
+
+// Save more registers to play with
+
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %rbp
+
+// Stash the lowest 55 bits at the top of c, then shift the whole 576-bit
+// input right by 9*64 - 521 = 576 - 521 = 55 bits.
+
+        movq    (x), d0
+        movq    d0, c
+        shlq    $9, c
+        movq    8(x), d1
+        shrdq   $55, d1, d0
+        movq    16(x), d2
+        shrdq   $55, d2, d1
+        movq    24(x), d3
+        shrdq   $55, d3, d2
+        movq    32(x), d4
+        shrdq   $55, d4, d3
+        movq    40(x), d5
+        shrdq   $55, d5, d4
+        movq    48(x), d6
+        shrdq   $55, d6, d5
+        movq    56(x), d7
+        shrdq   $55, d7, d6
+        movq    64(x), d8
+        shrdq   $55, d8, d7
+        shrq    $55, d8
+
+// Now writing x = 2^55 * h + l (so here [d8;..d0] = h and c = 2^9 * l)
+// we want (h + 2^{521-55} * l) mod p_521 = s mod p_521. Since s < 2 * p_521
+// this is just "if s >= p_521 then s - p_521 else s". First get
+// s + 1, but pad up the top to get a top-bit carry-out from it, so now
+// CF <=> s + 1 >= 2^521 <=> s >= p_521, while the digits [d8;...d0] are
+// now s + 1 except for bits above 521.
+
+        movq    c, l
+        shrq    $55, h
+        shlq    $9, l
+        orq     $~0x1FF, d8
+        addq    $1, d0
+        adcq    $0, d1
+        adcq    $0, d2
+        adcq    $0, d3
+        adcq    $0, d4
+        adcq    $0, d5
+        adcq    $0, d6
+        adcq    l, d7
+        adcq    h, d8
+
+// We want "if CF then (s + 1) - 2^521 else (s + 1) - 1" so subtract ~CF
+// and mask to 521 bits, writing digits back as they are created.
+
+        cmc
+        sbbq    $0, d0
+        movq    d0, (z)
+        sbbq    $0, d1
+        movq    d1, 8(z)
+        sbbq    $0, d2
+        movq    d2, 16(z)
+        sbbq    $0, d3
+        movq    d3, 24(z)
+        sbbq    $0, d4
+        movq    d4, 32(z)
+        sbbq    $0, d5
+        movq    d5, 40(z)
+        sbbq    $0, d6
+        movq    d6, 48(z)
+        sbbq    $0, d7
+        movq    d7, 56(z)
+        sbbq    $0, d8
+        andq    $0x1FF, d8
+        movq    d8, 64(z)
+
+// Restore registers and return
+
+        popq    %rbp
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert from Montgomery form z := (x / 2^576) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_demont_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// This assumes the input is < p_521 for correctness. If this is not the case,
+// use the variant "bignum_deamont_p521" instead.
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_demont_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// Rotating (aliased) registers for the digits
+
+#define c %rax
+#define d0 %rdx
+#define d1 %rcx
+
+#define d2 %rdx
+#define d3 %rcx
+#define d4 %rdx
+#define d5 %rcx
+#define d6 %rdx
+#define d7 %rcx
+#define d8 %rdx
+
+bignum_demont_p521:
+
+// Rotate, as a 521-bit quantity, by 9*64 - 521 = 55 bits right.
+
+        movq    (x), d0
+        movq    d0, c
+        movq    8(x), d1
+        shrdq   $55, d1, d0
+        movq    d0, (z)
+        movq    16(x), d2
+        shrdq   $55, d2, d1
+        movq    d1, 8(z)
+        movq    24(x), d3
+        shrdq   $55, d3, d2
+        shlq    $9, c
+        movq    d2, 16(z)
+        movq    32(x), d4
+        shrdq   $55, d4, d3
+        movq    d3, 24(z)
+        movq    40(x), d5
+        shrdq   $55, d5, d4
+        movq    d4, 32(z)
+        movq    48(x), d6
+        shrdq   $55, d6, d5
+        movq    d5, 40(z)
+        movq    56(x), d7
+        shrdq   $55, d7, d6
+        movq    d6, 48(z)
+        movq    64(x), d8
+        orq     c, d8
+        shrdq   $55, d8, d7
+        movq    d7, 56(z)
+        shrq    $55, d8
+        movq    d8, 64(z)
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Double modulo p_521, z := (2 * x) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_double_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_double_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+#define a %rax
+#define c %rcx
+
+
+
+bignum_double_p521:
+
+// We can decide whether 2 * x >= p_521 just by 2 * x >= 2^521, which
+// as we assume x < p_521 amounts to looking at bit 8 of the top word
+
+        movq    64(x), c
+        btq     $8, c
+
+// Now if 2 * x >= p_521 we want 2 * x - p_521 = (2 * x + 1) - 2^521
+// and otherwise just 2 * x. Feed in the condition as the carry bit
+// to get 2 * x + [2 * x >= p_521] then just mask it off to 521 bits.
+
+        movq    (x), a
+        adcq    a, a
+        movq    a, (z)
+
+        movq    8(x), a
+        adcq    a, a
+        movq    a, 8(z)
+
+        movq    16(x), a
+        adcq    a, a
+        movq    a, 16(z)
+
+        movq    24(x), a
+        adcq    a, a
+        movq    a, 24(z)
+
+        movq    32(x), a
+        adcq    a, a
+        movq    a, 32(z)
+
+        movq    40(x), a
+        adcq    a, a
+        movq    a, 40(z)
+
+        movq    48(x), a
+        adcq    a, a
+        movq    a, 48(z)
+
+        movq    56(x), a
+        adcq    a, a
+        movq    a, 56(z)
+
+        adcq    c, c
+        andq    $0x1FF, c
+        movq    c, 64(z)
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Halve modulo p_521, z := (x / 2) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_half_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_half_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// We use distinct variables for clarity, but these are heavily aliased
+
+#define d0 %rcx
+#define d1 %rdx
+#define d2 %rcx
+#define d3 %rdx
+#define d4 %rcx
+#define d5 %rdx
+#define d6 %rcx
+#define d7 %rdx
+#define d8 %rcx
+#define a %rax
+#define ashort %eax
+
+
+
+bignum_half_p521:
+
+// We do a 521-bit rotation one bit right, since 2^521 == 1 (mod p_521)
+
+                movq    (x), d0
+                movl    $1, ashort
+                andq    d0, a
+
+                movq    8(x), d1
+                shrdq   $1, d1, d0
+                movq    d0, (z)
+
+                movq    16(x), d2
+                shrdq   $1, d2, d1
+                movq    d1, 8(z)
+
+                movq    24(x), d3
+                shrdq   $1, d3, d2
+                movq    d2, 16(z)
+
+                movq    32(x), d4
+                shrdq   $1, d4, d3
+                movq    d3, 24(z)
+
+                movq    40(x), d5
+                shrdq   $1, d5, d4
+                movq    d4, 32(z)
+
+                movq    48(x), d6
+                shrdq   $1, d6, d5
+                movq    d5, 40(z)
+
+                movq    56(x), d7
+                shrdq   $1, d7, d6
+                movq    d6, 48(z)
+
+                movq    64(x), d8
+                shrdq   $1, d8, d7
+                movq    d7, 56(z)
+
+                shlq    $55, d8
+                shrdq   $56, a, d8
+                movq    d8, 64(z)
+
+// Return
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
@@ -1,0 +1,144 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Reduce modulo group order, z := x mod n_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_mod_n521_9
+//      (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Reduction is modulo the group order of the NIST curve P-521.
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_mod_n521_9
+        .text
+
+#define z %rdi
+#define x %rsi
+
+#define q %rdx
+#define a %rax
+
+#define c %rcx
+#define d %r8
+
+#define n0 %r9
+#define n1 %r10
+#define n2 %r11
+#define n3 d
+
+#define ashort %eax
+#define cshort %ecx
+#define qshort %edx
+
+bignum_mod_n521_9:
+
+// Load the top digit, putting a bit-stuffed version in output buffer.
+// The initial quotient estimate is q = h + 1 where x = 2^521 * h + t
+// The last add also clears the CF and OF flags ready for the carry chain.
+
+        movq    64(x), q
+        movq    $~0x1FF, a
+        orq     q, a
+        movq    a, 64(z)
+        shrq    $9, q
+        addq    $1, q
+
+// Now load other digits and form r = x - q * n_521 = (q * r_521 + t) - 2^521,
+// which is stored in the output buffer. Thanks to the bit-stuffing at the
+// start, we get r' = (q * r_521 + t) + (2^576 - 2^521) = r + 2^576 as the
+// computed result including the top carry. Hence CF <=> r >= 0, while
+// r' == r (mod 2^521) because things below bit 521 are uncorrupted. We
+// keep the top word in the register c since we at least have that one free.
+
+        movq    $0x449048e16ec79bf7, n0
+        mulxq   n0, a, c
+        adcxq   (x), a
+        movq    a, (z)
+
+        movq    $0xc44a36477663b851, n1
+        mulxq   n1, a, d
+        adcxq   8(x), a
+        adoxq   c, a
+        movq    a, 8(z)
+
+        movq    $0x8033feb708f65a2f, n2
+        mulxq   n2, a, c
+        adcxq   16(x), a
+        adoxq   d, a
+        movq    a, 16(z)
+
+        movq    $0xae79787c40d06994, a
+        mulxq   a, a, d
+        adcxq   24(x), a
+        adoxq   c, a
+        movq    a, 24(z)
+
+        movl    $5, ashort
+        mulxq   a, a, c
+        adcxq   32(x), a
+        adoxq   d, a
+        movq    a, 32(z)
+
+        movq    c, a // a is now used for zero hereafter
+        adoxq   c, c
+        adcq    40(x), c
+        movq    c, 40(z)
+
+        movq    48(x), c
+        adcq    a, c
+        movq    c, 48(z)
+
+        movq    56(x), c
+        adcq    a, c
+        movq    c, 56(z)
+
+        movq    64(z), c
+        adcq    a, c
+
+// We already know r < n_521, but if it actually went negative then
+// we need to add back n_521 again. Recycle q as a bitmask for r < n_521,
+// and just subtract r_521 and mask rather than literally adding 2^521.
+// This also gets rid of the bit-stuffing above.
+
+        cmc
+        sbbq    q, q
+        andq    q, n0
+        andq    q, n1
+        andq    q, n2
+        movq    $0xae79787c40d06994, n3
+        andq    q, n3
+        andl    $5, qshort
+        subq    n0, (z)
+        sbbq    n1, 8(z)
+        sbbq    n2, 16(z)
+        sbbq    n3, 24(z)
+        sbbq    q, 32(z)
+        sbbq    a, 40(z)
+        sbbq    a, 48(z)
+        sbbq    a, 56(z)
+        sbbl    ashort, cshort
+        andl    $0x1FF, cshort
+        movq    c, 64(z)
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
@@ -1,0 +1,116 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Reduce modulo field characteristic, z := x mod p_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_mod_p521_9
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_mod_p521_9
+        .text
+
+#define z %rdi
+#define x %rsi
+
+#define d0 %rax
+#define d1 %rcx
+#define d2 %r8
+#define d3 %r9
+#define d4 %r10
+#define d5 %r11
+#define d6 %rbx
+
+#define d8 %rdx
+
+#define d8short %edx
+
+// Re-use the input pointer as other variable once safe to do so
+
+#define d7 %rsi
+
+bignum_mod_p521_9:
+
+// Save one more register
+
+        pushq   %rbx
+
+// Separate out the input into x = 2^521 * H + L, so that x mod p_521 =
+// (H + L) mod p_521 = if H + L >= p_521 then H + L - p_521 else H + L.
+
+        movq    64(x), d0
+        movl    $0x1FF, d8short
+        andq    d0, d8
+        shrq    $9, d0
+
+// Force carry-in to get s = [d8;d7;d6;d5;d4;d3;d2;d1;d0] = H + L + 1.
+
+        stc
+        adcq    (x), d0
+        movq    8(x), d1
+        adcq    $0, d1
+        movq    16(x), d2
+        adcq    $0, d2
+        movq    24(x), d3
+        adcq    $0, d3
+        movq    32(x), d4
+        adcq    $0, d4
+        movq    40(x), d5
+        adcq    $0, d5
+        movq    48(x), d6
+        adcq    $0, d6
+        movq    56(x), d7
+        adcq    $0, d7
+        adcq    $0, d8
+
+// Set CF <=> s < 2^521 <=> H + L < p_521, so that if CF is set
+// we want H + L = s - 1, otherwise (H + L) - p_521 = s - 2^521.
+// This is done with just s - CF then masking to 521 bits.
+
+        cmpq    $512, d8
+
+        sbbq    $0, d0
+        movq    d0, (z)
+        sbbq    $0, d1
+        movq    d1, 8(z)
+        sbbq    $0, d2
+        movq    d2, 16(z)
+        sbbq    $0, d3
+        movq    d3, 24(z)
+        sbbq    $0, d4
+        movq    d4, 32(z)
+        sbbq    $0, d5
+        movq    d5, 40(z)
+        sbbq    $0, d6
+        movq    d6, 48(z)
+        sbbq    $0, d7
+        movq    d7, 56(z)
+        sbbq    $0, d8
+        andq    $0x1FF, d8
+        movq    d8, 64(z)
+
+// Restore register
+
+        popq    %rbx
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
@@ -1,0 +1,406 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^576) mod p_521
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_montmul_p521
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Does z := (x * y / 2^576) mod p_521, assuming x < p_521, y < p_521. This
+// means the Montgomery base is the "native size" 2^{9*64} = 2^576; since
+// p_521 is a Mersenne prime the basic modular multiplication bignum_mul_p521
+// can be considered a Montgomery operation to base 2^521.
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_montmul_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// Copied in
+
+#define y %rcx
+
+// mulpadd (high,low,x) adds rdx * x to a register-pair (high,low)
+// maintaining consistent double-carrying with adcx and adox,
+// using %rax and %rbx as temporaries.
+
+#define mulpadd(high,low,x)             \
+        mulxq   x, %rax, %rbx ;            \
+        adcxq   %rax, low ;               \
+        adoxq   %rbx, high
+
+bignum_montmul_p521:
+
+// Save more registers to play with
+
+        pushq   %rbp
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Copy y into a safe register to start with
+
+        movq    %rdx, y
+
+// Clone of the main body of bignum_8_16, writing back the low 8 words
+// to the output buffer z and keeping the top half in %r15,...,%r8
+
+        xorl   %ebp, %ebp
+        movq   (y), %rdx
+        mulxq  (x), %r8, %r9
+        movq   %r8, (z)
+        mulxq  0x8(x), %rbx, %r10
+        adcq   %rbx, %r9
+        mulxq  0x10(x), %rbx, %r11
+        adcq   %rbx, %r10
+        mulxq  0x18(x), %rbx, %r12
+        adcq   %rbx, %r11
+        mulxq  0x20(x), %rbx, %r13
+        adcq   %rbx, %r12
+        mulxq  0x28(x), %rbx, %r14
+        adcq   %rbx, %r13
+        mulxq  0x30(x), %rbx, %r15
+        adcq   %rbx, %r14
+        mulxq  0x38(x), %rbx, %r8
+        adcq   %rbx, %r15
+        adcq   %rbp, %r8
+        movq   0x8(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        movq   %r9, 0x8(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x38(x), %rax, %r9
+        adcxq  %rax, %r8
+        adoxq  %rbp, %r9
+        adcq   %rbp, %r9
+        movq   0x10(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        movq   %r10, 0x10(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x38(x), %rax, %r10
+        adcxq  %rax, %r9
+        adoxq  %rbp, %r10
+        adcq   %rbp, %r10
+        movq   0x18(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        movq   %r11, 0x18(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        mulxq  0x38(x), %rax, %r11
+        adcxq  %rax, %r10
+        adoxq  %rbp, %r11
+        adcq   %rbp, %r11
+        movq   0x20(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        movq   %r12, 0x20(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        mulxq  0x38(x), %rax, %r12
+        adcxq  %rax, %r11
+        adoxq  %rbp, %r12
+        adcq   %rbp, %r12
+        movq   0x28(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        movq   %r13, 0x28(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        mulxq  0x38(x), %rax, %r13
+        adcxq  %rax, %r12
+        adoxq  %rbp, %r13
+        adcq   %rbp, %r13
+        movq   0x30(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        movq   %r14, 0x30(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        mulxq  0x38(x), %rax, %r14
+        adcxq  %rax, %r13
+        adoxq  %rbp, %r14
+        adcq   %rbp, %r14
+        movq   0x38(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        movq   %r15, 0x38(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        mulxq  0x38(x), %rax, %r15
+        adcxq  %rax, %r14
+        adoxq  %rbp, %r15
+        adcq   %rbp, %r15
+
+// Accumulate x[8] * y[0..7], extending the window to %rbp,%r15,...,%r8
+
+        movq    64(x), %rdx
+        xorl    %ebp, %ebp
+        mulpadd(%r9,%r8,(y))
+        mulpadd(%r10,%r9,8(y))
+        mulpadd(%r11,%r10,16(y))
+        mulpadd(%r12,%r11,24(y))
+        mulpadd(%r13,%r12,32(y))
+        mulpadd(%r14,%r13,40(y))
+        mulpadd(%r15,%r14,48(y))
+        mulxq   56(y), %rax, %rbx
+        adcxq   %rax, %r15
+        adoxq   %rbp, %rbx
+        adcq    %rbx, %rbp
+
+// Accumulate y[8] * x[0..8] within this extended window %rbp,%r15,...,%r8
+
+        movq    64(y), %rdx
+        xorl    %eax, %eax
+        mulpadd(%r9,%r8,(x))
+        mulpadd(%r10,%r9,8(x))
+        mulpadd(%r11,%r10,16(x))
+        mulpadd(%r12,%r11,24(x))
+        mulpadd(%r13,%r12,32(x))
+        mulpadd(%r14,%r13,40(x))
+        mulpadd(%r15,%r14,48(x))
+        mulxq   56(x), %rax, %rbx
+        adcxq   %rax, %r15
+        adoxq   %rbx, %rbp
+        mulxq   64(x), %rax, %rbx
+        adcq    %rax, %rbp
+
+// Rotate the upper portion right 9 bits since 2^512 == 2^-9 (mod p_521)
+// Let rotated result %rbp,%r15,%r14,...,%r8 be h (high) and z[0..7] be l (low)
+
+        movq    %r8, %rax
+        andq    $0x1FF, %rax
+        shrdq   $9, %r9, %r8
+        shrdq   $9, %r10, %r9
+        shrdq   $9, %r11, %r10
+        shrdq   $9, %r12, %r11
+        shrdq   $9, %r13, %r12
+        shrdq   $9, %r14, %r13
+        shrdq   $9, %r15, %r14
+        shrdq   $9, %rbp, %r15
+        shrq    $9, %rbp
+        addq    %rax, %rbp
+
+// Force carry-in then add to get s = h + l + 1
+// but actually add all 1s in the top 53 bits to get simple carry out
+
+        stc
+        adcq    (z), %r8
+        adcq    8(z), %r9
+        adcq    16(z), %r10
+        adcq    24(z), %r11
+        adcq    32(z), %r12
+        adcq    40(z), %r13
+        adcq    48(z), %r14
+        adcq    56(z), %r15
+        adcq    $~0x1FF, %rbp
+
+// Now CF is set <=> h + l + 1 >= 2^521 <=> h + l >= p_521,
+// in which case the lower 521 bits are already right. Otherwise if
+// CF is clear, we want to subtract 1. Hence subtract the complement
+// of the carry flag then mask the top word, which scrubs the
+// padding in either case.
+
+        cmc
+        sbbq    $0, %r8
+        sbbq    $0, %r9
+        sbbq    $0, %r10
+        sbbq    $0, %r11
+        sbbq    $0, %r12
+        sbbq    $0, %r13
+        sbbq    $0, %r14
+        sbbq    $0, %r15
+        sbbq    $0, %rbp
+        andq    $0x1FF, %rbp
+
+// So far, this has been the same as a pure modular multiply.
+// Now finally the Montgomery ingredient, which is just a 521-bit
+// rotation by 9*64 - 521 = 55 bits right. Write digits back as
+// they are created.
+
+        movq    %r8, %rax
+        shrdq   $55, %r9, %r8
+        movq    %r8, (z)
+        shrdq   $55, %r10, %r9
+        movq    %r9, 8(z)
+        shrdq   $55, %r11, %r10
+        shlq    $9, %rax
+        movq    %r10, 16(z)
+        shrdq   $55, %r12, %r11
+        movq    %r11, 24(z)
+        shrdq   $55, %r13, %r12
+        movq    %r12, 32(z)
+        orq     %rax, %rbp
+        shrdq   $55, %r14, %r13
+        movq    %r13, 40(z)
+        shrdq   $55, %r15, %r14
+        movq    %r14, 48(z)
+        shrdq   $55, %rbp, %r15
+        movq    %r15, 56(z)
+        shrq    $55, %rbp
+        movq    %rbp, 64(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+        popq    %rbp
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
@@ -1,0 +1,336 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^576) mod p_521
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_montmul_p521_alt
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Does z := (x * y / 2^576) mod p_521, assuming x < p_521, y < p_521. This
+// means the Montgomery base is the "native size" 2^{9*64} = 2^576; since
+// p_521 is a Mersenne prime the basic modular multiplication bignum_mul_p521
+// can be considered a Montgomery operation to base 2^521.
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_montmul_p521_alt
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// This is moved from %rdx to free it for muls
+
+#define y %rcx
+
+// Macro for the key "multiply and add to (c,h,l)" step
+
+#define combadd(c,h,l,numa,numb)                \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+// A minutely shorter form for when c = 0 initially
+
+#define combadz(c,h,l,numa,numb)                \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    c, c
+
+// A short form where we don't expect a top carry
+
+#define combads(h,l,numa,numb)                  \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h
+
+bignum_montmul_p521_alt:
+
+// Make more registers available
+
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Copy y into a safe register to start with
+
+        movq    %rdx, y
+
+// Copy y into a safe register to start with
+
+        mov %rdx, y
+
+// Start doing a conventional columnwise multiplication,
+// temporarily storing the lower 9 digits to the output buffer.
+// Start with result term 0
+
+        movq    (x), %rax
+        mulq     (y)
+
+        movq    %rax, (z)
+        movq    %rdx, %r9
+        xorq    %r10, %r10
+
+// Result term 1
+
+        xorq    %r11, %r11
+        combads(%r10,%r9,(x),8(y))
+        combadz(%r11,%r10,%r9,8(x),(y))
+        movq    %r9, 8(z)
+
+// Result term 2
+
+        xorq    %r12, %r12
+        combadz(%r12,%r11,%r10,(x),16(y))
+        combadd(%r12,%r11,%r10,8(x),8(y))
+        combadd(%r12,%r11,%r10,16(x),(y))
+        movq    %r10, 16(z)
+
+// Result term 3
+
+        xorq    %r13, %r13
+        combadz(%r13,%r12,%r11,(x),24(y))
+        combadd(%r13,%r12,%r11,8(x),16(y))
+        combadd(%r13,%r12,%r11,16(x),8(y))
+        combadd(%r13,%r12,%r11,24(x),(y))
+        movq    %r11, 24(z)
+
+// Result term 4
+
+        xorq    %r14, %r14
+        combadz(%r14,%r13,%r12,(x),32(y))
+        combadd(%r14,%r13,%r12,8(x),24(y))
+        combadd(%r14,%r13,%r12,16(x),16(y))
+        combadd(%r14,%r13,%r12,24(x),8(y))
+        combadd(%r14,%r13,%r12,32(x),(y))
+        movq    %r12, 32(z)
+
+// Result term 5
+
+        xorq    %r15, %r15
+        combadz(%r15,%r14,%r13,(x),40(y))
+        combadd(%r15,%r14,%r13,8(x),32(y))
+        combadd(%r15,%r14,%r13,16(x),24(y))
+        combadd(%r15,%r14,%r13,24(x),16(y))
+        combadd(%r15,%r14,%r13,32(x),8(y))
+        combadd(%r15,%r14,%r13,40(x),(y))
+        movq    %r13, 40(z)
+
+// Result term 6
+
+        xorq    %r8, %r8
+        combadz(%r8,%r15,%r14,(x),48(y))
+        combadd(%r8,%r15,%r14,8(x),40(y))
+        combadd(%r8,%r15,%r14,16(x),32(y))
+        combadd(%r8,%r15,%r14,24(x),24(y))
+        combadd(%r8,%r15,%r14,32(x),16(y))
+        combadd(%r8,%r15,%r14,40(x),8(y))
+        combadd(%r8,%r15,%r14,48(x),(y))
+        movq    %r14, 48(z)
+
+// Result term 7
+
+        xorq    %r9, %r9
+        combadz(%r9,%r8,%r15,(x),56(y))
+        combadd(%r9,%r8,%r15,8(x),48(y))
+        combadd(%r9,%r8,%r15,16(x),40(y))
+        combadd(%r9,%r8,%r15,24(x),32(y))
+        combadd(%r9,%r8,%r15,32(x),24(y))
+        combadd(%r9,%r8,%r15,40(x),16(y))
+        combadd(%r9,%r8,%r15,48(x),8(y))
+        combadd(%r9,%r8,%r15,56(x),(y))
+        movq    %r15, 56(z)
+
+// Result term 8
+
+        xorq    %r10, %r10
+        combadz(%r10,%r9,%r8,(x),64(y))
+        combadd(%r10,%r9,%r8,8(x),56(y))
+        combadd(%r10,%r9,%r8,16(x),48(y))
+        combadd(%r10,%r9,%r8,24(x),40(y))
+        combadd(%r10,%r9,%r8,32(x),32(y))
+        combadd(%r10,%r9,%r8,40(x),24(y))
+        combadd(%r10,%r9,%r8,48(x),16(y))
+        combadd(%r10,%r9,%r8,56(x),8(y))
+        combadd(%r10,%r9,%r8,64(x),(y))
+        movq    %r8, 64(z)
+
+// At this point we suspend writing back results and collect them
+// in a register window. Next is result term 9
+
+        xorq    %r11, %r11
+        combadz(%r11,%r10,%r9,8(x),64(y))
+        combadd(%r11,%r10,%r9,16(x),56(y))
+        combadd(%r11,%r10,%r9,24(x),48(y))
+        combadd(%r11,%r10,%r9,32(x),40(y))
+        combadd(%r11,%r10,%r9,40(x),32(y))
+        combadd(%r11,%r10,%r9,48(x),24(y))
+        combadd(%r11,%r10,%r9,56(x),16(y))
+        combadd(%r11,%r10,%r9,64(x),8(y))
+
+// Result term 10
+
+        xorq    %r12, %r12
+        combadz(%r12,%r11,%r10,16(x),64(y))
+        combadd(%r12,%r11,%r10,24(x),56(y))
+        combadd(%r12,%r11,%r10,32(x),48(y))
+        combadd(%r12,%r11,%r10,40(x),40(y))
+        combadd(%r12,%r11,%r10,48(x),32(y))
+        combadd(%r12,%r11,%r10,56(x),24(y))
+        combadd(%r12,%r11,%r10,64(x),16(y))
+
+// Result term 11
+
+        xorq    %r13, %r13
+        combadz(%r13,%r12,%r11,24(x),64(y))
+        combadd(%r13,%r12,%r11,32(x),56(y))
+        combadd(%r13,%r12,%r11,40(x),48(y))
+        combadd(%r13,%r12,%r11,48(x),40(y))
+        combadd(%r13,%r12,%r11,56(x),32(y))
+        combadd(%r13,%r12,%r11,64(x),24(y))
+
+// Result term 12
+
+        xorq    %r14, %r14
+        combadz(%r14,%r13,%r12,32(x),64(y))
+        combadd(%r14,%r13,%r12,40(x),56(y))
+        combadd(%r14,%r13,%r12,48(x),48(y))
+        combadd(%r14,%r13,%r12,56(x),40(y))
+        combadd(%r14,%r13,%r12,64(x),32(y))
+
+// Result term 13
+
+        xorq    %r15, %r15
+        combadz(%r15,%r14,%r13,40(x),64(y))
+        combadd(%r15,%r14,%r13,48(x),56(y))
+        combadd(%r15,%r14,%r13,56(x),48(y))
+        combadd(%r15,%r14,%r13,64(x),40(y))
+
+// Result term 14
+
+        xorq    %r8, %r8
+        combadz(%r8,%r15,%r14,48(x),64(y))
+        combadd(%r8,%r15,%r14,56(x),56(y))
+        combadd(%r8,%r15,%r14,64(x),48(y))
+
+// Result term 15
+
+        combads(%r8,%r15,56(x),64(y))
+        combads(%r8,%r15,64(x),56(y))
+
+// Result term 16
+
+        movq    64(x), %rax
+        imulq   64(y), %rax
+        addq    %r8, %rax
+
+// Now the upper portion is [%rax;%r15;%r14;%r13;%r12;%r11;%r10;%r9;[z+64]].
+// Rotate the upper portion right 9 bits since 2^512 == 2^-9 (mod p_521)
+// Let rotated result %rdx,%r15,%r14,...,%r8 be h (high) and z[0..7] be l (low)
+
+        movq    64(z), %r8
+        movq    %r8, %rdx
+        andq    $0x1FF, %rdx
+        shrdq   $9, %r9, %r8
+        shrdq   $9, %r10, %r9
+        shrdq   $9, %r11, %r10
+        shrdq   $9, %r12, %r11
+        shrdq   $9, %r13, %r12
+        shrdq   $9, %r14, %r13
+        shrdq   $9, %r15, %r14
+        shrdq   $9, %rax, %r15
+        shrq    $9, %rax
+        addq    %rax, %rdx
+
+// Force carry-in then add to get s = h + l + 1
+// but actually add all 1s in the top 53 bits to get simple carry out
+
+        stc
+        adcq    (z), %r8
+        adcq    8(z), %r9
+        adcq    16(z), %r10
+        adcq    24(z), %r11
+        adcq    32(z), %r12
+        adcq    40(z), %r13
+        adcq    48(z), %r14
+        adcq    56(z), %r15
+        adcq    $~0x1FF, %rdx
+
+// Now CF is set <=> h + l + 1 >= 2^521 <=> h + l >= p_521,
+// in which case the lower 521 bits are already right. Otherwise if
+// CF is clear, we want to subtract 1. Hence subtract the complement
+// of the carry flag then mask the top word, which scrubs the
+// padding in either case.
+
+        cmc
+        sbbq    $0, %r8
+        sbbq    $0, %r9
+        sbbq    $0, %r10
+        sbbq    $0, %r11
+        sbbq    $0, %r12
+        sbbq    $0, %r13
+        sbbq    $0, %r14
+        sbbq    $0, %r15
+        sbbq    $0, %rdx
+        andq    $0x1FF, %rdx
+
+// So far, this has been the same as a pure modular multiply.
+// Now finally the Montgomery ingredient, which is just a 521-bit
+// rotation by 9*64 - 521 = 55 bits right. Write digits back as
+// they are created.
+
+        movq    %r8, %rax
+        shrdq   $55, %r9, %r8
+        movq    %r8, (z)
+        shrdq   $55, %r10, %r9
+        movq    %r9, 8(z)
+        shrdq   $55, %r11, %r10
+        shlq    $9, %rax
+        movq    %r10, 16(z)
+        shrdq   $55, %r12, %r11
+        movq    %r11, 24(z)
+        shrdq   $55, %r13, %r12
+        movq    %r12, 32(z)
+        orq     %rax, %rdx
+        shrdq   $55, %r14, %r13
+        movq    %r13, 40(z)
+        shrdq   $55, %r15, %r14
+        movq    %r14, 48(z)
+        shrdq   $55, %rdx, %r15
+        movq    %r15, 56(z)
+        shrq    $55, %rdx
+        movq    %rdx, 64(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
@@ -1,0 +1,316 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^576) mod p_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_montsqr_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Does z := (x^2 / 2^576) mod p_521, assuming x < p_521. This means the
+// Montgomery base is the "native size" 2^{9*64} = 2^576; since p_521 is
+// a Mersenne prime the basic modular squaring bignum_sqr_p521 can be
+// considered a Montgomery operation to base 2^521.
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_montsqr_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// A zero register
+
+#define zero %rbp
+#define zeroe %ebp
+
+// mulpadd(high,low,i) adds %rdx * x[i] to a register-pair (high,low)
+// maintaining consistent double-carrying with adcx and adox,
+// using %rax and %rcx as temporaries.
+
+#define mulpadd(high,low,I)             \
+        mulxq   I(x), %rax, %rcx ;        \
+        adcxq   %rax, low ;               \
+        adoxq   %rcx, high
+
+// mulpade(high,low,i) adds %rdx * x[i] to a register-pair (high,low)
+// maintaining consistent double-carrying with adcx and adox,
+// using %rax as a temporary, assuming high created from scratch
+// and that zero has value zero.
+
+#define mulpade(high,low,I)             \
+        mulxq   I(x), %rax, high ;       \
+        adcxq   %rax, low ;               \
+        adoxq   zero, high
+
+bignum_montsqr_p521:
+
+// Save more registers to play with
+
+        pushq   %rbp
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Do a basic 8x8 squaring writing back z[0..7] but keeping the
+// top half in the usual rotating register window %r15,...,%r8. Except
+// for the lack of full writeback this is the same as bignum_sqr_8_16.
+
+        xorl    zeroe, zeroe
+
+        movq    (x), %rdx
+        mulxq   8(x), %r9, %rax
+        movq    %r9, 8(z)
+        mulxq   16(x), %r10, %rcx
+        adcxq   %rax, %r10
+        movq    %r10, 16(z)
+        mulxq   24(x), %r11, %rax
+        adcxq   %rcx, %r11
+        mulxq   32(x), %r12, %rcx
+        adcxq   %rax, %r12
+        mulxq   40(x), %r13, %rax
+        adcxq   %rcx, %r13
+        mulxq   48(x), %r14, %rcx
+        adcxq   %rax, %r14
+        mulxq   56(x), %r15, %r8
+        adcxq   %rcx, %r15
+        adcxq   zero, %r8
+
+        xorl    zeroe, zeroe
+        movq    8(x), %rdx
+        mulpadd(%r12,%r11,16)
+        movq    %r11, 24(z)
+        mulpadd(%r13,%r12,24)
+        movq    %r12, 32(z)
+        mulpadd(%r14,%r13,32)
+        mulpadd(%r15,%r14,40)
+        mulpadd(%r8,%r15,48)
+        mulpade(%r9,%r8,56)
+        movq    32(x), %rdx
+        mulpade(%r10,%r9,40)
+        adcxq   zero, %r10
+
+        xorl    zeroe, zeroe
+        movq    16(x), %rdx
+        mulpadd(%r14,%r13,24)
+        movq    %r13, 40(z)
+        mulpadd(%r15,%r14,32)
+        movq    %r14, 48(z)
+        mulpadd(%r8,%r15,40)
+        mulpadd(%r9,%r8,48)
+        mulpadd(%r10,%r9,56)
+        movq    48(x), %rdx
+        mulpade(%r11,%r10,32)
+        mulpade(%r12,%r11,40)
+        adcxq   zero, %r12
+
+        xorl    zeroe, zeroe
+        movq    24(x), %rdx
+        mulpadd(%r8,%r15,32)
+        movq    %r15, 56(z)
+        mulpadd(%r9,%r8,40)
+        mulpadd(%r10,%r9,48)
+        mulpadd(%r11,%r10,56)
+        movq    56(x), %rdx
+        mulpadd(%r12,%r11,32)
+        mulpade(%r13,%r12,40)
+        mulpade(%r14,%r13,48)
+        adcxq   zero, %r14
+
+        xorl    zeroe, zeroe
+        movq    (x), %rdx
+        mulxq   %rdx, %rax, %rcx
+        movq    %rax, (z)
+        movq    8(z), %rax
+        adcxq   %rax, %rax
+        adoxq   %rcx, %rax
+        movq    %rax, 8(z)
+
+        movq    16(z), %rax
+        movq    8(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %rax, %rax
+        adoxq   %rdx, %rax
+        movq    %rax, 16(z)
+        movq    24(z), %rax
+        adcxq   %rax, %rax
+        adoxq   %rcx, %rax
+        movq    %rax, 24(z)
+
+        movq    32(z), %rax
+        movq    16(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %rax, %rax
+        adoxq   %rdx, %rax
+        movq    %rax, 32(z)
+        movq    40(z), %rax
+        adcxq   %rax, %rax
+        adoxq   %rcx, %rax
+        movq    %rax, 40(z)
+
+        movq    48(z), %rax
+        movq    24(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %rax, %rax
+        adoxq   %rdx, %rax
+        movq    %rax, 48(z)
+        movq    56(z), %rax
+        adcxq   %rax, %rax
+        adoxq   %rcx, %rax
+        movq    %rax, 56(z)
+
+        movq    32(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %r8, %r8
+        adoxq   %rdx, %r8
+        adcxq   %r9, %r9
+        adoxq   %rcx, %r9
+
+        movq    40(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %r10, %r10
+        adoxq   %rdx, %r10
+        adcxq   %r11, %r11
+        adoxq   %rcx, %r11
+
+        movq    48(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %r12, %r12
+        adoxq   %rdx, %r12
+        adcxq   %r13, %r13
+        adoxq   %rcx, %r13
+
+        movq    56(x), %rdx
+        mulxq   %rdx, %rdx, %r15
+        adcxq   %r14, %r14
+        adoxq   %rdx, %r14
+        adcxq   zero, %r15
+        adoxq   zero, %r15
+
+// Augment the high part with the contribution from the top little word C.
+// If we write the input as 2^512 * C + x then we are otherwise just doing
+// x^2, so we need to add to the high part 2^512 * C^2 + (2 * C) * x.
+// The initial doubling add of C also clears the CF and OF flags as desired.
+// We extend the window now to the 9-element %rbp,%r15,%r14,...,%r8.
+
+        movq    64(x), %rdx
+        movq    %rdx, %rbp
+        imulq   %rbp, %rbp
+        addq    %rdx, %rdx
+        mulpadd(%r9,%r8,0)
+        mulpadd(%r10,%r9,8)
+        mulpadd(%r11,%r10,16)
+        mulpadd(%r12,%r11,24)
+        mulpadd(%r13,%r12,32)
+        mulpadd(%r14,%r13,40)
+        mulpadd(%r15,%r14,48)
+        mulxq  56(x), %rax, %rcx
+        adcxq  %rax, %r15
+        adoxq  %rcx, %rbp
+        adcq   $0, %rbp
+
+// Rotate the upper portion right 9 bits since 2^512 == 2^-9 (mod p_521)
+// Let rotated result %rbp,%r15,%r14,...,%r8 be h (high) and z[0..7] be l (low)
+
+        movq    %r8, %rax
+        andq    $0x1FF, %rax
+        shrdq   $9, %r9, %r8
+        shrdq   $9, %r10, %r9
+        shrdq   $9, %r11, %r10
+        shrdq   $9, %r12, %r11
+        shrdq   $9, %r13, %r12
+        shrdq   $9, %r14, %r13
+        shrdq   $9, %r15, %r14
+        shrdq   $9, %rbp, %r15
+        shrq    $9, %rbp
+        addq    %rax, %rbp
+
+// Force carry-in then add to get s = h + l + 1
+// but actually add all 1s in the top 53 bits to get simple carry out
+
+        stc
+        adcq    (z), %r8
+        adcq    8(z), %r9
+        adcq    16(z), %r10
+        adcq    24(z), %r11
+        adcq    32(z), %r12
+        adcq    40(z), %r13
+        adcq    48(z), %r14
+        adcq    56(z), %r15
+        adcq    $~0x1FF, %rbp
+
+// Now CF is set <=> h + l + 1 >= 2^521 <=> h + l >= p_521,
+// in which case the lower 521 bits are already right. Otherwise if
+// CF is clear, we want to subtract 1. Hence subtract the complement
+// of the carry flag then mask the top word, which scrubs the
+// padding in either case.
+
+        cmc
+        sbbq    $0, %r8
+        sbbq    $0, %r9
+        sbbq    $0, %r10
+        sbbq    $0, %r11
+        sbbq    $0, %r12
+        sbbq    $0, %r13
+        sbbq    $0, %r14
+        sbbq    $0, %r15
+        sbbq    $0, %rbp
+        andq    $0x1FF, %rbp
+
+// So far, this has been the same as a pure modular squaring.
+// Now finally the Montgomery ingredient, which is just a 521-bit
+// rotation by 9*64 - 521 = 55 bits right. Write digits back as
+// they are created.
+
+        movq    %r8, %rax
+        shrdq   $55, %r9, %r8
+        movq    %r8, (z)
+        shrdq   $55, %r10, %r9
+        movq    %r9, 8(z)
+        shrdq   $55, %r11, %r10
+        shlq    $9, %rax
+        movq    %r10, 16(z)
+        shrdq   $55, %r12, %r11
+        movq    %r11, 24(z)
+        shrdq   $55, %r13, %r12
+        movq    %r12, 32(z)
+        orq     %rax, %rbp
+        shrdq   $55, %r14, %r13
+        movq    %r13, 40(z)
+        shrdq   $55, %r15, %r14
+        movq    %r14, 48(z)
+        shrdq   $55, %rbp, %r15
+        movq    %r15, 56(z)
+        shrq    $55, %rbp
+        movq    %rbp, 64(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbp
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
@@ -1,0 +1,329 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^576) mod p_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_montsqr_p521_alt
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Does z := (x^2 / 2^576) mod p_521, assuming x < p_521. This means the
+// Montgomery base is the "native size" 2^{9*64} = 2^576; since p_521 is
+// a Mersenne prime the basic modular squaring bignum_sqr_p521 can be
+// considered a Montgomery operation to base 2^521.
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_montsqr_p521_alt
+        .text
+
+// Input arguments
+
+#define z %rdi
+#define x %rsi
+
+// Macro for the key "multiply and add to (c,h,l)" step
+
+#define combadd(c,h,l,numa,numb)                \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+// Set up initial window (c,h,l) = numa * numb
+
+#define combaddz(c,h,l,numa,numb)               \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        xorq    c, c ;                           \
+        movq    %rax, l ;                         \
+        movq    %rdx, h
+
+// Doubling step (c,h,l) = 2 * (c,hh,ll) + (0,h,l)
+
+#define doubladd(c,h,l,hh,ll)                   \
+        addq    ll, ll ;                         \
+        adcq    hh, hh ;                         \
+        adcq    c, c ;                           \
+        addq    ll, l ;                          \
+        adcq    hh, h ;                          \
+        adcq    $0, c
+
+// Square term incorporation (c,h,l) += numba^2
+
+#define combadd1(c,h,l,numa)                    \
+        movq    numa, %rax ;                      \
+        mulq    %rax;                            \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+// A short form where we don't expect a top carry
+
+#define combads(h,l,numa)                       \
+        movq    numa, %rax ;                      \
+        mulq    %rax;                            \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h
+
+// A version doubling directly before adding, for single non-square terms
+
+#define combadd2(c,h,l,numa,numb)               \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        addq    %rax, %rax ;                       \
+        adcq    %rdx, %rdx ;                       \
+        adcq    $0, c ;                           \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+bignum_montsqr_p521_alt:
+
+// Make more registers available
+
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Start doing a conventional columnwise squaring,
+// temporarily storing the lower 9 digits to the output buffer.
+// Start with result term 0
+
+        movq    (x), %rax
+        mulq    %rax
+
+        movq    %rax, (z)
+        movq    %rdx, %r9
+        xorq    %r10, %r10
+
+// Result term 1
+
+        xorq    %r11, %r11
+        combadd2(%r11,%r10,%r9,(x),8(x))
+        movq    %r9, 8(z)
+
+// Result term 2
+
+        xorq    %r12, %r12
+        combadd1(%r12,%r11,%r10,8(x))
+        combadd2(%r12,%r11,%r10,(x),16(x))
+        movq    %r10, 16(z)
+
+// Result term 3
+
+        combaddz(%r13,%rcx,%rbx,(x),24(x))
+        combadd(%r13,%rcx,%rbx,8(x),16(x))
+        doubladd(%r13,%r12,%r11,%rcx,%rbx)
+        movq    %r11, 24(z)
+
+// Result term 4
+
+        combaddz(%r14,%rcx,%rbx,(x),32(x))
+        combadd(%r14,%rcx,%rbx,8(x),24(x))
+        doubladd(%r14,%r13,%r12,%rcx,%rbx)
+        combadd1(%r14,%r13,%r12,16(x))
+        movq    %r12, 32(z)
+
+// Result term 5
+
+        combaddz(%r15,%rcx,%rbx,(x),40(x))
+        combadd(%r15,%rcx,%rbx,8(x),32(x))
+        combadd(%r15,%rcx,%rbx,16(x),24(x))
+        doubladd(%r15,%r14,%r13,%rcx,%rbx)
+        movq    %r13, 40(z)
+
+// Result term 6
+
+        combaddz(%r8,%rcx,%rbx,(x),48(x))
+        combadd(%r8,%rcx,%rbx,8(x),40(x))
+        combadd(%r8,%rcx,%rbx,16(x),32(x))
+        doubladd(%r8,%r15,%r14,%rcx,%rbx)
+        combadd1(%r8,%r15,%r14,24(x))
+        movq    %r14, 48(z)
+
+// Result term 7
+
+        combaddz(%r9,%rcx,%rbx,(x),56(x))
+        combadd(%r9,%rcx,%rbx,8(x),48(x))
+        combadd(%r9,%rcx,%rbx,16(x),40(x))
+        combadd(%r9,%rcx,%rbx,24(x),32(x))
+        doubladd(%r9,%r8,%r15,%rcx,%rbx)
+        movq    %r15, 56(z)
+
+// Result term 8
+
+        combaddz(%r10,%rcx,%rbx,(x),64(x))
+        combadd(%r10,%rcx,%rbx,8(x),56(x))
+        combadd(%r10,%rcx,%rbx,16(x),48(x))
+        combadd(%r10,%rcx,%rbx,24(x),40(x))
+        doubladd(%r10,%r9,%r8,%rcx,%rbx)
+        combadd1(%r10,%r9,%r8,32(x))
+        movq    %r8, 64(z)
+
+// We now stop writing back and keep remaining results in a register window.
+// Continue with result term 9
+
+        combaddz(%r11,%rcx,%rbx,8(x),64(x))
+        combadd(%r11,%rcx,%rbx,16(x),56(x))
+        combadd(%r11,%rcx,%rbx,24(x),48(x))
+        combadd(%r11,%rcx,%rbx,32(x),40(x))
+        doubladd(%r11,%r10,%r9,%rcx,%rbx)
+
+// Result term 10
+
+        combaddz(%r12,%rcx,%rbx,16(x),64(x))
+        combadd(%r12,%rcx,%rbx,24(x),56(x))
+        combadd(%r12,%rcx,%rbx,32(x),48(x))
+        doubladd(%r12,%r11,%r10,%rcx,%rbx)
+        combadd1(%r12,%r11,%r10,40(x))
+
+// Result term 11
+
+        combaddz(%r13,%rcx,%rbx,24(x),64(x))
+        combadd(%r13,%rcx,%rbx,32(x),56(x))
+        combadd(%r13,%rcx,%rbx,40(x),48(x))
+        doubladd(%r13,%r12,%r11,%rcx,%rbx)
+
+// Result term 12
+
+        combaddz(%r14,%rcx,%rbx,32(x),64(x))
+        combadd(%r14,%rcx,%rbx,40(x),56(x))
+        doubladd(%r14,%r13,%r12,%rcx,%rbx)
+        combadd1(%r14,%r13,%r12,48(x))
+
+// Result term 13
+
+        combaddz(%r15,%rcx,%rbx,40(x),64(x))
+        combadd(%r15,%rcx,%rbx,48(x),56(x))
+        doubladd(%r15,%r14,%r13,%rcx,%rbx);
+
+// Result term 14
+
+        xorq    %r8, %r8
+        combadd1(%r8,%r15,%r14,56(x))
+        combadd2(%r8,%r15,%r14,48(x),64(x))
+
+// Result term 15
+
+        movq    56(x), %rax
+        mulq     64(x)
+        addq    %rax, %rax
+        adcq    %rdx, %rdx
+        addq    %rax, %r15
+        adcq    %rdx, %r8
+
+// Result term 16
+
+        movq    64(x), %rax
+        imulq   %rax, %rax
+        addq    %r8, %rax
+
+// Now the upper portion is [%rax;%r15;%r14;%r13;%r12;%r11;%r10;%r9;[z+64]].
+// Rotate the upper portion right 9 bits since 2^512 == 2^-9 (mod p_521)
+// Let rotated result %rdx,%r15,%r14,...,%r8 be h (high) and z[0..7] be l (low)
+
+        movq    64(z), %r8
+        movq    %r8, %rdx
+        andq    $0x1FF, %rdx
+        shrdq   $9, %r9, %r8
+        shrdq   $9, %r10, %r9
+        shrdq   $9, %r11, %r10
+        shrdq   $9, %r12, %r11
+        shrdq   $9, %r13, %r12
+        shrdq   $9, %r14, %r13
+        shrdq   $9, %r15, %r14
+        shrdq   $9, %rax, %r15
+        shrq    $9, %rax
+        addq    %rax, %rdx
+
+// Force carry-in then add to get s = h + l + 1
+// but actually add all 1s in the top 53 bits to get simple carry out
+
+        stc
+        adcq    (z), %r8
+        adcq    8(z), %r9
+        adcq    16(z), %r10
+        adcq    24(z), %r11
+        adcq    32(z), %r12
+        adcq    40(z), %r13
+        adcq    48(z), %r14
+        adcq    56(z), %r15
+        adcq    $~0x1FF, %rdx
+
+// Now CF is set <=> h + l + 1 >= 2^521 <=> h + l >= p_521,
+// in which case the lower 521 bits are already right. Otherwise if
+// CF is clear, we want to subtract 1. Hence subtract the complement
+// of the carry flag then mask the top word, which scrubs the
+// padding in either case.
+
+        cmc
+        sbbq    $0, %r8
+        sbbq    $0, %r9
+        sbbq    $0, %r10
+        sbbq    $0, %r11
+        sbbq    $0, %r12
+        sbbq    $0, %r13
+        sbbq    $0, %r14
+        sbbq    $0, %r15
+        sbbq    $0, %rdx
+        andq    $0x1FF, %rdx
+
+// So far, this has been the same as a pure modular squaring.
+// Now finally the Montgomery ingredient, which is just a 521-bit
+// rotation by 9*64 - 521 = 55 bits right. Write digits back as
+// they are created.
+
+        movq    %r8, %rax
+        shrdq   $55, %r9, %r8
+        movq    %r8, (z)
+        shrdq   $55, %r10, %r9
+        movq    %r9, 8(z)
+        shrdq   $55, %r11, %r10
+        shlq    $9, %rax
+        movq    %r10, 16(z)
+        shrdq   $55, %r12, %r11
+        movq    %r11, 24(z)
+        shrdq   $55, %r13, %r12
+        movq    %r12, 32(z)
+        orq     %rax, %rdx
+        shrdq   $55, %r14, %r13
+        movq    %r13, 40(z)
+        shrdq   $55, %r15, %r14
+        movq    %r14, 48(z)
+        shrdq   $55, %rdx, %r15
+        movq    %r15, 56(z)
+        shrq    $55, %rdx
+        movq    %rdx, 64(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
@@ -1,0 +1,383 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply modulo p_521, z := (x * y) mod p_521, assuming x and y reduced
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_mul_p521
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_mul_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// Copied in
+
+#define y %rcx
+
+// mulpadd (high,low,x) adds rdx * x to a register-pair (high,low)
+// maintaining consistent double-carrying with adcx and adox,
+// using %rax and %rbx as temporaries.
+
+#define mulpadd(high,low,x)             \
+        mulxq   x, %rax, %rbx ;            \
+        adcxq   %rax, low ;               \
+        adoxq   %rbx, high
+
+bignum_mul_p521:
+
+// Save more registers to play with
+
+        pushq   %rbp
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Copy y into a safe register to start with
+
+        movq    %rdx, y
+
+// Clone of the main body of bignum_8_16, writing back the low 8 words
+// to the output buffer z and keeping the top half in %r15,...,%r8
+
+        xorl   %ebp, %ebp
+        movq   (y), %rdx
+        mulxq  (x), %r8, %r9
+        movq   %r8, (z)
+        mulxq  0x8(x), %rbx, %r10
+        adcq   %rbx, %r9
+        mulxq  0x10(x), %rbx, %r11
+        adcq   %rbx, %r10
+        mulxq  0x18(x), %rbx, %r12
+        adcq   %rbx, %r11
+        mulxq  0x20(x), %rbx, %r13
+        adcq   %rbx, %r12
+        mulxq  0x28(x), %rbx, %r14
+        adcq   %rbx, %r13
+        mulxq  0x30(x), %rbx, %r15
+        adcq   %rbx, %r14
+        mulxq  0x38(x), %rbx, %r8
+        adcq   %rbx, %r15
+        adcq   %rbp, %r8
+        movq   0x8(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        movq   %r9, 0x8(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x38(x), %rax, %r9
+        adcxq  %rax, %r8
+        adoxq  %rbp, %r9
+        adcq   %rbp, %r9
+        movq   0x10(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        movq   %r10, 0x10(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x38(x), %rax, %r10
+        adcxq  %rax, %r9
+        adoxq  %rbp, %r10
+        adcq   %rbp, %r10
+        movq   0x18(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        movq   %r11, 0x18(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        mulxq  0x38(x), %rax, %r11
+        adcxq  %rax, %r10
+        adoxq  %rbp, %r11
+        adcq   %rbp, %r11
+        movq   0x20(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        movq   %r12, 0x20(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        mulxq  0x38(x), %rax, %r12
+        adcxq  %rax, %r11
+        adoxq  %rbp, %r12
+        adcq   %rbp, %r12
+        movq   0x28(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        movq   %r13, 0x28(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        mulxq  0x38(x), %rax, %r13
+        adcxq  %rax, %r12
+        adoxq  %rbp, %r13
+        adcq   %rbp, %r13
+        movq   0x30(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r14
+        adoxq  %rbx, %r15
+        movq   %r14, 0x30(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        mulxq  0x38(x), %rax, %r14
+        adcxq  %rax, %r13
+        adoxq  %rbp, %r14
+        adcq   %rbp, %r14
+        movq   0x38(y), %rdx
+        xorl   %ebp, %ebp
+        mulxq  (x), %rax, %rbx
+        adcxq  %rax, %r15
+        adoxq  %rbx, %r8
+        movq   %r15, 0x38(z)
+        mulxq  0x8(x), %rax, %rbx
+        adcxq  %rax, %r8
+        adoxq  %rbx, %r9
+        mulxq  0x10(x), %rax, %rbx
+        adcxq  %rax, %r9
+        adoxq  %rbx, %r10
+        mulxq  0x18(x), %rax, %rbx
+        adcxq  %rax, %r10
+        adoxq  %rbx, %r11
+        mulxq  0x20(x), %rax, %rbx
+        adcxq  %rax, %r11
+        adoxq  %rbx, %r12
+        mulxq  0x28(x), %rax, %rbx
+        adcxq  %rax, %r12
+        adoxq  %rbx, %r13
+        mulxq  0x30(x), %rax, %rbx
+        adcxq  %rax, %r13
+        adoxq  %rbx, %r14
+        mulxq  0x38(x), %rax, %r15
+        adcxq  %rax, %r14
+        adoxq  %rbp, %r15
+        adcq   %rbp, %r15
+
+// Accumulate x[8] * y[0..7], extending the window to %rbp,%r15,...,%r8
+
+        movq    64(x), %rdx
+        xorl    %ebp, %ebp
+        mulpadd(%r9,%r8,(y))
+        mulpadd(%r10,%r9,8(y))
+        mulpadd(%r11,%r10,16(y))
+        mulpadd(%r12,%r11,24(y))
+        mulpadd(%r13,%r12,32(y))
+        mulpadd(%r14,%r13,40(y))
+        mulpadd(%r15,%r14,48(y))
+        mulxq   56(y), %rax, %rbx
+        adcxq   %rax, %r15
+        adoxq   %rbp, %rbx
+        adcq    %rbx, %rbp
+
+// Accumulate y[8] * x[0..8] within this extended window %rbp,%r15,...,%r8
+
+        movq    64(y), %rdx
+        xorl    %eax, %eax
+        mulpadd(%r9,%r8,(x))
+        mulpadd(%r10,%r9,8(x))
+        mulpadd(%r11,%r10,16(x))
+        mulpadd(%r12,%r11,24(x))
+        mulpadd(%r13,%r12,32(x))
+        mulpadd(%r14,%r13,40(x))
+        mulpadd(%r15,%r14,48(x))
+        mulxq   56(x), %rax, %rbx
+        adcxq   %rax, %r15
+        adoxq   %rbx, %rbp
+        mulxq   64(x), %rax, %rbx
+        adcq    %rax, %rbp
+
+// Rotate the upper portion right 9 bits since 2^512 == 2^-9 (mod p_521)
+// Let rotated result %rbp,%r15,%r14,...,%r8 be h (high) and z[0..7] be l (low)
+
+        movq    %r8, %rax
+        andq    $0x1FF, %rax
+        shrdq   $9, %r9, %r8
+        shrdq   $9, %r10, %r9
+        shrdq   $9, %r11, %r10
+        shrdq   $9, %r12, %r11
+        shrdq   $9, %r13, %r12
+        shrdq   $9, %r14, %r13
+        shrdq   $9, %r15, %r14
+        shrdq   $9, %rbp, %r15
+        shrq    $9, %rbp
+        addq    %rax, %rbp
+
+// Force carry-in then add to get s = h + l + 1
+// but actually add all 1s in the top 53 bits to get simple carry out
+
+        stc
+        adcq    (z), %r8
+        adcq    8(z), %r9
+        adcq    16(z), %r10
+        adcq    24(z), %r11
+        adcq    32(z), %r12
+        adcq    40(z), %r13
+        adcq    48(z), %r14
+        adcq    56(z), %r15
+        adcq    $~0x1FF, %rbp
+
+// Now CF is set <=> h + l + 1 >= 2^521 <=> h + l >= p_521,
+// in which case the lower 521 bits are already right. Otherwise if
+// CF is clear, we want to subtract 1. Hence subtract the complement
+// of the carry flag then mask the top word, which scrubs the
+// padding in either case. Write digits back as they are created.
+
+        cmc
+        sbbq    $0, %r8
+        movq    %r8, (z)
+        sbbq    $0, %r9
+        movq    %r9, 8(z)
+        sbbq    $0, %r10
+        movq    %r10, 16(z)
+        sbbq    $0, %r11
+        movq    %r11, 24(z)
+        sbbq    $0, %r12
+        movq    %r12, 32(z)
+        sbbq    $0, %r13
+        movq    %r13, 40(z)
+        sbbq    $0, %r14
+        movq    %r14, 48(z)
+        sbbq    $0, %r15
+        movq    %r15, 56(z)
+        sbbq    $0, %rbp
+        andq    $0x1FF, %rbp
+        movq    %rbp, 64(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+        popq    %rbp
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
@@ -1,0 +1,313 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply modulo p_521, z := (x * y) mod p_521, assuming x and y reduced
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_mul_p521_alt
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_mul_p521_alt
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// This is moved from %rdx to free it for muls
+
+#define y %rcx
+
+// Macro for the key "multiply and add to (c,h,l)" step
+
+#define combadd(c,h,l,numa,numb)                \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+// A minutely shorter form for when c = 0 initially
+
+#define combadz(c,h,l,numa,numb)                \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    c, c
+
+// A short form where we don't expect a top carry
+
+#define combads(h,l,numa,numb)                  \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h
+
+bignum_mul_p521_alt:
+
+// Make more registers available
+
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Copy y into a safe register to start with
+
+        movq    %rdx, y
+
+// Copy y into a safe register to start with
+
+        mov %rdx, y
+
+// Start doing a conventional columnwise multiplication,
+// temporarily storing the lower 9 digits to the output buffer.
+// Start with result term 0
+
+        movq    (x), %rax
+        mulq     (y)
+
+        movq    %rax, (z)
+        movq    %rdx, %r9
+        xorq    %r10, %r10
+
+// Result term 1
+
+        xorq    %r11, %r11
+        combads(%r10,%r9,(x),8(y))
+        combadz(%r11,%r10,%r9,8(x),(y))
+        movq    %r9, 8(z)
+
+// Result term 2
+
+        xorq    %r12, %r12
+        combadz(%r12,%r11,%r10,(x),16(y))
+        combadd(%r12,%r11,%r10,8(x),8(y))
+        combadd(%r12,%r11,%r10,16(x),(y))
+        movq    %r10, 16(z)
+
+// Result term 3
+
+        xorq    %r13, %r13
+        combadz(%r13,%r12,%r11,(x),24(y))
+        combadd(%r13,%r12,%r11,8(x),16(y))
+        combadd(%r13,%r12,%r11,16(x),8(y))
+        combadd(%r13,%r12,%r11,24(x),(y))
+        movq    %r11, 24(z)
+
+// Result term 4
+
+        xorq    %r14, %r14
+        combadz(%r14,%r13,%r12,(x),32(y))
+        combadd(%r14,%r13,%r12,8(x),24(y))
+        combadd(%r14,%r13,%r12,16(x),16(y))
+        combadd(%r14,%r13,%r12,24(x),8(y))
+        combadd(%r14,%r13,%r12,32(x),(y))
+        movq    %r12, 32(z)
+
+// Result term 5
+
+        xorq    %r15, %r15
+        combadz(%r15,%r14,%r13,(x),40(y))
+        combadd(%r15,%r14,%r13,8(x),32(y))
+        combadd(%r15,%r14,%r13,16(x),24(y))
+        combadd(%r15,%r14,%r13,24(x),16(y))
+        combadd(%r15,%r14,%r13,32(x),8(y))
+        combadd(%r15,%r14,%r13,40(x),(y))
+        movq    %r13, 40(z)
+
+// Result term 6
+
+        xorq    %r8, %r8
+        combadz(%r8,%r15,%r14,(x),48(y))
+        combadd(%r8,%r15,%r14,8(x),40(y))
+        combadd(%r8,%r15,%r14,16(x),32(y))
+        combadd(%r8,%r15,%r14,24(x),24(y))
+        combadd(%r8,%r15,%r14,32(x),16(y))
+        combadd(%r8,%r15,%r14,40(x),8(y))
+        combadd(%r8,%r15,%r14,48(x),(y))
+        movq    %r14, 48(z)
+
+// Result term 7
+
+        xorq    %r9, %r9
+        combadz(%r9,%r8,%r15,(x),56(y))
+        combadd(%r9,%r8,%r15,8(x),48(y))
+        combadd(%r9,%r8,%r15,16(x),40(y))
+        combadd(%r9,%r8,%r15,24(x),32(y))
+        combadd(%r9,%r8,%r15,32(x),24(y))
+        combadd(%r9,%r8,%r15,40(x),16(y))
+        combadd(%r9,%r8,%r15,48(x),8(y))
+        combadd(%r9,%r8,%r15,56(x),(y))
+        movq    %r15, 56(z)
+
+// Result term 8
+
+        xorq    %r10, %r10
+        combadz(%r10,%r9,%r8,(x),64(y))
+        combadd(%r10,%r9,%r8,8(x),56(y))
+        combadd(%r10,%r9,%r8,16(x),48(y))
+        combadd(%r10,%r9,%r8,24(x),40(y))
+        combadd(%r10,%r9,%r8,32(x),32(y))
+        combadd(%r10,%r9,%r8,40(x),24(y))
+        combadd(%r10,%r9,%r8,48(x),16(y))
+        combadd(%r10,%r9,%r8,56(x),8(y))
+        combadd(%r10,%r9,%r8,64(x),(y))
+        movq    %r8, 64(z)
+
+// At this point we suspend writing back results and collect them
+// in a register window. Next is result term 9
+
+        xorq    %r11, %r11
+        combadz(%r11,%r10,%r9,8(x),64(y))
+        combadd(%r11,%r10,%r9,16(x),56(y))
+        combadd(%r11,%r10,%r9,24(x),48(y))
+        combadd(%r11,%r10,%r9,32(x),40(y))
+        combadd(%r11,%r10,%r9,40(x),32(y))
+        combadd(%r11,%r10,%r9,48(x),24(y))
+        combadd(%r11,%r10,%r9,56(x),16(y))
+        combadd(%r11,%r10,%r9,64(x),8(y))
+
+// Result term 10
+
+        xorq    %r12, %r12
+        combadz(%r12,%r11,%r10,16(x),64(y))
+        combadd(%r12,%r11,%r10,24(x),56(y))
+        combadd(%r12,%r11,%r10,32(x),48(y))
+        combadd(%r12,%r11,%r10,40(x),40(y))
+        combadd(%r12,%r11,%r10,48(x),32(y))
+        combadd(%r12,%r11,%r10,56(x),24(y))
+        combadd(%r12,%r11,%r10,64(x),16(y))
+
+// Result term 11
+
+        xorq    %r13, %r13
+        combadz(%r13,%r12,%r11,24(x),64(y))
+        combadd(%r13,%r12,%r11,32(x),56(y))
+        combadd(%r13,%r12,%r11,40(x),48(y))
+        combadd(%r13,%r12,%r11,48(x),40(y))
+        combadd(%r13,%r12,%r11,56(x),32(y))
+        combadd(%r13,%r12,%r11,64(x),24(y))
+
+// Result term 12
+
+        xorq    %r14, %r14
+        combadz(%r14,%r13,%r12,32(x),64(y))
+        combadd(%r14,%r13,%r12,40(x),56(y))
+        combadd(%r14,%r13,%r12,48(x),48(y))
+        combadd(%r14,%r13,%r12,56(x),40(y))
+        combadd(%r14,%r13,%r12,64(x),32(y))
+
+// Result term 13
+
+        xorq    %r15, %r15
+        combadz(%r15,%r14,%r13,40(x),64(y))
+        combadd(%r15,%r14,%r13,48(x),56(y))
+        combadd(%r15,%r14,%r13,56(x),48(y))
+        combadd(%r15,%r14,%r13,64(x),40(y))
+
+// Result term 14
+
+        xorq    %r8, %r8
+        combadz(%r8,%r15,%r14,48(x),64(y))
+        combadd(%r8,%r15,%r14,56(x),56(y))
+        combadd(%r8,%r15,%r14,64(x),48(y))
+
+// Result term 15
+
+        combads(%r8,%r15,56(x),64(y))
+        combads(%r8,%r15,64(x),56(y))
+
+// Result term 16
+
+        movq    64(x), %rax
+        imulq   64(y), %rax
+        addq    %r8, %rax
+
+// Now the upper portion is [%rax;%r15;%r14;%r13;%r12;%r11;%r10;%r9;[z+64]].
+// Rotate the upper portion right 9 bits since 2^512 == 2^-9 (mod p_521)
+// Let rotated result %rdx,%r15,%r14,...,%r8 be h (high) and z[0..7] be l (low)
+
+        movq    64(z), %r8
+        movq    %r8, %rdx
+        andq    $0x1FF, %rdx
+        shrdq   $9, %r9, %r8
+        shrdq   $9, %r10, %r9
+        shrdq   $9, %r11, %r10
+        shrdq   $9, %r12, %r11
+        shrdq   $9, %r13, %r12
+        shrdq   $9, %r14, %r13
+        shrdq   $9, %r15, %r14
+        shrdq   $9, %rax, %r15
+        shrq    $9, %rax
+        addq    %rax, %rdx
+
+// Force carry-in then add to get s = h + l + 1
+// but actually add all 1s in the top 53 bits to get simple carry out
+
+        stc
+        adcq    (z), %r8
+        adcq    8(z), %r9
+        adcq    16(z), %r10
+        adcq    24(z), %r11
+        adcq    32(z), %r12
+        adcq    40(z), %r13
+        adcq    48(z), %r14
+        adcq    56(z), %r15
+        adcq    $~0x1FF, %rdx
+
+// Now CF is set <=> h + l + 1 >= 2^521 <=> h + l >= p_521,
+// in which case the lower 521 bits are already right. Otherwise if
+// CF is clear, we want to subtract 1. Hence subtract the complement
+// of the carry flag then mask the top word, which scrubs the
+// padding in either case. Write digits back as they are created.
+
+        cmc
+        sbbq    $0, %r8
+        movq    %r8, (z)
+        sbbq    $0, %r9
+        movq    %r9, 8(z)
+        sbbq    $0, %r10
+        movq    %r10, 16(z)
+        sbbq    $0, %r11
+        movq    %r11, 24(z)
+        sbbq    $0, %r12
+        movq    %r12, 32(z)
+        sbbq    $0, %r13
+        movq    %r13, 40(z)
+        sbbq    $0, %r14
+        movq    %r14, 48(z)
+        sbbq    $0, %r15
+        movq    %r15, 56(z)
+        sbbq    $0, %rdx
+        andq    $0x1FF, %rdx
+        movq    %rdx, 64(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Negate modulo p_521, z := (-x) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_neg_p521 (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_neg_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+#define p %rax
+#define d0 %rcx
+#define d1 %rdx
+#define d2 %r8
+#define d3 %r9
+#define d4 %r10
+#define d5 %r11
+
+bignum_neg_p521:
+
+// Load most inputs (into the limited registers) and OR all of them to get p
+
+                movq    (x), d0
+                movq    d0, p
+                movq    8(x), d1
+                orq     d1, p
+                movq    16(x), d2
+                orq     d2, p
+                movq    24(x), d3
+                orq     d3, p
+                movq    32(x), d4
+                orq     d4, p
+                movq    40(x), d5
+                orq     d5, p
+                orq     48(x), p
+                orq     56(x), p
+                orq     64(x), p
+
+// Turn p into a bitmask for "input is nonzero", so that we avoid doing
+// -0 = p_521 and hence maintain strict modular reduction
+
+                negq    p
+                sbbq    p, p
+
+// Since p_521 is all 1s, the subtraction is just an exclusive-or with p
+// to give an optional inversion, with a slight fiddle for the top digit.
+
+                xorq    p, d0
+                movq    d0, (z)
+                xorq    p, d1
+                movq    d1, 8(z)
+                xorq    p, d2
+                movq    d2, 16(z)
+                xorq    p, d3
+                movq    d3, 24(z)
+                xorq    p, d4
+                movq    d4, 32(z)
+                xorq    p, d5
+                movq    d5, 40(z)
+                movq    48(x), d0
+                xorq    p, d0
+                movq    d0, 48(z)
+                movq    56(x), d1
+                xorq    p, d1
+                movq    d1, 56(z)
+                movq    64(x), d2
+                andq    $0x1FF, p
+                xorq    p, d2
+                movq    d2, 64(z)
+
+// Return
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Optionally negate modulo p_521, z := (-x) mod p_521 (if p nonzero) or
+// z := x (if p zero), assuming x reduced
+// Inputs p, x[9]; output z[9]
+//
+//    extern void bignum_optneg_p521
+//      (uint64_t z[static 9], uint64_t p, uint64_t x[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_optneg_p521
+        .text
+
+#define z %rdi
+#define p %rsi
+#define x %rdx
+
+#define q %rax
+#define d0 %rcx
+#define d1 %r8
+#define d2 %r9
+#define d3 %r10
+#define d4 %r11
+
+bignum_optneg_p521:
+
+// Load most inputs (into the limited registers) and OR all of them to get q
+
+                movq    (x), d0
+                movq    d0, q
+                movq    8(x), d1
+                orq     d1, q
+                movq    16(x), d2
+                orq     d2, q
+                movq    24(x), d3
+                orq     d3, q
+                movq    32(x), d4
+                orq     d4, q
+                orq     40(x), q
+                orq     48(x), q
+                orq     56(x), q
+                orq     64(x), q
+
+// Turn q into a bitmask for "input is nonzero and p is nonzero", so that
+// we avoid doing -0 = p_521 and hence maintain strict modular reduction
+
+                negq    q
+                sbbq    q, q
+                testq   p, p
+                cmovzq  p, q
+
+// Since p_521 is all 1s, the subtraction is just an exclusive-or with q
+// to give an optional inversion, with a slight fiddle for the top digit.
+
+                xorq    q, d0
+                movq    d0, (z)
+                xorq    q, d1
+                movq    d1, 8(z)
+                xorq    q, d2
+                movq    d2, 16(z)
+                xorq    q, d3
+                movq    d3, 24(z)
+                xorq    q, d4
+                movq    d4, 32(z)
+                movq    40(x), d0
+                xorq    q, d0
+                movq    d0, 40(z)
+                movq    48(x), d1
+                xorq    q, d1
+                movq    d1, 48(z)
+                movq    56(x), d2
+                xorq    q, d2
+                movq    d2, 56(z)
+                movq    64(x), d3
+                andq    $0x1FF, q
+                xorq    q, d3
+                movq    d3, 64(z)
+
+// Return
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
@@ -1,0 +1,292 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Square modulo p_521, z := (x^2) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_sqr_p521 (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_sqr_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// A zero register
+
+#define zero %rbp
+#define zeroe %ebp
+
+// mulpadd(high,low,i) adds %rdx * x[i] to a register-pair (high,low)
+// maintaining consistent double-carrying with adcx and adox,
+// using %rax and %rcx as temporaries.
+
+#define mulpadd(high,low,I)             \
+        mulxq   I(x), %rax, %rcx ;        \
+        adcxq   %rax, low ;               \
+        adoxq   %rcx, high
+
+// mulpade(high,low,i) adds %rdx * x[i] to a register-pair (high,low)
+// maintaining consistent double-carrying with adcx and adox,
+// using %rax as a temporary, assuming high created from scratch
+// and that zero has value zero.
+
+#define mulpade(high,low,I)             \
+        mulxq   I(x), %rax, high ;       \
+        adcxq   %rax, low ;               \
+        adoxq   zero, high
+
+bignum_sqr_p521:
+
+// Save more registers to play with
+
+        pushq   %rbp
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Do a basic 8x8 squaring writing back z[0..7] but keeping the
+// top half in the usual rotating register window %r15,...,%r8. Except
+// for the lack of full writeback this is the same as bignum_sqr_8_16.
+
+        xorl    zeroe, zeroe
+
+        movq    (x), %rdx
+        mulxq   8(x), %r9, %rax
+        movq    %r9, 8(z)
+        mulxq   16(x), %r10, %rcx
+        adcxq   %rax, %r10
+        movq    %r10, 16(z)
+        mulxq   24(x), %r11, %rax
+        adcxq   %rcx, %r11
+        mulxq   32(x), %r12, %rcx
+        adcxq   %rax, %r12
+        mulxq   40(x), %r13, %rax
+        adcxq   %rcx, %r13
+        mulxq   48(x), %r14, %rcx
+        adcxq   %rax, %r14
+        mulxq   56(x), %r15, %r8
+        adcxq   %rcx, %r15
+        adcxq   zero, %r8
+
+        xorl    zeroe, zeroe
+        movq    8(x), %rdx
+        mulpadd(%r12,%r11,16)
+        movq    %r11, 24(z)
+        mulpadd(%r13,%r12,24)
+        movq    %r12, 32(z)
+        mulpadd(%r14,%r13,32)
+        mulpadd(%r15,%r14,40)
+        mulpadd(%r8,%r15,48)
+        mulpade(%r9,%r8,56)
+        movq    32(x), %rdx
+        mulpade(%r10,%r9,40)
+        adcxq   zero, %r10
+
+        xorl    zeroe, zeroe
+        movq    16(x), %rdx
+        mulpadd(%r14,%r13,24)
+        movq    %r13, 40(z)
+        mulpadd(%r15,%r14,32)
+        movq    %r14, 48(z)
+        mulpadd(%r8,%r15,40)
+        mulpadd(%r9,%r8,48)
+        mulpadd(%r10,%r9,56)
+        movq    48(x), %rdx
+        mulpade(%r11,%r10,32)
+        mulpade(%r12,%r11,40)
+        adcxq   zero, %r12
+
+        xorl    zeroe, zeroe
+        movq    24(x), %rdx
+        mulpadd(%r8,%r15,32)
+        movq    %r15, 56(z)
+        mulpadd(%r9,%r8,40)
+        mulpadd(%r10,%r9,48)
+        mulpadd(%r11,%r10,56)
+        movq    56(x), %rdx
+        mulpadd(%r12,%r11,32)
+        mulpade(%r13,%r12,40)
+        mulpade(%r14,%r13,48)
+        adcxq   zero, %r14
+
+        xorl    zeroe, zeroe
+        movq    (x), %rdx
+        mulxq   %rdx, %rax, %rcx
+        movq    %rax, (z)
+        movq    8(z), %rax
+        adcxq   %rax, %rax
+        adoxq   %rcx, %rax
+        movq    %rax, 8(z)
+
+        movq    16(z), %rax
+        movq    8(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %rax, %rax
+        adoxq   %rdx, %rax
+        movq    %rax, 16(z)
+        movq    24(z), %rax
+        adcxq   %rax, %rax
+        adoxq   %rcx, %rax
+        movq    %rax, 24(z)
+
+        movq    32(z), %rax
+        movq    16(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %rax, %rax
+        adoxq   %rdx, %rax
+        movq    %rax, 32(z)
+        movq    40(z), %rax
+        adcxq   %rax, %rax
+        adoxq   %rcx, %rax
+        movq    %rax, 40(z)
+
+        movq    48(z), %rax
+        movq    24(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %rax, %rax
+        adoxq   %rdx, %rax
+        movq    %rax, 48(z)
+        movq    56(z), %rax
+        adcxq   %rax, %rax
+        adoxq   %rcx, %rax
+        movq    %rax, 56(z)
+
+        movq    32(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %r8, %r8
+        adoxq   %rdx, %r8
+        adcxq   %r9, %r9
+        adoxq   %rcx, %r9
+
+        movq    40(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %r10, %r10
+        adoxq   %rdx, %r10
+        adcxq   %r11, %r11
+        adoxq   %rcx, %r11
+
+        movq    48(x), %rdx
+        mulxq   %rdx, %rdx, %rcx
+        adcxq   %r12, %r12
+        adoxq   %rdx, %r12
+        adcxq   %r13, %r13
+        adoxq   %rcx, %r13
+
+        movq    56(x), %rdx
+        mulxq   %rdx, %rdx, %r15
+        adcxq   %r14, %r14
+        adoxq   %rdx, %r14
+        adcxq   zero, %r15
+        adoxq   zero, %r15
+
+// Augment the high part with the contribution from the top little word C.
+// If we write the input as 2^512 * C + x then we are otherwise just doing
+// x^2, so we need to add to the high part 2^512 * C^2 + (2 * C) * x.
+// The initial doubling add of C also clears the CF and OF flags as desired.
+// We extend the window now to the 9-element %rbp,%r15,%r14,...,%r8.
+
+        movq    64(x), %rdx
+        movq    %rdx, %rbp
+        imulq   %rbp, %rbp
+        addq    %rdx, %rdx
+        mulpadd(%r9,%r8,0)
+        mulpadd(%r10,%r9,8)
+        mulpadd(%r11,%r10,16)
+        mulpadd(%r12,%r11,24)
+        mulpadd(%r13,%r12,32)
+        mulpadd(%r14,%r13,40)
+        mulpadd(%r15,%r14,48)
+        mulxq  56(x), %rax, %rcx
+        adcxq  %rax, %r15
+        adoxq  %rcx, %rbp
+        adcq   $0, %rbp
+
+// Rotate the upper portion right 9 bits since 2^512 == 2^-9 (mod p_521)
+// Let rotated result %rbp,%r15,%r14,...,%r8 be h (high) and z[0..7] be l (low)
+
+        movq    %r8, %rax
+        andq    $0x1FF, %rax
+        shrdq   $9, %r9, %r8
+        shrdq   $9, %r10, %r9
+        shrdq   $9, %r11, %r10
+        shrdq   $9, %r12, %r11
+        shrdq   $9, %r13, %r12
+        shrdq   $9, %r14, %r13
+        shrdq   $9, %r15, %r14
+        shrdq   $9, %rbp, %r15
+        shrq    $9, %rbp
+        addq    %rax, %rbp
+
+// Force carry-in then add to get s = h + l + 1
+// but actually add all 1s in the top 53 bits to get simple carry out
+
+        stc
+        adcq    (z), %r8
+        adcq    8(z), %r9
+        adcq    16(z), %r10
+        adcq    24(z), %r11
+        adcq    32(z), %r12
+        adcq    40(z), %r13
+        adcq    48(z), %r14
+        adcq    56(z), %r15
+        adcq    $~0x1FF, %rbp
+
+// Now CF is set <=> h + l + 1 >= 2^521 <=> h + l >= p_521,
+// in which case the lower 521 bits are already right. Otherwise if
+// CF is clear, we want to subtract 1. Hence subtract the complement
+// of the carry flag then mask the top word, which scrubs the
+// padding in either case. Write digits back as they are created.
+
+        cmc
+        sbbq    $0, %r8
+        movq    %r8, (z)
+        sbbq    $0, %r9
+        movq    %r9, 8(z)
+        sbbq    $0, %r10
+        movq    %r10, 16(z)
+        sbbq    $0, %r11
+        movq    %r11, 24(z)
+        sbbq    $0, %r12
+        movq    %r12, 32(z)
+        sbbq    $0, %r13
+        movq    %r13, 40(z)
+        sbbq    $0, %r14
+        movq    %r14, 48(z)
+        sbbq    $0, %r15
+        movq    %r15, 56(z)
+        sbbq    $0, %rbp
+        andq    $0x1FF, %rbp
+        movq    %rbp, 64(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbp
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
@@ -1,0 +1,304 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Square modulo p_521, z := (x^2) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_sqr_p521_alt (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_sqr_p521_alt
+        .text
+
+// Input arguments
+
+#define z %rdi
+#define x %rsi
+
+// Macro for the key "multiply and add to (c,h,l)" step
+
+#define combadd(c,h,l,numa,numb)                \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+// Set up initial window (c,h,l) = numa * numb
+
+#define combaddz(c,h,l,numa,numb)               \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        xorq    c, c ;                           \
+        movq    %rax, l ;                         \
+        movq    %rdx, h
+
+// Doubling step (c,h,l) = 2 * (c,hh,ll) + (0,h,l)
+
+#define doubladd(c,h,l,hh,ll)                   \
+        addq    ll, ll ;                         \
+        adcq    hh, hh ;                         \
+        adcq    c, c ;                           \
+        addq    ll, l ;                          \
+        adcq    hh, h ;                          \
+        adcq    $0, c
+
+// Square term incorporation (c,h,l) += numba^2
+
+#define combadd1(c,h,l,numa)                    \
+        movq    numa, %rax ;                      \
+        mulq    %rax;                            \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+// A short form where we don't expect a top carry
+
+#define combads(h,l,numa)                       \
+        movq    numa, %rax ;                      \
+        mulq    %rax;                            \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h
+
+// A version doubling directly before adding, for single non-square terms
+
+#define combadd2(c,h,l,numa,numb)               \
+        movq    numa, %rax ;                      \
+        mulq     numb;                 \
+        addq    %rax, %rax ;                       \
+        adcq    %rdx, %rdx ;                       \
+        adcq    $0, c ;                           \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+bignum_sqr_p521_alt:
+
+// Make more registers available
+
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Start doing a conventional columnwise squaring,
+// temporarily storing the lower 9 digits to the output buffer.
+// Start with result term 0
+
+        movq    (x), %rax
+        mulq    %rax
+
+        movq    %rax, (z)
+        movq    %rdx, %r9
+        xorq    %r10, %r10
+
+// Result term 1
+
+        xorq    %r11, %r11
+        combadd2(%r11,%r10,%r9,(x),8(x))
+        movq    %r9, 8(z)
+
+// Result term 2
+
+        xorq    %r12, %r12
+        combadd1(%r12,%r11,%r10,8(x))
+        combadd2(%r12,%r11,%r10,(x),16(x))
+        movq    %r10, 16(z)
+
+// Result term 3
+
+        combaddz(%r13,%rcx,%rbx,(x),24(x))
+        combadd(%r13,%rcx,%rbx,8(x),16(x))
+        doubladd(%r13,%r12,%r11,%rcx,%rbx)
+        movq    %r11, 24(z)
+
+// Result term 4
+
+        combaddz(%r14,%rcx,%rbx,(x),32(x))
+        combadd(%r14,%rcx,%rbx,8(x),24(x))
+        doubladd(%r14,%r13,%r12,%rcx,%rbx)
+        combadd1(%r14,%r13,%r12,16(x))
+        movq    %r12, 32(z)
+
+// Result term 5
+
+        combaddz(%r15,%rcx,%rbx,(x),40(x))
+        combadd(%r15,%rcx,%rbx,8(x),32(x))
+        combadd(%r15,%rcx,%rbx,16(x),24(x))
+        doubladd(%r15,%r14,%r13,%rcx,%rbx)
+        movq    %r13, 40(z)
+
+// Result term 6
+
+        combaddz(%r8,%rcx,%rbx,(x),48(x))
+        combadd(%r8,%rcx,%rbx,8(x),40(x))
+        combadd(%r8,%rcx,%rbx,16(x),32(x))
+        doubladd(%r8,%r15,%r14,%rcx,%rbx)
+        combadd1(%r8,%r15,%r14,24(x))
+        movq    %r14, 48(z)
+
+// Result term 7
+
+        combaddz(%r9,%rcx,%rbx,(x),56(x))
+        combadd(%r9,%rcx,%rbx,8(x),48(x))
+        combadd(%r9,%rcx,%rbx,16(x),40(x))
+        combadd(%r9,%rcx,%rbx,24(x),32(x))
+        doubladd(%r9,%r8,%r15,%rcx,%rbx)
+        movq    %r15, 56(z)
+
+// Result term 8
+
+        combaddz(%r10,%rcx,%rbx,(x),64(x))
+        combadd(%r10,%rcx,%rbx,8(x),56(x))
+        combadd(%r10,%rcx,%rbx,16(x),48(x))
+        combadd(%r10,%rcx,%rbx,24(x),40(x))
+        doubladd(%r10,%r9,%r8,%rcx,%rbx)
+        combadd1(%r10,%r9,%r8,32(x))
+        movq    %r8, 64(z)
+
+// We now stop writing back and keep remaining results in a register window.
+// Continue with result term 9
+
+        combaddz(%r11,%rcx,%rbx,8(x),64(x))
+        combadd(%r11,%rcx,%rbx,16(x),56(x))
+        combadd(%r11,%rcx,%rbx,24(x),48(x))
+        combadd(%r11,%rcx,%rbx,32(x),40(x))
+        doubladd(%r11,%r10,%r9,%rcx,%rbx)
+
+// Result term 10
+
+        combaddz(%r12,%rcx,%rbx,16(x),64(x))
+        combadd(%r12,%rcx,%rbx,24(x),56(x))
+        combadd(%r12,%rcx,%rbx,32(x),48(x))
+        doubladd(%r12,%r11,%r10,%rcx,%rbx)
+        combadd1(%r12,%r11,%r10,40(x))
+
+// Result term 11
+
+        combaddz(%r13,%rcx,%rbx,24(x),64(x))
+        combadd(%r13,%rcx,%rbx,32(x),56(x))
+        combadd(%r13,%rcx,%rbx,40(x),48(x))
+        doubladd(%r13,%r12,%r11,%rcx,%rbx)
+
+// Result term 12
+
+        combaddz(%r14,%rcx,%rbx,32(x),64(x))
+        combadd(%r14,%rcx,%rbx,40(x),56(x))
+        doubladd(%r14,%r13,%r12,%rcx,%rbx)
+        combadd1(%r14,%r13,%r12,48(x))
+
+// Result term 13
+
+        combaddz(%r15,%rcx,%rbx,40(x),64(x))
+        combadd(%r15,%rcx,%rbx,48(x),56(x))
+        doubladd(%r15,%r14,%r13,%rcx,%rbx);
+
+// Result term 14
+
+        xorq    %r8, %r8
+        combadd1(%r8,%r15,%r14,56(x))
+        combadd2(%r8,%r15,%r14,48(x),64(x))
+
+// Result term 15
+
+        movq    56(x), %rax
+        mulq     64(x)
+        addq    %rax, %rax
+        adcq    %rdx, %rdx
+        addq    %rax, %r15
+        adcq    %rdx, %r8
+
+// Result term 16
+
+        movq    64(x), %rax
+        imulq   %rax, %rax
+        addq    %r8, %rax
+
+// Now the upper portion is [%rax;%r15;%r14;%r13;%r12;%r11;%r10;%r9;[z+64]].
+// Rotate the upper portion right 9 bits since 2^512 == 2^-9 (mod p_521)
+// Let rotated result %rdx,%r15,%r14,...,%r8 be h (high) and z[0..7] be l (low)
+
+        movq    64(z), %r8
+        movq    %r8, %rdx
+        andq    $0x1FF, %rdx
+        shrdq   $9, %r9, %r8
+        shrdq   $9, %r10, %r9
+        shrdq   $9, %r11, %r10
+        shrdq   $9, %r12, %r11
+        shrdq   $9, %r13, %r12
+        shrdq   $9, %r14, %r13
+        shrdq   $9, %r15, %r14
+        shrdq   $9, %rax, %r15
+        shrq    $9, %rax
+        addq    %rax, %rdx
+
+// Force carry-in then add to get s = h + l + 1
+// but actually add all 1s in the top 53 bits to get simple carry out
+
+        stc
+        adcq    (z), %r8
+        adcq    8(z), %r9
+        adcq    16(z), %r10
+        adcq    24(z), %r11
+        adcq    32(z), %r12
+        adcq    40(z), %r13
+        adcq    48(z), %r14
+        adcq    56(z), %r15
+        adcq    $~0x1FF, %rdx
+
+// Now CF is set <=> h + l + 1 >= 2^521 <=> h + l >= p_521,
+// in which case the lower 521 bits are already right. Otherwise if
+// CF is clear, we want to subtract 1. Hence subtract the complement
+// of the carry flag then mask the top word, which scrubs the
+// padding in either case. Write digits back as they are created.
+
+        cmc
+        sbbq    $0, %r8
+        movq    %r8, (z)
+        sbbq    $0, %r9
+        movq    %r9, 8(z)
+        sbbq    $0, %r10
+        movq    %r10, 16(z)
+        sbbq    $0, %r11
+        movq    %r11, 24(z)
+        sbbq    $0, %r12
+        movq    %r12, 32(z)
+        sbbq    $0, %r13
+        movq    %r13, 40(z)
+        sbbq    $0, %r14
+        movq    %r14, 48(z)
+        sbbq    $0, %r15
+        movq    %r15, 56(z)
+        sbbq    $0, %rdx
+        andq    $0x1FF, %rdx
+        movq    %rdx, 64(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
@@ -1,0 +1,111 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Subtract modulo p_521, z := (x - y) mod p_521
+// Inputs x[9], y[9]; output z[9]
+//
+//    extern void bignum_sub_p521
+//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_sub_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+#define y %rdx
+
+#define d0 %rax
+#define d1 %rcx
+#define d2 %r8
+#define d3 %r9
+#define d4 %r10
+#define d5 %r11
+#define d6 %r12
+#define d7 %rbx
+
+// Re-use one input pointer as other variable once safe to do so
+
+#define d8 %rsi
+
+
+
+bignum_sub_p521:
+
+// Save more registers to play with
+
+        pushq   %rbx
+        pushq   %r12
+
+// First just subtract the numbers as [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x - y
+
+        movq    (x), d0
+        subq    (y), d0
+        movq    8(x), d1
+        sbbq    8(y), d1
+        movq    16(x), d2
+        sbbq    16(y), d2
+        movq    24(x), d3
+        sbbq    24(y), d3
+        movq    32(x), d4
+        sbbq    32(y), d4
+        movq    40(x), d5
+        sbbq    40(y), d5
+        movq    48(x), d6
+        sbbq    48(y), d6
+        movq    56(x), d7
+        sbbq    56(y), d7
+        movq    64(x), d8
+        sbbq    64(y), d8
+
+// Now if x < y we want (x - y) + p_521 == (x - y) - 1 (mod 2^521)
+// Otherwise we just want the existing x - y result. So subtract
+// 1 iff the initial subtraction carried, then mask to 521 bits.
+// Write back the results as generated.
+
+        sbbq    $0, d0
+        movq    d0, (z)
+        sbbq    $0, d1
+        movq    d1, 8(z)
+        sbbq    $0, d2
+        movq    d2, 16(z)
+        sbbq    $0, d3
+        movq    d3, 24(z)
+        sbbq    $0, d4
+        movq    d4, 32(z)
+        sbbq    $0, d5
+        movq    d5, 40(z)
+        sbbq    $0, d6
+        movq    d6, 48(z)
+        sbbq    $0, d7
+        movq    d7, 56(z)
+        sbbq    $0, d8
+        andq    $0x1FF, d8
+        movq    d8, 64(z)
+
+// Restore registers and return
+
+        popq    %r12
+        popq    %rbx
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
@@ -1,0 +1,134 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Convert to Montgomery form z := (2^576 * x) mod p_521
+// Input x[9]; output z[9]
+//
+//    extern void bignum_tomont_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_tomont_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+#define d0 %rax
+#define d1 %rcx
+#define d2 %r8
+#define d3 %r9
+#define d4 %r10
+#define d5 %r11
+#define d6 %rbx
+
+#define d8 %rdx
+
+#define d8short %edx
+
+// Re-use the input pointer as other variable once safe to do so
+
+#define d7 %rsi
+
+bignum_tomont_p521:
+
+// Save one more register
+
+        pushq   %rbx
+
+// Separate out the input into x = 2^521 * H + L, so that x mod p_521 =
+// (H + L) mod p_521 = if H + L >= p_521 then H + L - p_521 else H + L.
+
+        movq    64(x), d0
+        movl    $0x1FF, d8short
+        andq    d0, d8
+        shrq    $9, d0
+
+// Force carry-in to get s = [d8;d7;d6;d5;d4;d3;d2;d1;d0] = H + L + 1.
+
+        stc
+        adcq    (x), d0
+        movq    8(x), d1
+        adcq    $0, d1
+        movq    16(x), d2
+        adcq    $0, d2
+        movq    24(x), d3
+        adcq    $0, d3
+        movq    32(x), d4
+        adcq    $0, d4
+        movq    40(x), d5
+        adcq    $0, d5
+        movq    48(x), d6
+        adcq    $0, d6
+        movq    56(x), d7
+        adcq    $0, d7
+        adcq    $0, d8
+
+// Set CF <=> s < 2^521 <=> H + L < p_521, so that if CF is set
+// we want H + L = s - 1, otherwise (H + L) - p_521 = s - 2^521.
+// This is done with just s - CF then masking to 521 bits.
+
+        cmpq    $512, d8
+
+        sbbq    $0, d0
+        sbbq    $0, d1
+        sbbq    $0, d2
+        sbbq    $0, d3
+        sbbq    $0, d4
+        sbbq    $0, d5
+        sbbq    $0, d6
+        sbbq    $0, d7
+        sbbq    $0, d8
+
+// So far, this is just a modular reduction as in bignum_mod_p521_9,
+// except that the final masking of d8 is skipped since that comes out
+// in the wash anyway from the next block, which is the Montgomery map,
+// multiplying by 2^576 modulo p_521. Because 2^521 == 1 (mod p_521)
+// this is just rotation left by 576 - 521 = 55 bits. Store back
+// digits as created, though in a slightly peculiar order because we
+// want to avoid using another register.
+
+        shldq   $55, d7, d8
+        shldq   $55, d6, d7
+        movq    d7, 56(z)
+        shldq   $55, d5, d6
+        movq    d6, 48(z)
+        shldq   $55, d4, d5
+        movq    d5, 40(z)
+        shldq   $55, d3, d4
+        movq    d4, 32(z)
+        shldq   $55, d2, d3
+        movq    d3, 24(z)
+        shldq   $55, d1, d2
+        movq    d2, 16(z)
+        shldq   $55, d0, d1
+        movq    d1, 8(z)
+        shldq   $55, d8, d0
+        movq    d0, (z)
+        andq    $0x1FF, d8
+        movq    d8, 64(z)
+
+// Restore register
+
+        popq    %rbx
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
@@ -1,0 +1,154 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Triple modulo p_521, z := (3 * x) mod p_521, assuming x reduced
+// Input x[9]; output z[9]
+//
+//    extern void bignum_triple_p521
+//     (uint64_t z[static 9], uint64_t x[static 9]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_triple_p521
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// d7 re-uses the input pointer when safe to do so
+
+#define d0 %rax
+#define d1 %rcx
+#define d2 %r8
+#define d3 %r9
+#define d4 %r10
+#define d5 %r11
+#define d6 %r12
+#define d7 %rsi
+#define d8 %rdx
+
+#define m %rbx
+#define mshort %ebx
+
+
+
+bignum_triple_p521:
+
+// Save more registers to play with
+
+                pushq   %rbx
+                pushq   %r12
+
+// Load the top (short) word first to compute the initial carry-in
+// Set OF according to bit 520, but *always* set CF to get a +1 bump
+
+                movq    64(x), m
+                movq    m, d8
+                shlq    $54, m
+                addq    m, m
+                stc
+
+// Use a double carry chain to compute x' + x + 1 where x' is a
+// 1-bit left rotation of x; this is then == 3 * x + 1 (mod p_521)
+// This gives us s = [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x + x' + 1.
+
+                movq    (x), m
+                movq    m, d0
+                adcxq   m, m
+                adoxq   m, d0
+                movq    8(x), m
+                movq    m, d1
+                adcxq   m, m
+                adoxq   m, d1
+                movq    16(x), m
+                movq    m, d2
+                adcxq   m, m
+                adoxq   m, d2
+                movq    24(x), m
+                movq    m, d3
+                adcxq   m, m
+                adoxq   m, d3
+                movq    32(x), m
+                movq    m, d4
+                adcxq   m, m
+                adoxq   m, d4
+                movq    40(x), m
+                movq    m, d5
+                adcxq   m, m
+                adoxq   m, d5
+                movq    48(x), m
+                movq    m, d6
+                adcxq   m, m
+                adoxq   m, d6
+                movq    56(x), m
+                movq    m, d7
+                adcxq   m, m
+                adoxq   m, d7
+
+// The last word is slightly more intricate: we naturally end up adding
+// 2 * top bit when we shouldn't (because it's a rotation and we've already
+// added it at the LSB position) but then compensate by subtracting it.
+
+                movq    d8, m
+                adcxq   m, m
+                adoxq   m, d8
+                andq    $0x200, m
+                subq    m, d8
+
+// Now x + x' >= p_521 <=> s = x + x' + 1 >= 2^521
+// Make m = 512 * [x + x' >= p_521]
+
+                movl    $512, mshort
+                andq    d8, m
+
+// Now if x + x' >= p_521, we want (x + x') - p_521 = s - 2^521
+// while otherwise we want x + x' = s - 1
+// We use the mask m both as an operand and to generate the dual carry
+// Write back the results as generated
+
+                cmpq    $512, m
+
+                sbbq    $0, d0
+                movq    d0, (z)
+                sbbq    $0, d1
+                movq    d1, 8(z)
+                sbbq    $0, d2
+                movq    d2, 16(z)
+                sbbq    $0, d3
+                movq    d3, 24(z)
+                sbbq    $0, d4
+                movq    d4, 32(z)
+                sbbq    $0, d5
+                movq    d5, 40(z)
+                sbbq    $0, d6
+                movq    d6, 48(z)
+                sbbq    $0, d7
+                movq    d7, 56(z)
+                sbbq    m, d8
+                movq    d8, 64(z)
+
+// Restore registers and return
+
+                popq    %r12
+                popq    %rbx
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
### Issues:
CryptoAlg-924

### Description of changes: 
Import the latest (as of 2022-02-07) s2n-bignum changes for P-384 and P-521. The commands used to merge the changes:

```
git fetch s2n-bignum
git checkout -b s2n-bignum-main s2n-bignum/main
git checkout -b s2n-bignum-2022-02-07

PATHS_TO_KEEP="./arm/p384 ./x86_att/p384 ./arm/p521 ./x86_att/p521"

git filter-branch -f --index-filter "git rm --ignore-unmatch --cached -qr -- . && git reset -q \$GIT_COMMIT -- $PATHS_TO_KEEP" --msg-filter 'cat; echo; echo "s2n-bignum original commit: https://github.com/awslabs/s2n-bignum/commit/$GIT_COMMIT"' --prune-empty -- HEAD

git checkout s2n-bignum-alt-funcs
git merge -s subtree -Xsubtree="third_party/s2n-bignum" s2n-bignum-2022-02-07 --allow-unrelated-histories
# Fix merge conflicts
git add -u
git commit
```

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
