### PR TITLE
Update CI README.

### DIFF
--- a/tests/ci/cdk/README.md
+++ b/tests/ci/cdk/README.md
@@ -58,27 +58,30 @@ To setup or update the CI in your account you will need the following IAM permis
   * secretsmanager:DeleteSecret
   * secretsmanager:GetSecretValue
 
-### Command
+### Commands
+
+Note: `GITHUB_REPO_OWNER` is to specify the GitHub repo targeted by this CI setup.
+* https://github.com/${GITHUB_REPO_OWNER}/aws-lc.git
 
 To set up AWS-LC CI, run command:
 ```
-./run-cdk.sh --action deploy-ci
+./run-cdk.sh --github-repo-owner=${GITHUB_REPO_OWNER} --action deploy-ci
 ```
 
 To update AWS-LC CI, run command:
 ```
-./run-cdk.sh --action update-ci
+./run-cdk.sh --github-repo-owner=${GITHUB_REPO_OWNER} --action update-ci
 ```
 
 To create/update Linux Docker images, run command:
 ```
-./run-cdk.sh --action build-linux-img
+./run-cdk.sh --github-repo-owner=${GITHUB_REPO_OWNER} --action build-linux-img
 ```
 
 To destroy AWS-LC CI resources created above, run command:
 ```
 # NOTE: this command will destroy all resources (AWS CodeBuild and ECR).
-./run-cdk.sh --action destroy-ci
+./run-cdk.sh --github-repo-owner=${GITHUB_REPO_OWNER} --action destroy-ci
 ```
 
 For help, run command:

--- a/tests/ci/cdk/README.md
+++ b/tests/ci/cdk/README.md
@@ -60,7 +60,7 @@ To setup or update the CI in your account you will need the following IAM permis
 
 ### Commands
 
-Note: `GITHUB_REPO_OWNER` is to specify the GitHub repo targeted by this CI setup.
+Note: `GITHUB_REPO_OWNER` specifies the GitHub repo targeted by this CI setup.
 * https://github.com/${GITHUB_REPO_OWNER}/aws-lc.git
 
 To set up AWS-LC CI, run command:


### PR DESCRIPTION
### Description of changes: 

This PR is to update the CI README by specifying `GITHUB_REPO_OWNER`, which is to specify the GitHub repo targeted by this CI setup.
* https://github.com/${GITHUB_REPO_OWNER}/aws-lc.git

### Call-outs:

* Without `--github-repo-owner=${GITHUB_REPO_OWNER}`, the default value `awslabs` is used for convenience.

### Testing:
CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
