### PR TITLE
CMake Target Changes

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -467,14 +467,14 @@ if(FIPS_SHARED)
   add_custom_command(
     TARGET crypto POST_BUILD
     COMMAND ${GO_EXECUTABLE} run
-    ${CMAKE_SOURCE_DIR}/util/fipstools/inject_hash/inject_hash.go
+    ${PROJECT_SOURCE_DIR}/util/fipstools/inject_hash/inject_hash.go
     -o $<TARGET_FILE:crypto> -in-object $<TARGET_FILE:crypto>
     -sha256 ${INJECT_HASH_MACOS_FLAG}
     # The DEPENDS argument to a POST_BUILD rule appears to be ignored. Thus
     # go_executable isn't used (as it doesn't get built), but we list this
     # dependency anyway in case it starts working in some CMake version.
     DEPENDS ../util/fipstools/inject_hash/inject_hash.go
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )
 endif()
 

--- a/third_party/jitterentropy/CMakeLists.txt
+++ b/third_party/jitterentropy/CMakeLists.txt
@@ -7,12 +7,12 @@
 # the same as the source code.
 
 set(JITTER_SOURCES
-        ${CMAKE_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-base.c
-        ${CMAKE_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-gcd.c
-        ${CMAKE_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-health.c
-        ${CMAKE_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-noise.c
-        ${CMAKE_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-sha3.c
-        ${CMAKE_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-timer.c)
+        ${PROJECT_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-base.c
+        ${PROJECT_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-gcd.c
+        ${PROJECT_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-health.c
+        ${PROJECT_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-noise.c
+        ${PROJECT_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-sha3.c
+        ${PROJECT_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-timer.c)
 
 include_directories(../../include)
 


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-895`

### Description of changes: 
Previously the FIPS shared build would work if the source code was built directly with the AWS-LC's root CMake file. This change helps support building from other CMake projects that build AWS-LC with `add_subdirectory`. 
Using `CMAKE_SOURCE_DIR` will refer to the folder where the top-level `CMakeLists.txt ` is defined, which in some cases will be the external CMake file which calls `add_subdirectory`.  This lets parts of the current build point to the incorrect places. Replacing `CMAKE_SOURCE_DIR` with `PROJECT_SOURCE_DIR` fixes this, as `PROJECT_SOURCE_DIR` points to the project source directory. 

Resource: https://stackoverflow.com/questions/32028667/are-cmake-source-dir-and-project-source-dir-the-same-in-cmake 

### Call-outs:
This was found when trying to build the AWS-LC FIPS Shared build with an external CMake file which builds AWS-LC with `add_subdirectory`.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
Tested and built the FIPS shared build successfully with `add_subdirectory` on local. Also ran `./tests/ci/run_fips_tests.sh` on local. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
