### PR TITLE
Adding pre-notification instructions to AWS-LC

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,5 @@ If you discover a potential security issue in AWS-LC, we ask that you notify AWS
 Security via our
 [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/).
 Please do **not** create a public GitHub issue.
+
+If you package or distribute aws-lc, or use aws-lc as part of a large multi-user service, you may be eligible for pre-notification of future aws-lc releases. Please contact aws-lc-pre-notifications@amazon.com.

--- a/README.md
+++ b/README.md
@@ -128,4 +128,4 @@ Security via our
 [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/).
 Please do **not** create a public GitHub issue.
 
-If you package or distribute aws-lc, or use aws-lc as part of a large multi-user service, you may be eligible for pre-notification of future aws-lc releases. Please contact aws-lc-pre-notifications@amazon.com.
+If you package or distribute AWS-LC, or use AWS-LC as part of a large multi-user service, you may be eligible for pre-notification of future AWS-LC releases. Please contact aws-lc-pre-notifications@amazon.com.


### PR DESCRIPTION
### Issues:  
CryptoAlg-861

### Description of changes: 
Modifying our readme to add instructions on how to register for pre-notifications of AWS-LC.  

### Testing:
Ensured the e-mail list allowed access from both internal and external e-mail addresses. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
