### PR TITLE
Symbol visibility to default for static build

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -234,7 +234,11 @@ extern "C" {
 
 #else  // defined(BORINGSSL_SHARED_LIBRARY)
 
-#define OPENSSL_EXPORT
+#if defined(OPENSSL_WINDOWS)
+#define OPENSSL_EXPORT __declspec(dllexport)
+#else
+#define OPENSSL_EXPORT __attribute__((visibility("default")))
+#endif
 
 #endif  // defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Issues:

Partially Resolves https://github.com/aws/s2n-tls/issues/3262

### Description of changes: 

While trying to internalize aws-lc into libs2n.so, we have observed that while symbols aren't hidden in static builds, once objcopy copies libcrypto, the fact that symbols are marked hidden is still honored in the shared lib.  This means libcrypto symbols aren't available (see the issue).

This change makes symbols visible for the aws-lc static.

Test summery run using this branch and the other changes in #3262
```
S2N_LIBCRYPTO=awslc ./codebuild/bin/test_libcrypto_interning.sh
...
Total Test time (real) =  57.71 sec
make: Leaving directory '/home/dougch/gitrepos/s2n-tls/build/static'
testing static linking with /home/dougch/gitrepos/s2n-tls/build/openssl_1_0
testing static linking with /home/dougch/gitrepos/s2n-tls/build/awslc
running pair: TLS 1.3 failure expected
checking for TLS 1.3
running pair: TLS 1.3 success expected
CONNECTED:
Handshake: NEGOTIATED|FULL_HANDSHAKE|MIDDLEBOX_COMPAT
Client hello version: 33
Client protocol version: 34
Server protocol version: 34
Actual protocol version: 34
Server name: localhost
Curve: x25519
KEM: NONE
KEM Group: NONE
Cipher negotiated: TLS_AES_128_GCM_SHA256
Server signature negotiated: RSA-PSS-RSAE+SHA256
Early Data status: NOT REQUESTED
s2n is ready
Connected to localhost:4433                                                                                                                                                                  checking for TLS 1.3                                                                                                                                                                         ./codebuild/bin/test_libcrypto_interning.sh: line 94: 22472 Terminated  
LD_PRELOAD=$OPENSSL_1_0/lib/libcrypto.so ./build/$TARGET/bin/s2nd -c default_tls13 localhost 4433 &> /dev/null
SUCCESS!
$ nm ./build/shared-testing/lib/libs2n.so |grep 's2n\$' |grep ' T '|head
00000000000ec540 T s2n$ACCESS_DESCRIPTION_free
00000000000ec580 T s2n$ACCESS_DESCRIPTION_new
0000000000130f20 T s2n$AES_CMAC
0000000000121b90 T s2n$AES_cbc_encrypt
000000000013ec50 T s2n$AES_cfb128_encrypt
000000000013f760 T s2n$AES_ctr128_encrypt
000000000011ab60 T s2n$AES_decrypt
0000000000121b70 T s2n$AES_ecb_encrypt
0000000000115450 T s2n$AES_encrypt
0000000000141e20 T s2n$AES_ofb128_encrypt
```

### Call-outs:

This brings aws-lc in-line with OpenSSL behavior. 

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? locally, future ci jobs needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
