### PR TITLE
Add AWS CLI to ARM AmazonLinux2 base image

### DIFF
--- a/tests/ci/docker_images/linux-aarch/amazonlinux-2_base/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/amazonlinux-2_base/Dockerfile
@@ -24,7 +24,13 @@ RUN set -ex && \
     wget \
     llvm \
     llvm-devel \
-    valgrind && \
+    valgrind \
+    unzip && \
+    # Based on https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install --bin-dir /usr/bin && \
+    rm -rf awscliv2.zip aws/ && \
     mkdir -p ${DEPENDENCIES_DIR} && \
     cd ${DEPENDENCIES_DIR} && \
     git clone https://github.com/llvm/llvm-project.git --branch llvmorg-11.1.0  --depth 1 && \


### PR DESCRIPTION
### Description of changes: 
The ARM AmazonLinux2 base image is out of sync with the [X86 image which includes the AWS CLI](https://github.com/awslabs/aws-lc/blob/main/tests/ci/docker_images/linux-x86/amazonlinux-2_base/Dockerfile#L29-L33). This change adds it to get them both in sync.

### Testing:
Built this image on an ARM instance and verified the `aws` command is found.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
