### PR TITLE
Entropy read retries

### DIFF
--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -150,6 +150,12 @@ OPENSSL_INLINE int have_fast_rdrand(void) {
 
 #endif  // OPENSSL_X86_64 && !OPENSSL_NO_ASM
 
+// Don't retry forever. There is no science in picking this number and can be
+// adjusted in the future if need be. We do not backoff forever, because we
+// believe that it is easier to detect failing calls than detecting infinite
+// spinning loops.
+#define MAX_BACKOFF_RETRIES 9
+OPENSSL_EXPORT void HAZMAT_set_urandom_test_mode_for_testing(void);
 
 #if defined(__cplusplus)
 }  // extern C

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -154,22 +154,36 @@ static void rand_thread_state_free(void *state_in) {
 
 #if defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM) && \
     !defined(BORINGSSL_UNSAFE_DETERMINISTIC_MODE)
+
+// rdrand maximum retries as suggested by:
+// Intel® Digital Random Number Generator (DRNG) Software Implementation Guide
+// Revision 2.1
+// https://software.intel.com/content/www/us/en/develop/articles/intel-digital-random-number-generator-drng-software-implementation-guide.html
+#define RDRAND_MAX_RETRIES 10
+
+OPENSSL_STATIC_ASSERT(RDRAND_MAX_RETRIES > 0, rdrand_max_retries_must_be_positive)
+#define CALL_RDRAND_WITH_RETRY(rdrand_func, fail_ret_value)       \
+    for (size_t tries = 0; tries < RDRAND_MAX_RETRIES; tries++) { \
+      if ((rdrand_func) == 1) {                                   \
+        break;                                                    \
+      }                                                           \
+      else if (tries == RDRAND_MAX_RETRIES - 1) {                 \
+        return fail_ret_value;                                    \
+      }                                                           \
+    }
+
 // rdrand should only be called if either |have_rdrand| or |have_fast_rdrand|
 // returned true.
 static int rdrand(uint8_t *buf, const size_t len) {
   const size_t len_multiple8 = len & ~7;
-  if (!CRYPTO_rdrand_multiple8_buf(buf, len_multiple8)) {
-    return 0;
-  }
+  CALL_RDRAND_WITH_RETRY(CRYPTO_rdrand_multiple8_buf(buf, len_multiple8), 0)
   const size_t remainder = len - len_multiple8;
 
   if (remainder != 0) {
     assert(remainder < 8);
 
     uint8_t rand_buf[8];
-    if (!CRYPTO_rdrand(rand_buf)) {
-      return 0;
-    }
+    CALL_RDRAND_WITH_RETRY(CRYPTO_rdrand(rand_buf), 0)
     OPENSSL_memcpy(buf + len_multiple8, rand_buf, remainder);
   }
 


### PR DESCRIPTION
### Issues:

CryptoAlg-812

### Description of changes: 

Changes here are cherry-picked from the rand-drbg-updates branch.
The cherry-picked commit is `02f42fcd0843718f3875650028865676ece71822` and was initially reviewed in PR #216 .

See the initial PR for details. But in summary:

* Implement recommended retries for entropy read functions: `rdrand`, `/dev/[u]random`, and `getrandom`.
* `rdrand`: Retry 10 times in case of failure in the accumulator function.
* `/dev/[u]random` / `getrandom`: Exponential backoff in case of certain failures based on observed behaviour in practice.

### Call-outs:

See #216 

### Testing:

See #216 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
