### PR TITLE
Set cryptofuzz docker image to use an older tag

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
@@ -23,13 +23,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ARM_ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_latest
 
+# Setting tag to an older image of cryptofuzz, fix is tracked in CryptoAlg-1066.
     - identifier: ubuntu2004_clang10_x86_64_cryptofuzz
       buildspec: ./tests/ci/codebuild/linux-x86/run_cryptofuzz.yml
       env:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: X86_ECR_REPO_PLACEHOLDER:ubuntu-20.04_cryptofuzz_latest
+        image: X86_ECR_REPO_PLACEHOLDER:ubuntu-20.04_cryptofuzz_2021-10-05
 
 # Turn off the ARM Cryptofuzz, fix is tracked in CryptoAlg-742
 #    - identifier: ubuntu2004_clang10_arm_cryptofuzz


### PR DESCRIPTION
### Issues:
Tracked in `CryptoAlg-1066`

### Description of changes: 
Fixating the CI to use the same cryptofuzz docker image.

### Call-outs:
N/A

### Testing:
The tag points to the same docker image that we currently use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
