### PR TITLE
Disable P-521 assembly when MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX is defined

### DIFF
--- a/crypto/fipsmodule/ec/p521.c
+++ b/crypto/fipsmodule/ec/p521.c
@@ -33,7 +33,8 @@
 // when s2n-bignum is used.
 //
 #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_LINUX) && \
-    (defined(OPENSSL_X86_64) || defined(OPENSSL_AARCH64))
+    (defined(OPENSSL_X86_64) || defined(OPENSSL_AARCH64)) && \
+    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
 
 #  include "../../../third_party/s2n-bignum/include/s2n-bignum_aws-lc.h"
 #  define P521_USE_S2N_BIGNUM_FIELD_ARITH 1


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Disable P-521 assembly when MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX is defined.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
