### PR TITLE
Add Device Farm permissions for android codebuild dimension

### DIFF
--- a/tests/ci/cdk/cdk/aws_lc_android_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_android_ci_stack.py
@@ -3,7 +3,7 @@
 
 from aws_cdk import core, aws_codebuild as codebuild, aws_iam as iam
 from util.ecr_util import ecr_arn
-from util.iam_policies import code_build_batch_policy_in_json
+from util.iam_policies import code_build_batch_policy_in_json, device_farm_access_policy_in_json
 from util.metadata import AWS_ACCOUNT, AWS_REGION, GITHUB_REPO_OWNER, GITHUB_REPO_NAME
 from util.yml_loader import YmlLoader
 
@@ -38,7 +38,10 @@ class AwsLcAndroidCIStack(core.Stack):
         code_build_batch_policy = iam.PolicyDocument.from_json(
             code_build_batch_policy_in_json([id])
         )
-        inline_policies = {"code_build_batch_policy": code_build_batch_policy}
+        device_farm_policy = iam.PolicyDocument.from_json(
+            device_farm_access_policy_in_json()
+        )
+        inline_policies = {"code_build_batch_policy": code_build_batch_policy, "device_farm_policy": device_farm_policy}
         role = iam.Role(scope=self,
                         id="{}-role".format(id),
                         assumed_by=iam.ServicePrincipal("codebuild.amazonaws.com"),

--- a/tests/ci/cdk/util/iam_policies.py
+++ b/tests/ci/cdk/util/iam_policies.py
@@ -202,3 +202,32 @@ def ecr_power_user_policy_in_json(ecr_repo_names):
             }
         ]
     }
+
+def device_farm_access_policy_in_json():
+    """
+    Define an IAM policy statement for Device Farm operations.
+    :return: an IAM policy statement in json.
+    """
+    resources = []
+    resources.append("arn:aws:devicefarm:{}:{}:*:*".format(AWS_REGION, AWS_ACCOUNT))
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "ViewProjectInfo",
+                "Effect": "Allow",
+                "Action": [
+                    "devicefarm:CreateUpload",
+                    "devicefarm:GetUpload",
+                    "devicefarm:GetRun",
+                    "devicefarm:ScheduleRun",
+                    "devicefarm:StopRun",
+                    "devicefarm:ListArtifacts",
+                    "devicefarm:ListJobs",
+                    "devicefarm:ListSuites",
+                    "devicefarm:ListTests",
+                ],
+                "Resource": resources
+            }
+        ]
+    }


### PR DESCRIPTION
### Issues:
Resolves Android failure in https://github.com/awslabs/aws-lc/pull/460

### Description of changes: 
The new https://github.com/awslabs/aws-lc/pull/460 Android CI functionality requires device farm IAM permissions to start up the new tests.

### Call-outs:
N/A

### Testing:
IAM Policy used and tested in https://github.com/samuel40791765/aws-lc/pull/14. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
