### PR TITLE
Improve MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ endmacro()
 option(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX "Exclude AVX code from the build" OFF)
 if(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
   add_definitions(-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
+  message(STATUS "MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX selected, removing AVX optimisations")
 endif()
 
 # Detect if memcmp is wrongly stripped like strcmp.

--- a/tests/ci/run_minimal_tests.sh
+++ b/tests/ci/run_minimal_tests.sh
@@ -22,21 +22,3 @@ build_and_run_minimal_test -DDISABLE_GO=ON -DDISABLE_PERL=ON -DCMAKE_BUILD_TYPE=
 
 echo "Testing shared lib AWS-LC without Perl/Go in release mode."
 build_and_run_minimal_test -DDISABLE_GO=ON -DDISABLE_PERL=ON -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
-
-# Special build options
-
-## build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
-echo "Testing static lib AWS-LC with MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option in release mode."
-build_and_run_minimal_test -DCMAKE_BUILD_TYPE=Release -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
-
-echo "Testing shared lib AWS-LC with MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option in release mode."
-build_and_run_minimal_test -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
-
-echo "Testing static lib AWS-LC with MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option in debug mode."
-build_and_run_minimal_test -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
-
-echo "Testing shared lib AWS-LC with MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option in debug mode."
-build_and_run_minimal_test -DBUILD_SHARED_LIBS=1 -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
-
-echo "Testing shared lib AWS-LC with MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option in [FIPS, release] mode."
-build_and_run_minimal_test -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON -DFIPS=1

--- a/tests/ci/run_minimal_tests.sh
+++ b/tests/ci/run_minimal_tests.sh
@@ -23,3 +23,20 @@ build_and_run_minimal_test -DDISABLE_GO=ON -DDISABLE_PERL=ON -DCMAKE_BUILD_TYPE=
 echo "Testing shared lib AWS-LC without Perl/Go in release mode."
 build_and_run_minimal_test -DDISABLE_GO=ON -DDISABLE_PERL=ON -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
 
+# Special build options
+
+## build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
+echo "Testing static lib AWS-LC with MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option in release mode."
+build_and_run_minimal_test -DCMAKE_BUILD_TYPE=Release -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
+
+echo "Testing shared lib AWS-LC with MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option in release mode."
+build_and_run_minimal_test -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
+
+echo "Testing static lib AWS-LC with MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option in debug mode."
+build_and_run_minimal_test -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
+
+echo "Testing shared lib AWS-LC with MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option in debug mode."
+build_and_run_minimal_test -DBUILD_SHARED_LIBS=1 -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
+
+echo "Testing shared lib AWS-LC with MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX build option in [FIPS, release] mode."
+build_and_run_minimal_test -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON -DFIPS=1

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -43,7 +43,7 @@ fi
 
 # Lightly verify that uncommon build options does not break the build. Fist
 # define a list of typical build options to verify the special build option with
-build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DFIPS=1")
+build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release")
 
 ## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
 for build_option in "${build_options_to_test[@]}"; do

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -43,7 +43,7 @@ fi
 
 # Lightly verify that uncommon build options does not break the build. Fist
 # define a list of typical build options to verify the special build option with
-build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release")
+build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release")
 
 ## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
 for build_option in "${build_options_to_test[@]}"; do

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -41,11 +41,11 @@ if [[ "${AWSLC_FUZZ}" == "1" ]]; then
   run_build -DFUZZ=1
 fi
 
-# Lightly verify that uncommon build options does not break anything. Fist
+# Lightly verify that uncommon build options does not break the build. Fist
 # define a list of typical build options to verify the special build option with
 build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DFIPS=1")
 
 ## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
 for build_option in "${build_options_to_test[@]}"; do
-  build_and_run_minimal_test ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
+  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
 done

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -40,3 +40,12 @@ if [[ "${AWSLC_FUZZ}" == "1" ]]; then
   echo "Testing building fuzz tests."
   run_build -DFUZZ=1
 fi
+
+# Lightly verify that uncommon build options does not break anything. Fist
+# define a list of typical build options to verify the special build option with
+build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DFIPS=1")
+
+## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
+for build_option in "${build_options_to_test[@]}"; do
+  build_and_run_minimal_test ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
+done


### PR DESCRIPTION

### Description of changes: 

#412 introduced a build regression when using the `MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX` build option. Regression was fixed in #426 

This PR improves the CI ability to verify that changes doesn't regress the `MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX` build option using the light weight tests.

Also, makes it clear in the cmake output that `MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX` is active.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
