### PR TITLE
Improve service indicator initialization and add tests for under/overflow

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -33,6 +33,7 @@ static struct fips_service_indicator_state * FIPS_service_indicator_get(void) {
     indicator->lock_state = STATE_UNLOCKED;
     indicator->counter = 0;
     if (!CRYPTO_set_thread_local(AWSLC_THREAD_LOCAL_FIPS_SERVICE_INDICATOR_STATE, indicator, OPENSSL_free)) {
+      OPENSSL_free(indicator);
       OPENSSL_PUT_ERROR(CRYPTO, ERR_R_INTERNAL_ERROR);
       return NULL;
     }

--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -33,7 +33,6 @@ static struct fips_service_indicator_state * FIPS_service_indicator_get(void) {
     indicator->lock_state = STATE_UNLOCKED;
     indicator->counter = 0;
     if (!CRYPTO_set_thread_local(AWSLC_THREAD_LOCAL_FIPS_SERVICE_INDICATOR_STATE, indicator, OPENSSL_free)) {
-      OPENSSL_free(indicator);
       OPENSSL_PUT_ERROR(CRYPTO, ERR_R_INTERNAL_ERROR);
       return NULL;
     }

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -21,6 +21,7 @@
 #include <openssl/rand.h>
 #include <openssl/rsa.h>
 #include <openssl/service_indicator.h>
+#include <openssl/err.h>
 
 #include "../../test/abi_test.h"
 #include "../../test/test_util.h"
@@ -664,7 +665,11 @@ struct AEADTestVector {
         kAESKey, 16, kAESCCMCiphertext, 64, AWSLC_APPROVED, false },
 };
 
-class AEAD_ServiceIndicatorTest : public testing::TestWithParam<AEADTestVector> {};
+class AEAD_ServiceIndicatorTest : public testing::TestWithParam<AEADTestVector> {
+  void TearDown() override {
+      ASSERT_EQ(ERR_get_error(), 0u);
+  }
+};
 
 INSTANTIATE_TEST_SUITE_P(All, AEAD_ServiceIndicatorTest, testing::ValuesIn(nAEADTestVectors));
 
@@ -712,6 +717,7 @@ TEST_P(AEAD_ServiceIndicatorTest, EVP_AEAD) {
          encrypt_output.data(), &out_len, encrypt_output.size(), nonce.data(), EVP_AEAD_nonce_length(aeadTestVector.cipher),
          kPlaintext, sizeof(kPlaintext), nullptr, 0)));
     ASSERT_EQ(approved, AWSLC_NOT_APPROVED);
+    ASSERT_EQ(ERR_GET_REASON(ERR_get_error()), CIPHER_R_INVALID_NONCE);
   }
 }
 
@@ -738,7 +744,11 @@ struct CipherTestVector {
   { EVP_des_ede3_cbc(), kAESKey_192, 24, KTDES_EDE3_CBCCipherText, 64, false, AWSLC_NOT_APPROVED }
 };
 
-class EVP_ServiceIndicatorTest : public testing::TestWithParam<CipherTestVector> {};
+class EVP_ServiceIndicatorTest : public testing::TestWithParam<CipherTestVector> {
+  void TearDown() override {
+      ASSERT_EQ(ERR_get_error(), 0u);
+  }
+};
 
 INSTANTIATE_TEST_SUITE_P(All, EVP_ServiceIndicatorTest, testing::ValuesIn(nTestVectors));
 
@@ -792,7 +802,11 @@ struct DigestTestVector {
     { sha512_256, kOutput_sha512_256, AWSLC_APPROVED }
 };
 
-class EVP_MD_ServiceIndicatorTest : public testing::TestWithParam<DigestTestVector> {};
+class EVP_MD_ServiceIndicatorTest : public testing::TestWithParam<DigestTestVector> {
+  void TearDown() override {
+      ASSERT_EQ(ERR_get_error(), 0u);
+  }
+};
 
 INSTANTIATE_TEST_SUITE_P(All, EVP_MD_ServiceIndicatorTest, testing::ValuesIn(kDigestTestVectors));
 
@@ -847,7 +861,11 @@ struct HMACTestVector {
     { EVP_sha512_256, kHMACOutput_sha512_256, AWSLC_NOT_APPROVED }
 };
 
-class HMAC_ServiceIndicatorTest : public testing::TestWithParam<HMACTestVector> {};
+class HMAC_ServiceIndicatorTest : public testing::TestWithParam<HMACTestVector> {
+  void TearDown() override {
+      ASSERT_EQ(ERR_get_error(), 0u);
+  }
+};
 
 INSTANTIATE_TEST_SUITE_P(All, HMAC_ServiceIndicatorTest, testing::ValuesIn(kHMACTestVectors));
 
@@ -1018,7 +1036,10 @@ struct RSATestVector kRSATestVectors[] = {
     { 4096, &EVP_sha512, true, AWSLC_APPROVED, AWSLC_APPROVED },
 };
 
-class RSA_ServiceIndicatorTest : public testing::TestWithParam<RSATestVector> {};
+class RSA_ServiceIndicatorTest : public testing::TestWithParam<RSATestVector> {  void TearDown() override {
+      ASSERT_EQ(ERR_get_error(), 0u);
+  }
+};
 
 INSTANTIATE_TEST_SUITE_P(All, RSA_ServiceIndicatorTest, testing::ValuesIn(kRSATestVectors));
 
@@ -1255,7 +1276,11 @@ struct ECDSATestVector kECDSATestVectors[] = {
     { NID_secp521r1, &EVP_sha512, AWSLC_APPROVED, AWSLC_APPROVED, AWSLC_APPROVED },
 };
 
-class ECDSA_ServiceIndicatorTest : public testing::TestWithParam<ECDSATestVector> {};
+class ECDSA_ServiceIndicatorTest : public testing::TestWithParam<ECDSATestVector> {
+  void TearDown() override {
+      ASSERT_EQ(ERR_get_error(), 0u);
+  }
+};
 
 INSTANTIATE_TEST_SUITE_P(All, ECDSA_ServiceIndicatorTest, testing::ValuesIn(kECDSATestVectors));
 
@@ -1491,7 +1516,11 @@ struct ECDHTestVector kECDHTestVectors[] = {
     { NID_secp521r1, SHA512_DIGEST_LENGTH, AWSLC_APPROVED },
 };
 
-class ECDH_ServiceIndicatorTest : public testing::TestWithParam<ECDHTestVector> {};
+class ECDH_ServiceIndicatorTest : public testing::TestWithParam<ECDHTestVector> {
+  void TearDown() override {
+      ASSERT_EQ(ERR_get_error(), 0u);
+  }
+};
 
 INSTANTIATE_TEST_SUITE_P(All, ECDH_ServiceIndicatorTest, testing::ValuesIn(kECDHTestVectors));
 
@@ -1565,7 +1594,11 @@ struct KDFTestVector {
     { EVP_sha512, kTLSOutput_sha512, AWSLC_APPROVED },
 };
 
-class KDF_ServiceIndicatorTest : public testing::TestWithParam<KDFTestVector> {};
+class KDF_ServiceIndicatorTest : public testing::TestWithParam<KDFTestVector> {
+  void TearDown() override {
+      ASSERT_EQ(ERR_get_error(), 0u);
+  }
+};
 
 INSTANTIATE_TEST_SUITE_P(All, KDF_ServiceIndicatorTest, testing::ValuesIn(kKDFTestVectors));
 

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -29,6 +29,15 @@
 #include "../rand/internal.h"
 #include "../tls/internal.h"
 
+namespace awslc {
+  template <typename T>
+  class TestWithNoErrors : public testing::TestWithParam<T> {
+    void TearDown() override {
+      ASSERT_EQ(ERR_get_error(), 0u);
+    }
+  };
+}
+
 static const uint8_t kAESKey[16] = {
     'A','W','S','-','L','C','C','r','y','p','t','o',' ','K', 'e','y'};
 static const uint8_t kPlaintext[64] = {
@@ -665,11 +674,7 @@ struct AEADTestVector {
         kAESKey, 16, kAESCCMCiphertext, 64, AWSLC_APPROVED, false },
 };
 
-class AEAD_ServiceIndicatorTest : public testing::TestWithParam<AEADTestVector> {
-  void TearDown() override {
-      ASSERT_EQ(ERR_get_error(), 0u);
-  }
-};
+class AEAD_ServiceIndicatorTest : public awslc::TestWithNoErrors<AEADTestVector> {};
 
 INSTANTIATE_TEST_SUITE_P(All, AEAD_ServiceIndicatorTest, testing::ValuesIn(nAEADTestVectors));
 
@@ -744,11 +749,7 @@ struct CipherTestVector {
   { EVP_des_ede3_cbc(), kAESKey_192, 24, KTDES_EDE3_CBCCipherText, 64, false, AWSLC_NOT_APPROVED }
 };
 
-class EVP_ServiceIndicatorTest : public testing::TestWithParam<CipherTestVector> {
-  void TearDown() override {
-      ASSERT_EQ(ERR_get_error(), 0u);
-  }
-};
+class EVP_ServiceIndicatorTest : public awslc::TestWithNoErrors<CipherTestVector> {};
 
 INSTANTIATE_TEST_SUITE_P(All, EVP_ServiceIndicatorTest, testing::ValuesIn(nTestVectors));
 
@@ -802,11 +803,7 @@ struct DigestTestVector {
     { sha512_256, kOutput_sha512_256, AWSLC_APPROVED }
 };
 
-class EVP_MD_ServiceIndicatorTest : public testing::TestWithParam<DigestTestVector> {
-  void TearDown() override {
-      ASSERT_EQ(ERR_get_error(), 0u);
-  }
-};
+class EVP_MD_ServiceIndicatorTest : public awslc::TestWithNoErrors<DigestTestVector> {};
 
 INSTANTIATE_TEST_SUITE_P(All, EVP_MD_ServiceIndicatorTest, testing::ValuesIn(kDigestTestVectors));
 
@@ -861,11 +858,7 @@ struct HMACTestVector {
     { EVP_sha512_256, kHMACOutput_sha512_256, AWSLC_NOT_APPROVED }
 };
 
-class HMAC_ServiceIndicatorTest : public testing::TestWithParam<HMACTestVector> {
-  void TearDown() override {
-      ASSERT_EQ(ERR_get_error(), 0u);
-  }
-};
+class HMAC_ServiceIndicatorTest : public awslc::TestWithNoErrors<HMACTestVector> {};
 
 INSTANTIATE_TEST_SUITE_P(All, HMAC_ServiceIndicatorTest, testing::ValuesIn(kHMACTestVectors));
 
@@ -1036,10 +1029,7 @@ struct RSATestVector kRSATestVectors[] = {
     { 4096, &EVP_sha512, true, AWSLC_APPROVED, AWSLC_APPROVED },
 };
 
-class RSA_ServiceIndicatorTest : public testing::TestWithParam<RSATestVector> {  void TearDown() override {
-      ASSERT_EQ(ERR_get_error(), 0u);
-  }
-};
+class RSA_ServiceIndicatorTest : public awslc::TestWithNoErrors<RSATestVector> {};
 
 INSTANTIATE_TEST_SUITE_P(All, RSA_ServiceIndicatorTest, testing::ValuesIn(kRSATestVectors));
 
@@ -1276,11 +1266,7 @@ struct ECDSATestVector kECDSATestVectors[] = {
     { NID_secp521r1, &EVP_sha512, AWSLC_APPROVED, AWSLC_APPROVED, AWSLC_APPROVED },
 };
 
-class ECDSA_ServiceIndicatorTest : public testing::TestWithParam<ECDSATestVector> {
-  void TearDown() override {
-      ASSERT_EQ(ERR_get_error(), 0u);
-  }
-};
+class ECDSA_ServiceIndicatorTest : public awslc::TestWithNoErrors<ECDSATestVector> {};
 
 INSTANTIATE_TEST_SUITE_P(All, ECDSA_ServiceIndicatorTest, testing::ValuesIn(kECDSATestVectors));
 
@@ -1516,11 +1502,7 @@ struct ECDHTestVector kECDHTestVectors[] = {
     { NID_secp521r1, SHA512_DIGEST_LENGTH, AWSLC_APPROVED },
 };
 
-class ECDH_ServiceIndicatorTest : public testing::TestWithParam<ECDHTestVector> {
-  void TearDown() override {
-      ASSERT_EQ(ERR_get_error(), 0u);
-  }
-};
+class ECDH_ServiceIndicatorTest : public awslc::TestWithNoErrors<ECDHTestVector> {};
 
 INSTANTIATE_TEST_SUITE_P(All, ECDH_ServiceIndicatorTest, testing::ValuesIn(kECDHTestVectors));
 
@@ -1594,11 +1576,7 @@ struct KDFTestVector {
     { EVP_sha512, kTLSOutput_sha512, AWSLC_APPROVED },
 };
 
-class KDF_ServiceIndicatorTest : public testing::TestWithParam<KDFTestVector> {
-  void TearDown() override {
-      ASSERT_EQ(ERR_get_error(), 0u);
-  }
-};
+class KDF_ServiceIndicatorTest : public awslc::TestWithNoErrors<KDFTestVector> {};
 
 INSTANTIATE_TEST_SUITE_P(All, KDF_ServiceIndicatorTest, testing::ValuesIn(kKDFTestVectors));
 


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-907

### Description of changes: 
Add lazy initialization logic to all service indicator functions. This is *not* an issue for the current Linux FIPS branch. This issue only happens on Windows FIPS builds. The Windows issue is nothing was calling `FIPS_service_indicator_update_state` which created the state before calling `FIPS_service_indicator_lock_state`. When lock was called with a null state nothing happens and AWS-LC continues and eventually hits a call to update state which creates the state, then something calls unlock and underflows. My hypothesis is MSVC changes the order of self tests in the `BORINGSSL_bcm_power_on_self_test` to hit this unlock issue while Clang/GCC does not.

### Call-outs:
The CI does not test FIPS on Windows yet due to other issues. I have tested this part on a Windows machine manually and it addressed the issue. On Linux there is no behavior change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
