### PR TITLE
Bump AWS-LC API version

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -202,7 +202,7 @@ extern "C" {
 // against multiple revisions of BoringSSL at the same time. It is not
 // recommended to do so for longer than is necessary.
 
-#define AWSLC_API_VERSION 16
+#define AWSLC_API_VERSION 17
 
 // This string tracks the most current production release version on Github
 // https://github.com/awslabs/aws-lc/releases.


### PR DESCRIPTION
### Description of changes: 
#458 is not backwards compatible. Bump API version to allow downstream detection in the preprocessor. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
