### PR TITLE
Support old assemblers that don't know about AVX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,9 +193,9 @@ endmacro()
 # Some ancient assemblers don't know about AVX instructions, which is an
 # assumption we make for some of the assembly implementations. This flag
 # can be set to handle such cases.
+option(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX "Exclude AVX code from the build" OFF)
 if(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX")
+  add_definitions(-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 endif()
 
 # Detect if memcmp is wrongly stripped like strcmp.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,14 @@ macro(check_run file_to_test flag_to_set compile_flags)
   endif()
 endmacro()
 
+# Some ancient assemblers don't know about AVX instructions, which is an
+# assumption we make for some of the assembly implementations. This flag
+# can be set to handle such cases.
+if(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX")
+endif()
+
 # Detect if memcmp is wrongly stripped like strcmp.
 # If exists, let CMake generate a warning.
 # memcmp bug link https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -74,10 +74,14 @@ if(PERL_EXECUTABLE)
       set(dir ".")
     endif()
 
+    if(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
+      set(PERLASM_FLAGS "${PERLASM_FLAGS} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX")
+    endif()
+
     add_custom_command(
       OUTPUT ${dest}
       COMMAND ${CMAKE_COMMAND} -E make_directory ${dir}
-      COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${src} ${PERLASM_STYLE} ${PERLASM_FLAGS} ${ARGN} ${dest}
+      COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${src} ${PERLASM_STYLE} ${dest} ${PERLASM_FLAGS}
       DEPENDS
       ${src}
       ${PROJECT_SOURCE_DIR}/crypto/perlasm/arm-xlate.pl
@@ -182,11 +186,14 @@ if(ARCH STREQUAL "x86_64")
     CRYPTO_ARCH_SOURCES
 
     chacha/chacha-x86_64.${ASM_EXT}
-    cipher_extra/aes128gcmsiv-x86_64.${ASM_EXT}
     cipher_extra/chacha20_poly1305_x86_64.${ASM_EXT}
-    hrss/asm/poly_rq_mul.S
     test/trampoline-x86_64.${ASM_EXT}
   )
+  if(NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
+    list(APPEND CRYPTO_ARCH_SOURCES
+                cipher_extra/aes128gcmsiv-x86_64.${ASM_EXT}
+                hrss/asm/poly_rq_mul.S)
+  endif()
 endif()
 
 if(GO_EXECUTABLE)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -187,13 +187,10 @@ if(ARCH STREQUAL "x86_64")
 
     chacha/chacha-x86_64.${ASM_EXT}
     cipher_extra/chacha20_poly1305_x86_64.${ASM_EXT}
+    cipher_extra/aes128gcmsiv-x86_64.${ASM_EXT}
     test/trampoline-x86_64.${ASM_EXT}
+    hrss/asm/poly_rq_mul.S
   )
-  if(NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
-    list(APPEND CRYPTO_ARCH_SOURCES
-                cipher_extra/aes128gcmsiv-x86_64.${ASM_EXT}
-                hrss/asm/poly_rq_mul.S)
-  endif()
 endif()
 
 if(GO_EXECUTABLE)

--- a/crypto/chacha/asm/chacha-armv4.pl
+++ b/crypto/chacha/asm/chacha-armv4.pl
@@ -34,9 +34,12 @@
 #	but then Snapdragon S4 and Cortex-A8 results get
 #	20-25% worse;
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-if ($flavour=~/\w[\w\-]*\.\w+$/) { $output=$flavour; undef $flavour; }
-else { while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {} }
+$output = shift;
 
 if ($flavour && $flavour ne "void") {
     $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/chacha/asm/chacha-armv8.pl
+++ b/crypto/chacha/asm/chacha-armv8.pl
@@ -35,8 +35,12 @@
 #	higher instruction issue rate;
 # (**)	expected improvement was actually higher;
 
-$flavour=shift;
-$output=shift;
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
+$flavour = shift;
+$output = shift;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}arm-xlate.pl" and -f $xlate ) or

--- a/crypto/chacha/asm/chacha-x86.pl
+++ b/crypto/chacha/asm/chacha-x86.pl
@@ -38,14 +38,18 @@
 #
 # Modified from upstream OpenSSL to remove the XOP code.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../perlasm");
 require "x86asm.pl";
 
-$output=pop;
+$output=$ARGV[1];
 open STDOUT,">$output";
 
-&asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
+&asm_init($ARGV[0],$ARGV[1] eq "386");
 
 $xmm=$ymm=1;
 $gasver=999;  # enable everything

--- a/crypto/chacha/asm/chacha-x86_64.pl
+++ b/crypto/chacha/asm/chacha-x86_64.pl
@@ -54,9 +54,12 @@
 #
 # Modified from upstream OpenSSL to remove the XOP code.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
@@ -65,10 +68,11 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}../../perlasm/x86_64-xlate.pl" and -f $xlate) or
 die "can't locate x86_64-xlate.pl";
 
-$avx = 2;
-
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT=*OUT;
+
+$avx = 2;
+for (@ARGV) { $avx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 # input parameter block
 ($out,$inp,$len,$key,$counter)=("%rdi","%rsi","%rdx","%rcx","%r8");

--- a/crypto/cipher_extra/asm/aes128gcmsiv-x86_64.pl
+++ b/crypto/cipher_extra/asm/aes128gcmsiv-x86_64.pl
@@ -17,9 +17,12 @@
 
 use warnings FATAL => 'all';
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 

--- a/crypto/cipher_extra/asm/aes128gcmsiv-x86_64.pl
+++ b/crypto/cipher_extra/asm/aes128gcmsiv-x86_64.pl
@@ -31,6 +31,9 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}../../perlasm/x86_64-xlate.pl" and -f $xlate) or
 die "can't locate x86_64-xlate.pl";
 
+$avx = 1;
+for (@ARGV) { $avx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
+
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT=*OUT;
 
@@ -2254,6 +2257,6 @@ ___
 }
 aes256gcmsiv_kdf();
 
-print $code;
+if ($avx) { print $code; }
 
 close STDOUT or die "error closing STDOUT: $!";

--- a/crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl
+++ b/crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl
@@ -20,8 +20,12 @@
 #                                                                            #
 ##############################################################################
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+$output = shift;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}arm-xlate.pl" and -f $xlate ) or

--- a/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl
+++ b/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl
@@ -20,9 +20,12 @@
 #                                                                            #
 ##############################################################################
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
@@ -35,6 +38,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT=*OUT;
 
 $avx = 2;
+for (@ARGV) { $avx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 $code.=<<___;
 .text

--- a/crypto/cipher_extra/e_aesgcmsiv.c
+++ b/crypto/cipher_extra/e_aesgcmsiv.c
@@ -30,7 +30,7 @@
 // TODO(davidben): AES-GCM-SIV assembly is not correct for Windows. It must save
 // and restore xmm6 through xmm15.
 #if defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM) && \
-    !defined(OPENSSL_WINDOWS)
+    !defined(OPENSSL_WINDOWS) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 #define AES_GCM_SIV_ASM
 
 // Optimised AES-GCM-SIV

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -23,6 +23,7 @@ if(ARCH STREQUAL "x86_64")
     ghash-x86_64.${ASM_EXT}
     md5-x86_64.${ASM_EXT}
     p256-x86_64-asm.${ASM_EXT}
+    p256_beeu-x86_64-asm.${ASM_EXT}
     rdrand-x86_64.${ASM_EXT}
     rsaz-avx2.${ASM_EXT}
     sha1-x86_64.${ASM_EXT}
@@ -32,10 +33,6 @@ if(ARCH STREQUAL "x86_64")
     x86_64-mont5.${ASM_EXT}
     x86_64-mont.${ASM_EXT}
   )
-
-  if(NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
-    list(APPEND BCM_ASM_SOURCES p256_beeu-x86_64-asm.${ASM_EXT})
-  endif()
 
   # Set the source directory for s2n-bignum assembly files
   set(S2N_BIGNUM_DIR ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/x86_att/p384)

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -23,7 +23,6 @@ if(ARCH STREQUAL "x86_64")
     ghash-x86_64.${ASM_EXT}
     md5-x86_64.${ASM_EXT}
     p256-x86_64-asm.${ASM_EXT}
-    p256_beeu-x86_64-asm.${ASM_EXT}
     rdrand-x86_64.${ASM_EXT}
     rsaz-avx2.${ASM_EXT}
     sha1-x86_64.${ASM_EXT}
@@ -33,6 +32,10 @@ if(ARCH STREQUAL "x86_64")
     x86_64-mont5.${ASM_EXT}
     x86_64-mont.${ASM_EXT}
   )
+
+  if(NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
+    list(APPEND BCM_ASM_SOURCES p256_beeu-x86_64-asm.${ASM_EXT})
+  endif()
 
   # Set the source directory for s2n-bignum assembly files
   set(S2N_BIGNUM_DIR ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/x86_att/p384)
@@ -151,7 +154,7 @@ if(PERL_EXECUTABLE)
 endif()
 
 # s2n-bignum files can be compiled on Unix platforms only (except Apple)
-if (S2N_BIGNUM_DIR AND UNIX AND NOT APPLE)
+if (S2N_BIGNUM_DIR AND UNIX AND NOT APPLE AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
   # We add s2n-bignum files to a separate list because they need
   # to go through C preprocessor in case of the static build.
   set(

--- a/crypto/fipsmodule/aes/asm/aesni-x86.pl
+++ b/crypto/fipsmodule/aes/asm/aesni-x86.pl
@@ -73,11 +73,15 @@ $PREFIX="aes_hw";	# if $PREFIX is set to "AES", the script
 $AESNI_PREFIX="aes_hw";
 $inline=1;		# inline _aesni_[en|de]crypt
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output = pop;
+$output = $ARGV[1];
 open OUT,">$output";
 *STDOUT=*OUT;
 

--- a/crypto/fipsmodule/aes/asm/aesni-x86_64.pl
+++ b/crypto/fipsmodule/aes/asm/aesni-x86_64.pl
@@ -192,9 +192,12 @@ $PREFIX="aes_hw";	# if $PREFIX is set to "AES", the script
 			# generates drop-in replacement for
 			# crypto/aes/asm/aes-x86_64.pl:-)
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 

--- a/crypto/fipsmodule/aes/asm/aesp8-ppc.pl
+++ b/crypto/fipsmodule/aes/asm/aesp8-ppc.pl
@@ -43,6 +43,10 @@
 # POWER9[le]	4.02/0.86	0.84	1.05
 # POWER9[be]	3.99/0.78	0.79	0.97
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 
 if ($flavour =~ /64/) {

--- a/crypto/fipsmodule/aes/asm/aesv8-armx.pl
+++ b/crypto/fipsmodule/aes/asm/aesv8-armx.pl
@@ -39,6 +39,9 @@
 # (*)	original 3.64/1.34/1.32 results were for r0p0 revision
 #	and are still same even for updated module;
 
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
 

--- a/crypto/fipsmodule/aes/asm/bsaes-armv7.pl
+++ b/crypto/fipsmodule/aes/asm/bsaes-armv7.pl
@@ -50,9 +50,11 @@
 # April-August 2013
 # Add CBC, CTR and XTS subroutines and adapt for kernel use; courtesy of Ard.
 
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-if ($flavour=~/\w[\w\-]*\.\w+$/) { $output=$flavour; undef $flavour; }
-else { while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {} }
+$output = shift;
 
 if ($flavour && $flavour ne "void") {
     $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/fipsmodule/aes/asm/vpaes-armv7.pl
+++ b/crypto/fipsmodule/aes/asm/vpaes-armv7.pl
@@ -98,9 +98,11 @@
 
 use strict;
 
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 my $flavour = shift;
-my $output;
-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+my $output = shift;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/;
 my $dir=$1;

--- a/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
+++ b/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
@@ -37,8 +37,11 @@
 #	code, but it's constant-time and therefore preferred;
 # (***)	presented for reference/comparison purposes;
 
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+$output = shift;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}arm-xlate.pl" and -f $xlate ) or

--- a/crypto/fipsmodule/aes/asm/vpaes-x86.pl
+++ b/crypto/fipsmodule/aes/asm/vpaes-x86.pl
@@ -54,11 +54,15 @@
 #
 #						<appro@openssl.org>
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output = pop;
+$output = $ARGV[1];
 open OUT,">$output";
 *STDOUT=*OUT;
 

--- a/crypto/fipsmodule/aes/asm/vpaes-x86_64.pl
+++ b/crypto/fipsmodule/aes/asm/vpaes-x86_64.pl
@@ -54,9 +54,12 @@
 #
 #						<appro@openssl.org>
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 

--- a/crypto/fipsmodule/bn/asm/armv4-mont.pl
+++ b/crypto/fipsmodule/bn/asm/armv4-mont.pl
@@ -54,9 +54,12 @@
 # integer-only on Cortex-A8, ~10-210% on Cortex-A15, ~70-450% on
 # Snapdragon S4.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-if ($flavour=~/\w[\w\-]*\.\w+$/) { $output=$flavour; undef $flavour; }
-else { while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {} }
+$output  = shift;
 
 if ($flavour && $flavour ne "void") {
     $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/fipsmodule/bn/asm/armv8-mont.pl
+++ b/crypto/fipsmodule/bn/asm/armv8-mont.pl
@@ -40,6 +40,10 @@
 # 50-70% improvement for RSA4096 sign. RSA2048 sign is ~25% faster
 # on Cortex-A57 and ~60-100% faster on others.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
 

--- a/crypto/fipsmodule/bn/asm/bn-586.pl
+++ b/crypto/fipsmodule/bn/asm/bn-586.pl
@@ -6,12 +6,15 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output = pop;
+$output = $ARGV[1];
 open STDOUT,">$output";
 
 &asm_init($ARGV[0]);

--- a/crypto/fipsmodule/bn/asm/co-586.pl
+++ b/crypto/fipsmodule/bn/asm/co-586.pl
@@ -6,11 +6,15 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output = pop;
+$output = $ARGV[1];
 open STDOUT,">$output";
 
 &asm_init($ARGV[0]);

--- a/crypto/fipsmodule/bn/asm/rsaz-avx2.pl
+++ b/crypto/fipsmodule/bn/asm/rsaz-avx2.pl
@@ -37,9 +37,12 @@
 # (***)	scalar AD*X code is faster than AVX2 and is preferred code
 #	path for Broadwell;
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
@@ -52,6 +55,7 @@ die "can't locate x86_64-xlate.pl";
 # versions, but BoringSSL is intended to be used with pre-generated perlasm
 # output, so this isn't useful anyway.
 $avx = 2;
+for (@ARGV) { $avx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT = *OUT;

--- a/crypto/fipsmodule/bn/asm/x86-mont.pl
+++ b/crypto/fipsmodule/bn/asm/x86-mont.pl
@@ -33,11 +33,15 @@
 # Integer-only code [being equipped with dedicated squaring procedure]
 # gives ~40% on rsa512 sign benchmark...
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output = pop;
+$output = $ARGV[1];
 open STDOUT,">$output";
 
 &asm_init($ARGV[0]);

--- a/crypto/fipsmodule/bn/asm/x86_64-mont.pl
+++ b/crypto/fipsmodule/bn/asm/x86_64-mont.pl
@@ -46,9 +46,12 @@
 #
 # Add MULX/ADOX/ADCX code path.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
@@ -64,6 +67,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 # versions, but BoringSSL is intended to be used with pre-generated perlasm
 # output, so this isn't useful anyway.
 $addx = 1;
+for (@ARGV) { $addx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 # int bn_mul_mont(
 $rp="%rdi";	# BN_ULONG *rp,

--- a/crypto/fipsmodule/bn/asm/x86_64-mont5.pl
+++ b/crypto/fipsmodule/bn/asm/x86_64-mont5.pl
@@ -31,9 +31,12 @@
 # the np argument is not just modulus value, but one interleaved
 # with 0. This is to optimize post-condition...
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
@@ -49,6 +52,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 # versions, but BoringSSL is intended to be used with pre-generated perlasm
 # output, so this isn't useful anyway.
 $addx = 1;
+for (@ARGV) { $addx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 # int bn_mul_mont_gather5(
 $rp="%rdi";	# BN_ULONG *rp,

--- a/crypto/fipsmodule/bn/rsaz_exp.h
+++ b/crypto/fipsmodule/bn/rsaz_exp.h
@@ -24,7 +24,8 @@
 extern "C" {
 #endif
 
-#if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_X86_64)
+#if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_X86_64) && \
+    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 #define RSAZ_ENABLED
 
 

--- a/crypto/fipsmodule/cpucap/cpu_intel.c
+++ b/crypto/fipsmodule/cpucap/cpu_intel.c
@@ -114,9 +114,13 @@ static uint64_t OPENSSL_xgetbv(uint32_t xcr) {
   return (uint64_t)_xgetbv(xcr);
 #else
   uint32_t eax, edx;
+#if defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
   // Some old assemblers don't support the xgetbv instruction so we emit
   // the opcode of xgetbv directly.
   __asm__ volatile (".byte 0x0f, 0x01, 0xd0" : "=a"(eax), "=d"(edx) : "c"(xcr));
+#else
+  __asm__ volatile ("xgetbv" : "=a"(eax), "=d"(edx) : "c"(xcr));
+#endif
   return (((uint64_t)edx) << 32) | eax;
 #endif
 }

--- a/crypto/fipsmodule/cpucap/cpu_intel.c
+++ b/crypto/fipsmodule/cpucap/cpu_intel.c
@@ -114,7 +114,9 @@ static uint64_t OPENSSL_xgetbv(uint32_t xcr) {
   return (uint64_t)_xgetbv(xcr);
 #else
   uint32_t eax, edx;
-  __asm__ volatile ("xgetbv" : "=a"(eax), "=d"(edx) : "c"(xcr));
+  // Some old assemblers don't support the xgetbv instruction so we emit
+  // the opcode of xgetbv directly.
+  __asm__ volatile (".byte 0x0f, 0x01, 0xd0" : "=a"(eax), "=d"(edx) : "c"(xcr));
   return (((uint64_t)edx) << 32) | eax;
 #endif
 }

--- a/crypto/fipsmodule/ec/asm/p256-armv8-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256-armv8-asm.pl
@@ -31,8 +31,12 @@
 # on benchmark. Lower coefficients are for ECDSA sign, server-side
 # operation. Keep in mind that +400% means 5x improvement.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+$output = shift;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}arm-xlate.pl" and -f $xlate ) or

--- a/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl
@@ -40,9 +40,12 @@
 # higher - for ECDSA sign, relatively fastest server-side operation.
 # Keep in mind that +100% means 2x improvement.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
@@ -56,6 +59,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 
 $avx = 2;
 $addx = 1;
+for (@ARGV) { $avx = 0, $addx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 $code.=<<___;
 .text

--- a/crypto/fipsmodule/ec/asm/p256_beeu-armv8-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256_beeu-armv8-asm.pl
@@ -3,8 +3,12 @@
 #
 # This code is based on p256_beeu-x86_64-asm.pl (which is based on BN_mod_inverse_odd).
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+$output  = shift;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}arm-xlate.pl" and -f $xlate ) or

--- a/crypto/fipsmodule/ec/asm/p256_beeu-x86_64-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256_beeu-x86_64-asm.pl
@@ -31,6 +31,9 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}../../../perlasm/x86_64-xlate.pl" and -f $xlate) or
 die "can't locate x86_64-xlate.pl";
 
+$avx = 2;
+for (@ARGV) { $avx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
+
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT=*OUT;
 
@@ -148,7 +151,7 @@ sub SHIFT256 {
 ___
 }
 
-$code.=<<___;
+$code.=<<___  if($avx);
 .text
 
 .type beeu_mod_inverse_vartime,\@function

--- a/crypto/fipsmodule/ec/asm/p256_beeu-x86_64-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256_beeu-x86_64-asm.pl
@@ -17,9 +17,12 @@
 # (ndrucker@amazon.com, gueron@amazon.com)
 # based on BN_mod_inverse_odd
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 

--- a/crypto/fipsmodule/ec/p256-nistz.c
+++ b/crypto/fipsmodule/ec/p256-nistz.c
@@ -564,6 +564,11 @@ static void ecp_nistz256_inv0_mod_ord(const EC_GROUP *group, EC_SCALAR *out,
 static int ecp_nistz256_scalar_to_montgomery_inv_vartime(const EC_GROUP *group,
                                                  EC_SCALAR *out,
                                                  const EC_SCALAR *in) {
+
+#if defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
+    return ec_simple_scalar_to_montgomery_inv_vartime(group, out, in);
+#else
+
 #if defined(OPENSSL_X86_64)
   if ((OPENSSL_ia32cap_P[1] & (1 << 28)) == 0) {
     // No AVX support; fallback to generic code.
@@ -579,6 +584,8 @@ static int ecp_nistz256_scalar_to_montgomery_inv_vartime(const EC_GROUP *group,
   // The result should be returned in the Montgomery domain.
   ec_scalar_to_montgomery(group, out, out);
   return 1;
+
+#endif
 }
 
 static int ecp_nistz256_cmp_x_coordinate(const EC_GROUP *group,

--- a/crypto/fipsmodule/ec/p256-nistz_test.cc
+++ b/crypto/fipsmodule/ec/p256-nistz_test.cc
@@ -34,7 +34,7 @@
 
 // Disable tests if BORINGSSL_SHARED_LIBRARY is defined. These tests need access
 // to internal functions.
-#if !defined(OPENSSL_NO_ASM) && \
+#if !defined(OPENSSL_NO_ASM) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX) && \
     (defined(OPENSSL_X86_64) || (defined(OPENSSL_AARCH64_P256) && defined(OPENSSL_AARCH64))) && \
     !defined(OPENSSL_SMALL) && !defined(BORINGSSL_SHARED_LIBRARY)
 

--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -30,7 +30,8 @@
 // when s2n-bignum is used.
 //
 #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_LINUX) && \
-    (defined(OPENSSL_X86_64) || defined(OPENSSL_AARCH64))
+    (defined(OPENSSL_X86_64) || defined(OPENSSL_AARCH64)) && \
+    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 
 #  include "../../../third_party/s2n-bignum/include/s2n-bignum_aws-lc.h"
 

--- a/crypto/fipsmodule/md5/asm/md5-586.pl
+++ b/crypto/fipsmodule/md5/asm/md5-586.pl
@@ -5,13 +5,17 @@
 # version, non-normal is the
 # md5_block_x86(MD5_CTX *c, ULONG *X,int blocks);
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path." }
+
 $normal=0;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output=pop;
+$output=$ARGV[1];
 open STDOUT,">$output";
 
 &asm_init($ARGV[0]);

--- a/crypto/fipsmodule/md5/asm/md5-x86_64.pl
+++ b/crypto/fipsmodule/md5/asm/md5-x86_64.pl
@@ -109,9 +109,13 @@ EOF
 }
 
 no warnings qw(uninitialized);
+
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 my $flavour = shift;
 my $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 my $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 

--- a/crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl
+++ b/crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl
@@ -40,9 +40,12 @@
 # [1] http://rt.openssl.org/Ticket/Display.html?id=2900&user=guest&pass=guest
 # [2] http://www.intel.com/content/dam/www/public/us/en/documents/software-support/enabling-high-performance-gcm.pdf
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
@@ -63,6 +66,7 @@ die "can't locate x86_64-xlate.pl";
 # if and only if AVX2 is also supported by the assembler; see
 # https://marc.info/?l=openssl-dev&m=146567589526984&w=2.
 $avx = 2;
+for (@ARGV) { $avx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT=*OUT;

--- a/crypto/fipsmodule/modes/asm/ghash-armv4.pl
+++ b/crypto/fipsmodule/modes/asm/ghash-armv4.pl
@@ -81,9 +81,13 @@
 # This file was patched in BoringSSL to remove the variable-time 4-bit
 # implementation.
 
+
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-if ($flavour=~/\w[\w\-]*\.\w+$/) { $output=$flavour; undef $flavour; }
-else { while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {} }
+$output = shift;
 
 if ($flavour && $flavour ne "void") {
     $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/fipsmodule/modes/asm/ghash-neon-armv8.pl
+++ b/crypto/fipsmodule/modes/asm/ghash-neon-armv8.pl
@@ -49,10 +49,12 @@
 
 use strict;
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 my $flavour = shift;
-my $output;
-if ($flavour=~/\w[\w\-]*\.\w+$/) { $output=$flavour; undef $flavour; }
-else { while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {} }
+my $output = shift;
 
 if ($flavour && $flavour ne "void") {
     $0 =~ m/(.*[\/\\])[^\/\\]+$/;

--- a/crypto/fipsmodule/modes/asm/ghash-ssse3-x86.pl
+++ b/crypto/fipsmodule/modes/asm/ghash-ssse3-x86.pl
@@ -68,11 +68,15 @@
 # in column 0b1000 and H*x^3 is stored in column 0b0001. It also means earlier
 # table rows contain more significant coefficients, so we iterate forwards.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output = pop;
+$output = $ARGV[1];
 open STDOUT, ">$output";
 
 &asm_init($ARGV[0]);

--- a/crypto/fipsmodule/modes/asm/ghash-ssse3-x86_64.pl
+++ b/crypto/fipsmodule/modes/asm/ghash-ssse3-x86_64.pl
@@ -70,9 +70,12 @@
 
 use strict;
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 my $flavour = shift;
 my $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 my $win64 = 0;
 $win64 = 1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);

--- a/crypto/fipsmodule/modes/asm/ghash-x86.pl
+++ b/crypto/fipsmodule/modes/asm/ghash-x86.pl
@@ -134,11 +134,15 @@
 # This file was patched in BoringSSL to remove the variable-time 4-bit
 # implementation.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output=pop;
+$output=$ARGV[1];
 open STDOUT,">$output";
 
 &asm_init($ARGV[0],$x86only = $ARGV[$#ARGV] eq "386");

--- a/crypto/fipsmodule/modes/asm/ghash-x86_64.pl
+++ b/crypto/fipsmodule/modes/asm/ghash-x86_64.pl
@@ -93,9 +93,12 @@
 # This file was patched in BoringSSL to remove the variable-time 4-bit
 # implementation.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
@@ -111,6 +114,7 @@ die "can't locate x86_64-xlate.pl";
 # versions, but BoringSSL is intended to be used with pre-generated perlasm
 # output, so this isn't useful anyway.
 $avx = 1;
+for (@ARGV) { $avx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT=*OUT;
@@ -831,6 +835,7 @@ ___
 } else {
 $code.=<<___;
 	jmp	.L_init_clmul
+.cfi_endproc
 .size	gcm_init_avx,.-gcm_init_avx
 ___
 }
@@ -1270,6 +1275,7 @@ ___
 } else {
 $code.=<<___;
 	jmp	.L_ghash_clmul
+.cfi_endproc
 .size	gcm_ghash_avx,.-gcm_ghash_avx
 ___
 }

--- a/crypto/fipsmodule/modes/asm/ghashp8-ppc.pl
+++ b/crypto/fipsmodule/modes/asm/ghashp8-ppc.pl
@@ -31,6 +31,10 @@
 # performance on POWER8 is 1 cycle per processed byte), and 4x
 # aggregated reduction - by 170% or 2.7x (resulting in 0.55 cpb).
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour=shift;
 $output =shift;
 

--- a/crypto/fipsmodule/modes/asm/ghashv8-armx.pl
+++ b/crypto/fipsmodule/modes/asm/ghashv8-armx.pl
@@ -42,6 +42,11 @@
 #
 # (*)	presented for reference/comparison purposes;
 
+
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
 

--- a/crypto/fipsmodule/modes/gcm_test.cc
+++ b/crypto/fipsmodule/modes/gcm_test.cc
@@ -119,7 +119,8 @@ TEST(GCMTest, ByteSwap) {
             CRYPTO_bswap8(UINT64_C(0x0102030405060708)));
 }
 
-#if defined(SUPPORTS_ABI_TEST) && !defined(OPENSSL_NO_ASM)
+#if defined(SUPPORTS_ABI_TEST) && !defined(OPENSSL_NO_ASM) && \
+    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 TEST(GCMTest, ABI) {
   static const uint64_t kH[2] = {
       UINT64_C(0x66e94bd4ef8a2c3b),
@@ -219,4 +220,4 @@ TEST(GCMTest, ABI) {
   }
 #endif  // GHASH_ASM_PPC64LE
 }
-#endif  // SUPPORTS_ABI_TEST && !OPENSSL_NO_ASM
+#endif  // SUPPORTS_ABI_TEST && !OPENSSL_NO_ASM && !MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX

--- a/crypto/fipsmodule/modes/internal.h
+++ b/crypto/fipsmodule/modes/internal.h
@@ -264,7 +264,7 @@ void gcm_gmult_ssse3(uint64_t Xi[2], const u128 Htable[16]);
 void gcm_ghash_ssse3(uint64_t Xi[2], const u128 Htable[16], const uint8_t *in,
                      size_t len);
 
-#if defined(OPENSSL_X86_64)
+#if defined(OPENSSL_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 #define GHASH_ASM_X86_64
 void gcm_init_avx(u128 Htable[16], const uint64_t Xi[2]);
 void gcm_gmult_avx(uint64_t Xi[2], const u128 Htable[16]);

--- a/crypto/fipsmodule/rand/asm/rdrand-x86_64.pl
+++ b/crypto/fipsmodule/rand/asm/rdrand-x86_64.pl
@@ -16,9 +16,12 @@
 
 use strict;
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 my $flavour = shift;
 my $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 my $win64 = 0;
 $win64 = 1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);

--- a/crypto/fipsmodule/sha/asm/sha1-586.pl
+++ b/crypto/fipsmodule/sha/asm/sha1-586.pl
@@ -119,11 +119,15 @@
 #
 # (***)	SHAEXT result
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output=pop;
+$output=$ARGV[1];
 open STDOUT,">$output";
 
 &asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");

--- a/crypto/fipsmodule/sha/asm/sha1-armv4-large.pl
+++ b/crypto/fipsmodule/sha/asm/sha1-armv4-large.pl
@@ -75,9 +75,11 @@
 #
 # Add ARMv8 code path performing at 2.35 cpb on Apple A7.
 
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-if ($flavour=~/\w[\w\-]*\.\w+$/) { $output=$flavour; undef $flavour; }
-else { while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {} }
+$output = shift;
 
 if ($flavour && $flavour ne "void") {
     $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/fipsmodule/sha/asm/sha1-armv8.pl
+++ b/crypto/fipsmodule/sha/asm/sha1-armv8.pl
@@ -32,6 +32,9 @@
 # (**)	Keep in mind that Denver relies on binary translation, which
 #	optimizes compiler output at run-time.
 
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
 

--- a/crypto/fipsmodule/sha/asm/sha1-x86_64.pl
+++ b/crypto/fipsmodule/sha/asm/sha1-x86_64.pl
@@ -93,9 +93,12 @@
 #	because SSSE3 code is compiled unconditionally;
 # (**)	SHAEXT result
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
@@ -107,8 +110,9 @@ die "can't locate x86_64-xlate.pl";
 # In upstream, this is controlled by shelling out to the compiler to check
 # versions, but BoringSSL is intended to be used with pre-generated perlasm
 # output, so this isn't useful anyway.
-$avx = 2;
 $shaext=1;	### set to zero if compiling for 1.0.1
+$avx = 2;
+for (@ARGV) { $avx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT=*OUT;

--- a/crypto/fipsmodule/sha/asm/sha256-586.pl
+++ b/crypto/fipsmodule/sha/asm/sha256-586.pl
@@ -69,11 +69,15 @@
 #	purposes, results are best-available;
 # (***)	SHAEXT result is 4.1, strangely enough better than 64-bit one;
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output=pop;
+$output=$ARGV[1];
 open STDOUT,">$output";
 
 &asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");
@@ -89,6 +93,7 @@ for (@ARGV) { $xmm=1 if (/-DOPENSSL_IA32_SSE2/); }
 $avx = 1;
 
 $avx = 0 unless ($xmm);
+for (@ARGV) { $avx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 $shaext=$xmm;	### set to zero if compiling for 1.0.1
 

--- a/crypto/fipsmodule/sha/asm/sha256-armv4.pl
+++ b/crypto/fipsmodule/sha/asm/sha256-armv4.pl
@@ -44,9 +44,11 @@
 #
 # Add ARMv8 code path performing at 2.0 cpb on Apple A7.
 
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-if ($flavour=~/\w[\w\-]*\.\w+$/) { $output=$flavour; undef $flavour; }
-else { while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {} }
+$output = shift;
 
 if ($flavour && $flavour ne "void") {
     $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/fipsmodule/sha/asm/sha512-586.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-586.pl
@@ -55,11 +55,15 @@
 # difference is that new code optimizes amount of writes, but at the
 # cost of increased data cache "footprint" by 1/2KB.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 push(@INC,"${dir}","${dir}../../../perlasm");
 require "x86asm.pl";
 
-$output=pop;
+$output=$ARGV[1];
 open STDOUT,">$output";
 
 &asm_init($ARGV[0],$ARGV[$#ARGV] eq "386");

--- a/crypto/fipsmodule/sha/asm/sha512-armv4.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-armv4.pl
@@ -57,9 +57,11 @@ $hi="HI";
 $lo="LO";
 # ====================================================================
 
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
-if ($flavour=~/\w[\w\-]*\.\w+$/) { $output=$flavour; undef $flavour; }
-else { while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {} }
+$output = shift;
 
 if ($flavour && $flavour ne "void") {
     $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/fipsmodule/sha/asm/sha512-armv8.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-armv8.pl
@@ -39,8 +39,11 @@
 #	generated with -mgeneral-regs-only is significantly faster
 #	and the gap is only 40-90%.
 
-$output=pop;
-$flavour=pop;
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
+$flavour = shift;
+$output = shift;
 
 if ($flavour && $flavour ne "void") {
     $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/fipsmodule/sha/asm/sha512-x86_64.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-x86_64.pl
@@ -111,9 +111,12 @@
 #
 # Modified from upstream OpenSSL to remove the XOP code.
 
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
 $flavour = shift;
 $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
 
@@ -129,8 +132,9 @@ die "can't locate x86_64-xlate.pl";
 # TODO(davidben): Enable AVX2 code after testing by setting $avx to 2. Is it
 # necessary to disable AVX2 code when SHA Extensions code is disabled? Upstream
 # did not tie them together until after $shaext was added.
-$avx = 1;
 $shaext=1;	### set to zero if compiling for 1.0.1
+$avx = 1;
+for (@ARGV) { $avx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT=*OUT;

--- a/crypto/hrss/asm/poly_rq_mul.S
+++ b/crypto/hrss/asm/poly_rq_mul.S
@@ -13,7 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && \
-    !defined(__linux__) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
+    defined(__linux__) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 
 #if defined(BORINGSSL_PREFIX)
 #include <boringssl_prefix_symbols_asm.h>

--- a/crypto/hrss/asm/poly_rq_mul.S
+++ b/crypto/hrss/asm/poly_rq_mul.S
@@ -12,7 +12,8 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && defined(__linux__)
+#if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && \
+    !defined(__linux__) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 
 #if defined(BORINGSSL_PREFIX)
 #include <boringssl_prefix_symbols_asm.h>

--- a/crypto/hrss/hrss_test.cc
+++ b/crypto/hrss/hrss_test.cc
@@ -451,7 +451,8 @@ TEST(HRSS, Golden) {
   EXPECT_EQ(Bytes(shared_key), Bytes(kExpectedFailureKey));
 }
 
-#if defined(POLY_RQ_MUL_ASM) && defined(SUPPORTS_ABI_TEST)
+#if defined(POLY_RQ_MUL_ASM) && defined(SUPPORTS_ABI_TEST) && \
+    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 TEST(HRSS, ABI) {
   const bool has_avx2 = (OPENSSL_ia32cap_P[2] & (1 << 5)) != 0;
   if (!has_avx2) {

--- a/crypto/hrss/internal.h
+++ b/crypto/hrss/internal.h
@@ -45,7 +45,8 @@ OPENSSL_EXPORT void HRSS_poly3_invert(struct poly3 *out,
 // explicit permission for this and signed a CLA.) However it's 57KB of object
 // code, so it's not used if |OPENSSL_SMALL| is defined.
 #if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && \
-    defined(OPENSSL_X86_64) && defined(OPENSSL_LINUX)
+    defined(OPENSSL_X86_64) && defined(OPENSSL_LINUX) && \
+    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 #define POLY_RQ_MUL_ASM
 // POLY_MUL_RQ_SCRATCH_SPACE is the number of bytes of scratch space needed
 // by the assembly function poly_Rq_mul.

--- a/crypto/test/asm/trampoline-armv4.pl
+++ b/crypto/test/asm/trampoline-armv4.pl
@@ -33,7 +33,6 @@ use strict;
 
 my $flavour = shift;
 my $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/;
 my $dir = $1;

--- a/crypto/test/asm/trampoline-armv8.pl
+++ b/crypto/test/asm/trampoline-armv8.pl
@@ -31,7 +31,6 @@ use strict;
 
 my $flavour = shift;
 my $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/;
 my $dir = $1;

--- a/crypto/test/asm/trampoline-ppc.pl
+++ b/crypto/test/asm/trampoline-ppc.pl
@@ -29,7 +29,6 @@ use strict;
 
 my $flavour = shift;
 my $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/;
 my $dir = $1;

--- a/crypto/test/asm/trampoline-x86.pl
+++ b/crypto/test/asm/trampoline-x86.pl
@@ -34,7 +34,7 @@ my $dir = $1;
 push(@INC, "${dir}", "${dir}../../perlasm");
 require "x86asm.pl";
 
-my $output = pop;
+my $output = $ARGV[1];
 open STDOUT, ">$output";
 
 &asm_init($ARGV[0]);

--- a/crypto/test/asm/trampoline-x86_64.pl
+++ b/crypto/test/asm/trampoline-x86_64.pl
@@ -31,7 +31,6 @@ use strict;
 
 my $flavour = shift;
 my $output  = shift;
-if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
 
 my $win64 = 0;
 $win64 = 1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);

--- a/util/generate_build_files.py
+++ b/util/generate_build_files.py
@@ -182,7 +182,7 @@ def PerlAsm(output_filename, input_filename, perlasm_style, extra_args):
   if not os.path.isdir(base_dir):
     os.makedirs(base_dir)
   subprocess.check_call(
-      ['perl', input_filename, perlasm_style] + extra_args + [output_filename])
+      ['perl', input_filename, perlasm_style, output_filename] + extra_args)
 
 
 def ArchForAsmFilename(filename):
@@ -373,10 +373,10 @@ def main():
 
 if __name__ == '__main__':
   usage = '''%prog
-      
+
   This script generates intermediate build files for CMake builds without the need
-  to install Go or Perl as a dependency. These files are output to the |generated-src| 
-  directory and are used by the top-level CMakeLists.txt for AWS-LC if these depedencies 
+  to install Go or Perl as a dependency. These files are output to the |generated-src|
+  directory and are used by the top-level CMakeLists.txt for AWS-LC if these depedencies
   are not found.
   '''
 


### PR DESCRIPTION
### Issues:
CryptoAlg-1011

### Description of changes: 
We assume that the assembler that is going to be used to compile the assembly code in the library is modern enough that it knows about AVX. However, this assumption is not always correct for our internal systems. With this patch we add logic to handle the case of ancient compilers that don't support AVX.  For this purpose we define a CMake flag called `MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX` that can be set to `TRUE` in case the assembler doesn't understand AVX instructions. In perl-assembly files we check if `MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX` flag is specified and don't generate the AVX code in case it is. Regarding pure assembly files that have AVX implementations -- we have to remove them from compilation all together.

Note that we also simplified and unified how our Perl-assembly scripts handle command line arguments. Previously, some scripts were expecting the `flavour` and `output` arguments to be the first two arguments (if given), while other scripts assumed `flavour` to be the first one and `output` to be the last argument. Now, all the scripts require at least two arguments, the first one being the `flavour`, the second one being the `output` file path, and optionally, additional flags starting from the third argument.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.