### PR TITLE
Make it possible to distinguish BSSL and AWS-LC

### DIFF
--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -113,7 +113,7 @@ const char *SSLeay_version(int which) { return OpenSSL_version(which); }
 const char *OpenSSL_version(int which) {
   switch (which) {
     case OPENSSL_VERSION:
-      return "BoringSSL";
+      return AWSLC_VERSION_NAME;
     case OPENSSL_CFLAGS:
       return "compiler: n/a";
     case OPENSSL_BUILT_ON:

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -72,7 +72,7 @@
 // Include a BoringSSL-only header so consumers including this header without
 // setting up include paths do not accidentally pick up the system
 // opensslconf.h.
-#include <openssl/is_boringssl.h>
+#include <openssl/is_awslc.h>
 #include <openssl/opensslconf.h>
 
 #if defined(BORINGSSL_PREFIX)
@@ -186,6 +186,7 @@ extern "C" {
 #define OPENSSL_THREADS
 #endif
 
+#define AWSLC_VERSION_NAME "AWS-LC"
 #define OPENSSL_IS_AWSLC
 #define OPENSSL_VERSION_NUMBER 0x1010107f
 #define SSLEAY_VERSION_NUMBER OPENSSL_VERSION_NUMBER

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -69,7 +69,7 @@
 #include <TargetConditionals.h>
 #endif
 
-// Include a BoringSSL-only header so consumers including this header without
+// Include an AWS-LC-only header so consumers including this header without
 // setting up include paths do not accidentally pick up the system
 // opensslconf.h.
 #include <openssl/is_awslc.h>

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -107,7 +107,7 @@ OPENSSL_EXPORT size_t FIPS_read_counter(enum fips_counter_t counter);
 
 // OPENSSL_VERSION_TEXT contains a string the identifies the version of
 // “OpenSSL”. node.js requires a version number in this text.
-#define OPENSSL_VERSION_TEXT "OpenSSL 1.1.1 (compatible; BoringSSL)"
+#define OPENSSL_VERSION_TEXT "OpenSSL 1.1.1 (compatible; AWS-LC)"
 
 #define OPENSSL_VERSION 0
 #define OPENSSL_CFLAGS 1

--- a/include/openssl/is_awslc.h
+++ b/include/openssl/is_awslc.h
@@ -13,4 +13,4 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
 
 // This header is provided in order to catch include path errors in consuming
-// BoringSSL.
+// AWS-LC.


### PR DESCRIPTION
### Description of changes: 

`OpenSSL_version()` can be a convenient method to distinguish AWS-LC from other projects at run-time. But it can't be used as a distinguisher from BSSL without changing the name to AWS-LC. Make this change since AWS-LC is a dependency in projects that can also depend on BSSL.

At the same time, modify the name of the project-specific header file (`is_boringssl.h`) to an AWS-LC-specific name.

It is better to make these changes early on.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
