### PR TITLE
CAVP should only be built if we have testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -743,6 +743,8 @@ if(BUILD_TESTING)
     file(COPY ${GENERATE_CODE_ROOT}/crypto_test_data.cc DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
   endif()
   add_library(crypto_test_data OBJECT crypto_test_data.cc)
+  # Only build this if we are doing testing
+  add_subdirectory(util/fipstools/cavp)
 endif()
 
 add_subdirectory(crypto)
@@ -751,7 +753,6 @@ if(BUILD_LIBSSL)
   add_subdirectory(tool)
   add_subdirectory(decrepit)
 endif()
-add_subdirectory(util/fipstools/cavp)
 add_subdirectory(util/fipstools/acvp/modulewrapper)
 
 if(FUZZ)


### PR DESCRIPTION
When we try to build with NO_TESTING currently it fails because CAVP
can't be built. We don't need CAVP when testing is off so this disables
CAVP if we don't have testing so we can successfully build without
testing.

### Issues:
Resolves CryptoAlg-934

### Testing:
Built locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
