### PR TITLE
Move XTS from libdecrepit to libcrypto

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -452,6 +452,7 @@ add_library(
   x509v3/v3_purp.c
   x509v3/v3_skey.c
   x509v3/v3_utl.c
+  xts/xts.c
 
   ${CRYPTO_ARCH_SOURCES}
 )
@@ -635,6 +636,7 @@ if(BUILD_TESTING)
     x509/x509_test.cc
     x509/x509_time_test.cc
     x509v3/tab_test.cc
+    xts/xts_test.cc
 
     $<TARGET_OBJECTS:crypto_test_data>
     $<TARGET_OBJECTS:boringssl_gtest_main>

--- a/crypto/fipsmodule/aes/internal.h
+++ b/crypto/fipsmodule/aes/internal.h
@@ -38,11 +38,8 @@ OPENSSL_INLINE int hwaes_capable(void) { return CRYPTO_is_AESNI_capable(); }
 #if defined(OPENSSL_X86_64)
 #define VPAES_CTR32
 #define HWAES_XTS
-// This function is defined within fipsmodule to be able to access
-// OPENSSL_ia32cap_P and give the result outside the module.
-OPENSSL_EXPORT int CRYPTO_is_xts_AESNI_capable(void);
 OPENSSL_INLINE int hwaes_xts_available(void) {
-  return CRYPTO_is_xts_AESNI_capable();
+  return CRYPTO_is_AESNI_capable();
 }
 #endif
 #define VPAES_CBC
@@ -169,9 +166,6 @@ OPENSSL_INLINE int aes_hw_xts_cipher(const uint8_t *in, uint8_t *out, size_t len
                                       const AES_KEY *key1, const AES_KEY *key2,
                                       const uint8_t iv[16], int enc) {
   abort();
-}
-OPENSSL_INLINE int CRYPTO_is_xts_AESNI_capable(void) {
-    return 0;
 }
 #endif  // HWAES_XTS
 

--- a/crypto/fipsmodule/aes/mode_wrappers.c
+++ b/crypto/fipsmodule/aes/mode_wrappers.c
@@ -143,10 +143,4 @@ int aes_hw_xts_cipher(const uint8_t *in, uint8_t *out, size_t length,
   return 1;
 }
 
-#if defined(OPENSSL_X86_64)
-int CRYPTO_is_xts_AESNI_capable(void) {
-  return CRYPTO_is_AESNI_capable();
-}
-#endif // OPENSSL_X86_64
-
 #endif // HWAES_XTS

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1129,7 +1129,7 @@ OPENSSL_EXPORT int CRYPTO_is_NEON_capable_at_runtime(void);
 
 // CRYPTO_is_ARMv8_AES_capable_at_runtime returns true if the current CPU
 // supports the ARMv8 AES instruction.
-OPENSSL_EXPORT int CRYPTO_is_ARMv8_AES_capable_at_runtime(void);
+int CRYPTO_is_ARMv8_AES_capable_at_runtime(void);
 
 // CRYPTO_is_ARMv8_PMULL_capable_at_runtime returns true if the current CPU
 // supports the ARMv8 PMULL instruction.

--- a/crypto/xts/xts.c
+++ b/crypto/xts/xts.c
@@ -54,8 +54,8 @@
 #include <openssl/cipher.h>
 #include <openssl/err.h>
 
-#include "../crypto/fipsmodule/modes/internal.h"
-#include "../crypto/fipsmodule/aes/internal.h"
+#include "../fipsmodule/modes/internal.h"
+#include "../fipsmodule/aes/internal.h"
 
 typedef struct xts128_context {
   AES_KEY *key1, *key2;

--- a/crypto/xts/xts_test.cc
+++ b/crypto/xts/xts_test.cc
@@ -19,9 +19,9 @@
 
 #include <gtest/gtest.h>
 
-#include "../../crypto/internal.h"
-#include "../../crypto/fipsmodule/modes/internal.h"
-#include "../../crypto/test/test_util.h"
+#include "../internal.h"
+#include "../fipsmodule/modes/internal.h"
+#include "../test/test_util.h"
 
 
 struct XTSTestCase {

--- a/decrepit/CMakeLists.txt
+++ b/decrepit/CMakeLists.txt
@@ -19,7 +19,6 @@ add_library(
   rsa/rsa_decrepit.c
   ssl/ssl_decrepit.c
   x509/x509_decrepit.c
-  xts/xts.c
 )
 target_compile_definitions(decrepit PRIVATE BORINGSSL_IMPLEMENTATION)
 
@@ -36,7 +35,6 @@ if(BUILD_TESTING)
     cfb/cfb_test.cc
     evp/evp_test.cc
     ripemd/ripemd_test.cc
-    xts/xts_test.cc
 
     $<TARGET_OBJECTS:boringssl_gtest_main>
   )

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -25,8 +25,6 @@ target_include_directories(bssl PUBLIC ${AWSLC_INSTALL_DIR}/include ${AWSLC_INST
 
 add_dependencies(bssl global_target)
 
-target_link_libraries(bssl decrepit)
-
 if(WIN32)
   target_link_libraries(bssl ws2_32)
 endif()
@@ -62,7 +60,6 @@ endfunction()
 
 if(AWSLC_INSTALL_DIR)
   build_benchmark(awslc_bm ${AWSLC_INSTALL_DIR}/include crypto)
-  target_link_libraries(awslc_bm decrepit)
 
   if(NOT CMAKE_BUILD_TYPE)
     target_compile_options(awslc_bm PUBLIC -DCMAKE_BUILD_TYPE_DEBUG)


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-929

### Description of changes: 
AES-XTS C implementation and tests were part of `libdecrepit` before this PR. Here, they are moved into `libcrypto`.
Note: the assembly implementation already co-exists with the rest of AES assembly functions in the respective Perl-Assembly code for AArch64 and x86_64 in `crypto/fipsmodule/aes/asm`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
