### PR TITLE
Detect ACCP keys when parsing RSA private keys from ASN.1/DER

### DIFF
--- a/crypto/fipsmodule/rsa/internal.h
+++ b/crypto/fipsmodule/rsa/internal.h
@@ -66,6 +66,11 @@
 extern "C" {
 #endif
 
+typedef enum {
+    RSA_STRIPPED_KEY,
+    RSA_CRT_KEY,
+    RSA_PUBLIC_KEY
+} rsa_asn1_key_encoding_t;
 
 // Default implementations of RSA operations.
 
@@ -110,7 +115,7 @@ int RSA_padding_add_none(uint8_t *to, size_t to_len, const uint8_t *from,
 
 // rsa_check_public_key checks that |rsa|'s public modulus and exponent are
 // within DoS bounds.
-int rsa_check_public_key(const RSA *rsa);
+int rsa_check_public_key(const RSA *rsa, rsa_asn1_key_encoding_t key_enc_type);
 
 // RSA_private_transform calls either the method-specific |private_transform|
 // function (if given) or the generic one. See the comment for
@@ -123,6 +128,8 @@ int RSA_private_transform(RSA *rsa, uint8_t *out, const uint8_t *in,
 extern const BN_ULONG kBoringSSLRSASqrtTwo[];
 extern const size_t kBoringSSLRSASqrtTwoLen;
 
+int RSA_validate_key(const RSA *rsa,
+  rsa_asn1_key_encoding_t key_enc_type);
 
 // Functions that avoid self-tests.
 //

--- a/crypto/fipsmodule/rsa/internal.h
+++ b/crypto/fipsmodule/rsa/internal.h
@@ -128,8 +128,7 @@ int RSA_private_transform(RSA *rsa, uint8_t *out, const uint8_t *in,
 extern const BN_ULONG kBoringSSLRSASqrtTwo[];
 extern const size_t kBoringSSLRSASqrtTwoLen;
 
-int RSA_validate_key(const RSA *rsa,
-  rsa_asn1_key_encoding_t key_enc_type);
+int RSA_validate_key(const RSA *rsa, rsa_asn1_key_encoding_t key_enc_type);
 
 // Functions that avoid self-tests.
 //

--- a/crypto/rsa_extra/rsa_asn1.c
+++ b/crypto/rsa_extra/rsa_asn1.c
@@ -102,7 +102,7 @@ RSA *RSA_parse_public_key(CBS *cbs) {
     return NULL;
   }
 
-  if (!RSA_check_key(ret)) {
+  if (!RSA_validate_key(ret, RSA_PUBLIC_KEY)) {
     OPENSSL_PUT_ERROR(RSA, RSA_R_BAD_RSA_PARAMETERS);
     RSA_free(ret);
     return NULL;
@@ -153,6 +153,15 @@ int RSA_public_key_to_bytes(uint8_t **out_bytes, size_t *out_len,
 // RSAPrivateKey structure (RFC 3447).
 static const uint64_t kVersionTwoPrime = 0;
 
+// Distinguisher for stripped ACCP RSA private keys.
+// Return 1 if ACCP stripped private key.
+// Return 0 otherwise.
+static int detect_stripped_accp_private_key(const RSA *key) {
+  return (key->e == NULL || BN_is_zero(key->e)) &&
+         (key->p == NULL || BN_is_zero(key->p)) &&
+         (key->q == NULL || BN_is_zero(key->q));
+}
+
 RSA *RSA_parse_private_key(CBS *cbs) {
   RSA *ret = RSA_new();
   if (ret == NULL) {
@@ -188,7 +197,12 @@ RSA *RSA_parse_private_key(CBS *cbs) {
     goto err;
   }
 
-  if (!RSA_check_key(ret)) {
+  rsa_asn1_key_encoding_t rsa_enc_key_type = RSA_CRT_KEY;
+  if (detect_stripped_accp_private_key(ret) == 1) {
+    rsa_enc_key_type = RSA_STRIPPED_KEY;
+  }
+
+  if (!RSA_validate_key(ret, rsa_enc_key_type)) {
     OPENSSL_PUT_ERROR(RSA, RSA_R_BAD_RSA_PARAMETERS);
     goto err;
   }

--- a/crypto/rsa_extra/rsa_asn1.c
+++ b/crypto/rsa_extra/rsa_asn1.c
@@ -158,10 +158,10 @@ static const uint64_t kVersionTwoPrime = 0;
 // expects absent values to be NULL. Returns 1 if ACCP stripped private key, 0
 // otherwise.
 static int detect_stripped_accp_private_key(RSA *key) {
-  if (!BN_is_zero(key->d) && !BN_is_zero(key->n)
-          && BN_is_zero(key->e) && BN_is_zero(key->iqmp)
-          && BN_is_zero(key->p) && BN_is_zero(key->q)
-          && BN_is_zero(key->dmp1) && BN_is_zero(key->dmq1)) {
+  if (!BN_is_zero(key->d) && !BN_is_zero(key->n) &&
+       BN_is_zero(key->e) && BN_is_zero(key->iqmp) &&
+       BN_is_zero(key->p) && BN_is_zero(key->q) &&
+       BN_is_zero(key->dmp1) && BN_is_zero(key->dmq1)) {
     BN_free(key->e);
     BN_free(key->p);
     BN_free(key->q);

--- a/crypto/rsa_extra/rsa_asn1.c
+++ b/crypto/rsa_extra/rsa_asn1.c
@@ -153,11 +153,11 @@ int RSA_public_key_to_bytes(uint8_t **out_bytes, size_t *out_len,
 // RSAPrivateKey structure (RFC 3447).
 static const uint64_t kVersionTwoPrime = 0;
 
-// Distinguisher for stripped ACCP RSA private keys, sets zeroed values to NULL
+// Distinguisher for stripped JCA RSA private keys, sets zeroed values to NULL
 // because ASN.1 treats absent values as 0, but post-parsing validation logic
-// expects absent values to be NULL. Returns 1 if ACCP stripped private key, 0
+// expects absent values to be NULL. Returns 1 if JCA stripped private key, 0
 // otherwise.
-static int detect_stripped_accp_private_key(RSA *key) {
+static int detect_stripped_jca_private_key(RSA *key) {
   if (!BN_is_zero(key->d) && !BN_is_zero(key->n) &&
        BN_is_zero(key->e) && BN_is_zero(key->iqmp) &&
        BN_is_zero(key->p) && BN_is_zero(key->q) &&
@@ -215,7 +215,7 @@ RSA *RSA_parse_private_key(CBS *cbs) {
   }
 
   rsa_asn1_key_encoding_t rsa_enc_key_type = RSA_CRT_KEY;
-  if (detect_stripped_accp_private_key(ret) == 1) {
+  if (detect_stripped_jca_private_key(ret) == 1) {
     rsa_enc_key_type = RSA_STRIPPED_KEY;
   }
 

--- a/crypto/rsa_extra/rsa_test.cc
+++ b/crypto/rsa_extra/rsa_test.cc
@@ -597,7 +597,8 @@ TEST(RSATest, OnlyDGiven) {
   // validated and used with "NULL"ness indicating absence of various RSA
   // parameters, the actual parsing logic assumes that these NULL'd values are
   // present and zero-valued when being un/marshalled. So, we zero them out
-  // before marshalling, and re-NULL them when parsing back from DER.
+  // before marshalling, and assert that they were NULLed when parsing back
+  // from DER.
   //
   // Also, note that here and in the previous test we expect RSA_check_key to
   // return false for ACCP-style keys. The current implementation does not
@@ -607,9 +608,9 @@ TEST(RSATest, OnlyDGiven) {
   // from DER and special case that.
   //
   // At some point in the future, we will likely want to standardize on one of
-  // of NULL/0 for indicating parameter absence, as well as fix up
-  // RSA_check_key to accurately account for all the different types of RSA
-  // keys that we support.
+  // of NULL/0 for indicating parameter absence across the codebase, as well as
+  // fix up RSA_check_key to accurately account for all the different types of
+  // RSA keys that we support.
   ASSERT_TRUE(BN_hex2bn(&key2->e, "0"));
   ASSERT_TRUE(BN_hex2bn(&key2->p, "0"));
   ASSERT_TRUE(BN_hex2bn(&key2->q, "0"));
@@ -627,24 +628,12 @@ TEST(RSATest, OnlyDGiven) {
   EXPECT_TRUE(accpKey);
   accpKey->flags |= RSA_FLAG_NO_BLINDING;
 
-  ASSERT_TRUE(BN_is_zero(accpKey->e));
-  ASSERT_TRUE(BN_is_zero(accpKey->p));
-  ASSERT_TRUE(BN_is_zero(accpKey->q));
-  ASSERT_TRUE(BN_is_zero(accpKey->dmp1));
-  ASSERT_TRUE(BN_is_zero(accpKey->dmq1));
-  ASSERT_TRUE(BN_is_zero(accpKey->iqmp));
-  BN_free(accpKey->e);
-  BN_free(accpKey->p);
-  BN_free(accpKey->q);
-  BN_free(accpKey->dmp1);
-  BN_free(accpKey->dmq1);
-  BN_free(accpKey->iqmp);
-  accpKey->e = NULL;
-  accpKey->p = NULL;
-  accpKey->q = NULL;
-  accpKey->dmp1 = NULL;
-  accpKey->dmq1 = NULL;
-  accpKey->iqmp = NULL;
+  ASSERT_FALSE(accpKey->e);
+  ASSERT_FALSE(accpKey->p);
+  ASSERT_FALSE(accpKey->q);
+  ASSERT_FALSE(accpKey->dmp1);
+  ASSERT_FALSE(accpKey->dmq1);
+  ASSERT_FALSE(accpKey->iqmp);
 
   EXPECT_FALSE(RSA_check_key(accpKey.get()));
 


### PR DESCRIPTION
# Summary

Prior to this change, all RSA private keys were also validated as public
keys during ASN.1 decoding. That was all well and good for CRT-enabled
private keys, as they contained the public exponent `e`, but was not
suitable for stripped private keys (i.e. keys defined only by `n` and
`d`) as required by the JCA and ACCP.

The refactor is based directly on @htorben's sketch [here][1], and does
not change AWS-LC's external API at all. We intentionally attempt to
minimize behavior and validation changes in order to minimize risk of
accidentally impacting RSA key generation and validation. To that end,
we only perform ACCP-aware validation when parsing from DER, and not
when doing key generation or general validation. The relevant RFC
([RFC-8107][2]) does not seem to explicitly permit omitted (i.e. NULL
type [ASN.1 tag value][3] of 5) RSA parameters when parsing RSA private
keys, so we consider an INTEGER value of 0 to indicate that a parameter
is missing in cases pertaining to ACCP.

This change resolves i/CryptoAlg-1026.

[1]: https://github.com/torben-hansen/aws-lc/compare/main...thoughts_rsa_accp_key_check
[2]: https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.1.2
[3]: https://en.wikipedia.org/wiki/X.690#Identifier_octets


# Testing

- local testing with ACCP (cf. [this PR](https://github.com/corretto/amazon-corretto-crypto-provider/pull/183))
- automated CI testing via GitHub