### PR TITLE
Remove reference to removed script in docker build spec

### DIFF
--- a/tests/ci/codebuild/linux-x86/docker-img-build.yml
+++ b/tests/ci/codebuild/linux-x86/docker-img-build.yml
@@ -16,5 +16,4 @@ phases:
     commands:
       - cd ./tests/ci/docker_images/linux-x86
       - ./build_images.sh
-      - ./pull_github_pkg.sh
       - ./push_images.sh $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$AWS_ECR_REPO_X86


### PR DESCRIPTION
### Issues:
Fixes CI docker image build

### Description of changes: 
Previous PR https://github.com/awslabs/aws-lc/pull/374 removed the script `pull_github_pkg.sh` since it was no longer needed. Running the `build-linux-img` command with the `run-cdk.sh` will fail because the script can't be found with the 
`tests/ci/codebuild/linux-x86/docker-img-build.yml` build spec. 

### Call-outs:
N/A

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
Ran `build-linux-img` with the cdk script in my personal Isengard account. Docker images got updated as intended.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
