### PR TITLE
Update the analytics to only run on the main branch

### DIFF
--- a/tests/ci/cdk/cdk/aws_lc_analytics_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_analytics_stack.py
@@ -28,6 +28,9 @@ class AwsLcGitHubAnalyticsStack(core.Stack):
             webhook=True,
             webhook_filters=[
                 codebuild.FilterGroup.in_event_of(codebuild.EventAction.PUSH)
+                # The current FIPS branch does not have the configuration needed to run the analytics, once we update
+                # the branch or create a new FIPS branch it should be updated to '(main)|(fips.*)'
+                .and_branch_is("main")
             ],
             webhook_triggers_batch_build=True)
 

--- a/tests/ci/cdk/cdk/codebuild/github_ci_analytics_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_analytics_omnibus.yaml
@@ -12,7 +12,7 @@ batch:
       env:
         type: LINUX_CONTAINER
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_SMALL
+        compute-type: BUILD_GENERAL1_LARGE
         image: X86_ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
 
     - identifier: amazonlinux2_gcc7x_arm_analytics
@@ -20,5 +20,5 @@ batch:
       env:
         type: ARM_CONTAINER
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_SMALL
+        compute-type: BUILD_GENERAL1_LARGE
         image: ARM_ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_latest


### PR DESCRIPTION
### Description of changes: 
Add a filter to the analytics webhook so it only runs on pushes to main. This is useful because not all branches have the analytics config yet and would create failing builds. 

### Testing:
I deployed this change to my local CI and made several pushes to branches and verified it only ran when I pushed to my main.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
