### PR TITLE
Integrate s2n-bignum alternative functions for P-384

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -163,10 +163,17 @@ if (S2N_BIGNUM_DIR AND UNIX AND NOT APPLE)
     bignum_tomont_p384.S
     bignum_deamont_p384.S
     bignum_montmul_p384.S
+    bignum_montmul_p384_alt.S
     bignum_montsqr_p384.S
+    bignum_montsqr_p384_alt.S
     bignum_nonzero_6.S
     bignum_littleendian_6.S
   )
+  if(ARCH STREQUAL "x86_64")
+    list(APPEND S2N_BIGNUM_ASM_SOURCES
+                bignum_tomont_p384_alt.S
+                bignum_deamont_p384_alt.S)
+  endif()
 
   # Copy s2n-bignum files to the current binary dir
   foreach(f ${S2N_BIGNUM_ASM_SOURCES})

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -170,6 +170,10 @@ if (S2N_BIGNUM_DIR AND UNIX AND NOT APPLE)
     bignum_littleendian_6.S
   )
   if(ARCH STREQUAL "x86_64")
+    # The files below contain the alternative functions for x86_64.
+    # For AArch64, the alternative tomont/deamont functions are
+    # the same as the non-alternative ones, so they are defined
+    # in the corresponding "non-alt" files (bignum_<deamont|tomont>_p384.S)
     list(APPEND S2N_BIGNUM_ASM_SOURCES
                 bignum_tomont_p384_alt.S
                 bignum_deamont_p384_alt.S)

--- a/crypto/fipsmodule/ec/make_tables.go
+++ b/crypto/fipsmodule/ec/make_tables.go
@@ -225,7 +225,7 @@ func writeP384Table(path string) error {
 // with the difference that we use a window size of 7 instead of 5.
 // The windows size is chosen based on analysis analogous to the one in
 // |ec_GFp_nistp_recode_scalar_bits| function in |util.c| file.
-#if defined(BORINGSSL_NISTP384_64BIT)
+#if defined(P384_USE_64BIT_LIMBS_FELEM)
 static const p384_felem p384_g_pre_comp[14][64][2] = `
 	if _, err := f.WriteString(fileHeader); err != nil {
 		return err

--- a/crypto/fipsmodule/ec/p384_table.h
+++ b/crypto/fipsmodule/ec/p384_table.h
@@ -27,7 +27,7 @@
 // with the difference that we use a window size of 7 instead of 5.
 // The windows size is chosen based on analysis analogous to the one in
 // |ec_GFp_nistp_recode_scalar_bits| function in |util.c| file.
-#if defined(BORINGSSL_NISTP384_64BIT)
+#if defined(P384_USE_64BIT_LIMBS_FELEM)
 static const p384_felem p384_g_pre_comp[14][64][2] = {
     {{{0x3dd0756649c0b528, 0x20e378e2a0d6ce38, 0x879c3afc541b4d6e,
        0x6454868459a30eff, 0x812ff723614ede2b, 0x4d3aadc2299e1513},

--- a/third_party/fiat/p384_32.h
+++ b/third_party/fiat/p384_32.h
@@ -29,6 +29,7 @@ OPENSSL_UNUSED static void fiat_p384_set_one(uint32_t out1[6]);
 OPENSSL_UNUSED static void fiat_p384_msat(uint32_t out1[7]);
 OPENSSL_UNUSED static void fiat_p384_divstep(uint32_t* out1, uint32_t out2[7], uint32_t out3[7], uint32_t out4[6], uint32_t out5[6], uint32_t arg1, const uint32_t arg2[7], const uint32_t arg3[7], const uint32_t arg4[6], const uint32_t arg5[6]);
 OPENSSL_UNUSED static void fiat_p384_divstep_precomp(uint32_t out1[6]);
+OPENSSL_UNUSED static void fiat_p384_selectznz(uint32_t out1[12], fiat_p384_uint1 arg1, const uint32_t arg2[12], const uint32_t arg3[12]);
 
 /*
  * The function fiat_p384_addcarryx_u32 is an addition with carry.

--- a/third_party/fiat/p384_64.h
+++ b/third_party/fiat/p384_64.h
@@ -26,16 +26,10 @@ __extension__ typedef __uint128_t fiat_p384_uint128;
 #error "This code only works on a two's complement system"
 #endif
 
-OPENSSL_UNUSED static void fiat_p384_opp(uint64_t out1[6], const uint64_t arg1[6]);
 OPENSSL_UNUSED static void fiat_p384_set_one(uint64_t out1[6]);
 OPENSSL_UNUSED static void fiat_p384_msat(uint64_t out1[7]);
 OPENSSL_UNUSED static void fiat_p384_divstep(uint64_t* out1, uint64_t out2[7], uint64_t out3[7], uint64_t out4[6], uint64_t out5[6], uint64_t arg1, const uint64_t arg2[7], const uint64_t arg3[7], const uint64_t arg4[6], const uint64_t arg5[6]);
 OPENSSL_UNUSED static void fiat_p384_divstep_precomp(uint64_t out1[6]);
-OPENSSL_UNUSED static void fiat_p384_add(uint64_t out1[6], const uint64_t arg1[6], const uint64_t arg2[6]);
-OPENSSL_UNUSED static void fiat_p384_sub(uint64_t out1[6], const uint64_t arg1[6], const uint64_t arg2[6]);
-OPENSSL_UNUSED static void fiat_p384_to_bytes(uint8_t out1[48], const uint64_t arg1[6]);
-OPENSSL_UNUSED static void fiat_p384_from_bytes(uint64_t out1[6], const uint8_t arg1[48]);
-OPENSSL_UNUSED static void fiat_p384_nonzero(uint64_t* out1, const uint64_t arg1[6]);
 OPENSSL_UNUSED static void fiat_p384_selectznz(uint64_t out1[6], fiat_p384_uint1 arg1, const uint64_t arg2[6], const uint64_t arg3[6]);
 
 /*

--- a/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
+++ b/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
@@ -19,40 +19,57 @@
 
 // Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
 // Inputs x[6], y[6]; output z[6]
-extern void bignum_add_p384 (uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
+extern void bignum_add_p384(uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
 
 // Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
 // Input x[6]; output z[6]
-extern void bignum_deamont_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
+extern void bignum_deamont_p384(uint64_t z[static 6], const uint64_t x[static 6]);
+
+// Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
+// Input x[6]; output z[6]
+extern void bignum_deamont_p384_alt(uint64_t z[static 6], const uint64_t x[static 6]);
 
 // Montgomery multiply, z := (x * y / 2^384) mod p_384 
-// /* // Inputs x[6], y[6]; output z[6]
-extern void bignum_montmul_p384 (uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
+// Inputs x[6], y[6]; output z[6]
+extern void bignum_montmul_p384(uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
+
+// Montgomery multiply, z := (x * y / 2^384) mod p_384 
+// Inputs x[6], y[6]; output z[6]
+extern void bignum_montmul_p384_alt(uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);
 
 // Montgomery square, z := (x^2 / 2^384) mod p_384
 // Input x[6]; output z[6]
-extern void bignum_montsqr_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
+extern void bignum_montsqr_p384(uint64_t z[static 6], const uint64_t x[static 6]);
+
+// Montgomery square, z := (x^2 / 2^384) mod p_384
+// Input x[6]; output z[6]
+extern void bignum_montsqr_p384_alt(uint64_t z[static 6], const uint64_t x[static 6]);
 
 // Negate modulo p_384, z := (-x) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
-extern void bignum_neg_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
+extern void bignum_neg_p384(uint64_t z[static 6], const uint64_t x[static 6]);
 
 // Subtract modulo p_384, z := (x - y) mod p_384
 // Inputs x[6], y[6]; output z[6]
-extern void bignum_sub_p384 (uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]); 
+extern void bignum_sub_p384(uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]); 
 
 // Convert to Montgomery form z := (2^384 * x) mod p_384 */
 // Input x[6]; output z[6] */
-extern void bignum_tomont_p384 (uint64_t z[static 6], const uint64_t x[static 6]);
+extern void bignum_tomont_p384(uint64_t z[static 6], const uint64_t x[static 6]);
+
+// Convert to Montgomery form z := (2^384 * x) mod p_384 */
+// Input x[6]; output z[6] */
+extern void bignum_tomont_p384_alt(uint64_t z[static 6], const uint64_t x[static 6]);
 
 // Convert 6-digit (384-bit) bignum from little-endian form
 // Input x[6]; output z[6]
-extern void bignum_fromlebytes_6 (uint64_t z[static 6], const uint8_t x[static 48]);
+extern void bignum_fromlebytes_6(uint64_t z[static 6], const uint8_t x[static 48]);
 
 // Convert 6-digit (384-bit) bignum to little-endian form
 // Input x[6]; output z[6]
-extern void bignum_tolebytes_6 (uint8_t z[static 48], const uint64_t x[static 6]);
+extern void bignum_tolebytes_6(uint8_t z[static 48], const uint64_t x[static 6]);
 
 // 384-bit nonzeroness test, returning 1 if x is nonzero, 0 if x is zero
 // Input x[6]; output function return
 extern uint64_t bignum_nonzero_6(const uint64_t x[static 6]);
+

--- a/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
+++ b/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
@@ -17,6 +17,16 @@
 // C prototypes for s2n-bignum functions used in AWS-LC
 // ----------------------------------------------------------------------------
 
+// For some functions there are additional variants with names ending in
+// "_alt". These have the same core mathematical functionality as their
+// non-"alt" versions, but can be better suited to some microarchitectures:
+//
+//      - On x86, the "_alt" forms avoid BMI and ADX instruction set
+//        extensions, so will run on any x86_64 machine, even older ones
+//
+//      - On ARM, the "_alt" forms target machines with higher multiplier
+//        throughput, generally offering higher performance there.
+
 // Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
 // Inputs x[6], y[6]; output z[6]
 extern void bignum_add_p384(uint64_t z[static 6], const uint64_t x[static 6], const uint64_t y[static 6]);


### PR DESCRIPTION
### Issues:
CryptoAlg-946

### Description of changes: 

On x86_64 platforms s2n-bignum uses bmi2 and adx instruction sets
for some of the P-384 functions. These instructions are not supported
by every x86 CPU. Previously, we checked in runtime if bmi2 and adx
are supported and if not we fallback to Fiat's implementation. This
solution had a drawbacks that we had to always compile both
s2n-bignum and Fiat code.

s2n-bignum implemented "alternative" implementations of functions
that don't require any special instructions. In this commit we integrate
those changes and instead of falling-back to Fiat's code we fall back
to s2n-bignum alternative implementations. The change has two
benefits:
 - s2n-bignum and Fiat are decoupled so we compile only one.
 - Performance improvement on x86 CPUs that don't support bmi2
 and adx instructions is x2.11, x1.58, x2.03 for ECDH, ECDSA sign,
 ECDSA verify, respectively.

The benchmark for a CPU without bmi2 and adx support, with
`bssl/speed -filter “P-384”`, before and after:
ECDH: 1594 —> 3372 (ops/s)
ECDSA Sign: 6332 —> 10000 (ops/s)
ECDSA Verify: 1981 —> 4019 (ops/s)

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
