### PR TITLE
Track size of bssl overtime

### DIFF
--- a/tests/ci/run_analytics.sh
+++ b/tests/ci/run_analytics.sh
@@ -82,8 +82,10 @@ function run_build_and_collect_metrics {
 
   libcrypto_size=$(size "${BUILD_ROOT}/crypto/libcrypto.${lib_extension}")
   libssl_size=$(size "${BUILD_ROOT}/ssl/libssl.${lib_extension}")
+  tool_size=$(size "${BUILD_ROOT}/tool/bssl")
   put_metric --metric-name LibCryptoSize --value "$libcrypto_size" --unit Bytes --dimensions "${size_common_dimensions}"
   put_metric --metric-name LibSSLSize --value "$libssl_size" --unit Bytes --dimensions "${size_common_dimensions}"
+  put_metric --metric-name ToolSize --value "$tool_size" --unit Bytes --dimensions "${size_common_dimensions}"
 
   pushd .
   cd "$BUILD_ROOT"


### PR DESCRIPTION
### Description of changes: 
Track the size of bssl as an indicator for the size implications to our customers picking between linking with the static or shared libraries for libcrypto and libssl. This isn't a perfect indicator as the size impact with a static library will depend on the customer's usecase.

### Testing:
Ran locally and verified new metrics are emitted with expected values:
```
aws cloudwatch put-metric-data --timestamp 1651012758 --namespace AWS-LC --metric-name ToolSize --value 3117944 --unit Bytes --dimensions Branch=analytics,Optimization=Release,BuildSize=Small,Assembly=NoAsm,CPU=x86_64,Linking=Shared,FIPS=NotFIPS
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
