### PR TITLE
Upgrade Android CI to use larger instance

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_android_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_android_omnibus.yaml
@@ -11,28 +11,28 @@ batch:
       env:
         type: LINUX_CONTAINER
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_MEDIUM
+        compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_android_latest
     - identifier: ubuntu2004_android_nonfips_static_release
       buildspec: ./tests/ci/codebuild/android/run_android_static_release.yml
       env:
         type: LINUX_CONTAINER
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_MEDIUM
+        compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_android_latest
     - identifier: ubuntu2004_android_nonfips_shared_debug
       buildspec: ./tests/ci/codebuild/android/run_android_shared_debug.yml
       env:
         type: LINUX_CONTAINER
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_MEDIUM
+        compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_android_latest
     - identifier: ubuntu2004_android_nonfips_shared_release
       buildspec: ./tests/ci/codebuild/android/run_android_shared_release.yml
       env:
         type: LINUX_CONTAINER
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_MEDIUM
+        compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_android_latest
     - identifier: ubuntu2004_android_fips
       buildspec: ./tests/ci/codebuild/android/run_android_fips.yml


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-895`

### Description of changes: 
Upgrading the Android CI compute type, reason described in `CryptoAlg-1063`.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
