### PR TITLE
Run OSx CI dimension for all target branches

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -5,8 +5,7 @@ name: macOS CI
 on:
   pull_request:
     branches:
-      - 'main'
-      - 'fips-*'
+      - '*'
 
 env:
   PACKAGE_NAME: aws-lc


### PR DESCRIPTION
### Description of changes: 

Run OSx CI dimension for all target branches.
Reason: We don't want to carry OSx regressions on branches. In particular, we would carry these on upstream staging branches.

### Testing:

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
