### PR TITLE
Fix compiler warn(treated as error) reported by gcc-4.1.

### DIFF
--- a/crypto/fipsmodule/hmac/hmac.c
+++ b/crypto/fipsmodule/hmac/hmac.c
@@ -185,7 +185,8 @@ uint8_t *HMAC(const EVP_MD *evp_md, const void *key, size_t key_len,
               const uint8_t *data, size_t data_len, uint8_t *out,
               unsigned int *out_len) {
 
-  HMAC_CTX ctx = {0};
+  HMAC_CTX ctx;
+  OPENSSL_memset(&ctx, 0, sizeof(HMAC_CTX));
   int result;
 
   // We have to avoid the underlying SHA services updating the indicator


### PR DESCRIPTION
### Description of changes: 
This PR fixed compiler warning(treated as error) reported by gcc-4.1 in the build `5907986753`.

```
cc1: warnings being treated as errors
...
crypto/fipsmodule/hmac/hmac.c: In function 'HMAC':
crypto/fipsmodule/hmac/hmac.c:188: warning: missing initializer
crypto/fipsmodule/hmac/hmac.c:188: warning: (near initialization for 'ctx.methods')
```

### Call-outs:
TBD

### Testing:
* This fix is verified by build `5908005917`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
