### PR TITLE
Add interned s2n-tls+aws-lc test and re-factor script

### DIFF
--- a/crypto/cmake/crypto-config.cmake
+++ b/crypto/cmake/crypto-config.cmake
@@ -3,8 +3,10 @@ if(WIN32 OR UNIX OR APPLE)
 endif()
 
 if (BUILD_SHARED_LIBS)
+    message(STATUS "FOUND AWS-LC CRYPTO cmake config - shared")
     include(${CMAKE_CURRENT_LIST_DIR}/shared/crypto-targets.cmake)
 else()
+    message(STATUS "FOUND AWS-LC CRYPTO cmake config - static")
     include(${CMAKE_CURRENT_LIST_DIR}/static/crypto-targets.cmake)
 endif()
 

--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -47,7 +47,7 @@ function s2n_tls_prepare_new_build() {
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${S2N_TLS_BUILD_FOLDER}
 git clone https://github.com/torben-hansen/s2n.git
 cd s2n
-git checkout test_something
+git checkout fix_cmake_interning_build
 cd ..
 ls
 

--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -34,7 +34,7 @@ function s2n_tls_build() {
 
 function s2n_tls_run_tests() {
 	cd ${S2N_TLS_BUILD_FOLDER}
-	ctest3 -j 8 --output-on-failure
+	ctest -j 8 --output-on-failure
 	cd ${ROOT}
 }
 

--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -4,13 +4,20 @@
 
 # Set up environment.
 
-AWS_LC_DIR=${PWD##*/}
+AWS_LC_DIR_NAME=${PWD##*/}
 cd ../
 ROOT=$(pwd)
+AWS_LC_DIR=${ROOT}/${AWS_LC_DIR_NAME}
 
-AWS_LC_BUILD_FOLDER="${ROOT}/aws-lc-build"
-AWS_LC_INSTALL_FOLDER="${ROOT}/aws-lc-install"
-S2N_TLS_BUILD_FOLDER="${ROOT}/s2n-tls-build"
+SCRATCH_FOLDER=${ROOT}/"SCRATCH_AWSLC_S2N_INTERN_TEST"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+S2N_TLS_BUILD_FOLDER="${SCRATCH_FOLDER}/s2n-tls-build"
+
+# Make script execution idempotent.
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf ${SCRATCH_FOLDER}/*
+cd ${SCRATCH_FOLDER}
 
 # Test helpers.
 
@@ -35,7 +42,7 @@ function s2n_tls_build() {
 function s2n_tls_run_tests() {
 	cd ${S2N_TLS_BUILD_FOLDER}
 	ctest -j 8 --output-on-failure
-	cd ${ROOT}
+	cd ${SCRATCH_FOLDER}
 }
 
 function s2n_tls_prepare_new_build() {

--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -2,7 +2,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Set up environment
+# Set up environment.
 
 AWS_LC_DIR=${PWD##*/}
 cd ../
@@ -12,7 +12,7 @@ AWS_LC_BUILD_FOLDER="${ROOT}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${ROOT}/aws-lc-install"
 S2N_TLS_BUILD_FOLDER="${ROOT}/s2n-tls-build"
 
-# Test helpers
+# Test helpers.
 
 function fail() {
     echo "test failure: $1"
@@ -23,15 +23,13 @@ function aws_lc_build() {
 	cmake ${AWS_LC_DIR} -GNinja "-B${AWS_LC_BUILD_FOLDER}" "-DCMAKE_INSTALL_PREFIX=${AWS_LC_INSTALL_FOLDER}" "$@"
 	ninja -C ${AWS_LC_BUILD_FOLDER} install
 	ls -R ${AWS_LC_INSTALL_FOLDER}
-	cat ${AWS_LC_INSTALL_FOLDER}/lib64/crypto/cmake/shared/crypto-targets-release.cmake
-	ls -R ${AWS_LC_INSTALL_FOLDER}/lib64/crypto/cmake
 	rm -rf ${AWS_LC_BUILD_FOLDER}/*
 }
 
 function s2n_tls_build() {
 	cmake s2n -GNinja "-B${S2N_TLS_BUILD_FOLDER}" "-DCMAKE_PREFIX_PATH=${AWS_LC_INSTALL_FOLDER}" "$@"
 	ninja -C ${S2N_TLS_BUILD_FOLDER}
-	#ls -R ${S2N_TLS_BUILD_FOLDER}
+	ls -R ${S2N_TLS_BUILD_FOLDER}
 }
 
 function s2n_tls_run_tests() {
@@ -64,13 +62,13 @@ aws_lc_build -DBUILD_SHARED_LIBS=1
 # Build s2n-tls+aws-lc and run s2n-tls tests. First using static aws-lc
 # libcrypto and then shared aws-lc libcrypto.
 
-#s2n_tls_build
-#s2n_tls_run_tests
-#s2n_tls_prepare_new_build
+s2n_tls_build
+s2n_tls_run_tests
+s2n_tls_prepare_new_build
 
-#s2n_tls_build -DBUILD_SHARED_LIBS=1
-#s2n_tls_run_tests
-#s2n_tls_prepare_new_build
+s2n_tls_build -DBUILD_SHARED_LIBS=1
+s2n_tls_run_tests
+s2n_tls_prepare_new_build
 
 # Test interned s2n-tls+aws-lc against both static and shared aws-lc libcrypto.
 

--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -46,6 +46,9 @@ function s2n_tls_prepare_new_build() {
 
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${S2N_TLS_BUILD_FOLDER}
 git clone https://github.com/torben-hansen/s2n.git
+cd s2n
+git checkout test_something
+cd ..
 ls
 
 # s2n-tls's FindLibCrypto.cmake expects to find both the static and shared

--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -23,13 +23,15 @@ function aws_lc_build() {
 	cmake ${AWS_LC_DIR} -GNinja "-B${AWS_LC_BUILD_FOLDER}" "-DCMAKE_INSTALL_PREFIX=${AWS_LC_INSTALL_FOLDER}" "$@"
 	ninja -C ${AWS_LC_BUILD_FOLDER} install
 	ls -R ${AWS_LC_INSTALL_FOLDER}
+	cat ${AWS_LC_INSTALL_FOLDER}/lib64/crypto/cmake/shared/crypto-targets-release.cmake
+	ls -R ${AWS_LC_INSTALL_FOLDER}/lib64/crypto/cmake
 	rm -rf ${AWS_LC_BUILD_FOLDER}/*
 }
 
 function s2n_tls_build() {
 	cmake s2n -GNinja "-B${S2N_TLS_BUILD_FOLDER}" "-DCMAKE_PREFIX_PATH=${AWS_LC_INSTALL_FOLDER}" "$@"
 	ninja -C ${S2N_TLS_BUILD_FOLDER}
-	ls -R ${S2N_TLS_BUILD_FOLDER}
+	#ls -R ${S2N_TLS_BUILD_FOLDER}
 }
 
 function s2n_tls_run_tests() {
@@ -62,13 +64,13 @@ aws_lc_build -DBUILD_SHARED_LIBS=1
 # Build s2n-tls+aws-lc and run s2n-tls tests. First using static aws-lc
 # libcrypto and then shared aws-lc libcrypto.
 
-s2n_tls_build
-s2n_tls_run_tests
-s2n_tls_prepare_new_build
+#s2n_tls_build
+#s2n_tls_run_tests
+#s2n_tls_prepare_new_build
 
-s2n_tls_build -DBUILD_SHARED_LIBS=1
-s2n_tls_run_tests
-s2n_tls_prepare_new_build
+#s2n_tls_build -DBUILD_SHARED_LIBS=1
+#s2n_tls_run_tests
+#s2n_tls_prepare_new_build
 
 # Test interned s2n-tls+aws-lc against both static and shared aws-lc libcrypto.
 

--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -2,12 +2,27 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+source tests/ci/common_posix_setup.sh
+
 # Set up environment.
 
-AWS_LC_DIR_NAME=${PWD##*/}
+# ROOT
+#  |
+#  - AWS_LC_DIR
+#    |
+#    - aws-lc
+#  |
+#  - SCRATCH_FOLDER
+#    |
+#    - s2n-tls
+#    - AWS_LC_BUILD_FOLDER
+#    - AWS_LC_INSTALL_FOLDER
+#    - S2N_TLS_BUILD_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+AWS_LC_DIR=$(pwd)
 cd ../
 ROOT=$(pwd)
-AWS_LC_DIR=${ROOT}/${AWS_LC_DIR_NAME}
 
 SCRATCH_FOLDER=${ROOT}/"SCRATCH_AWSLC_S2N_INTERN_TEST"
 AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
@@ -19,7 +34,9 @@ mkdir -p ${SCRATCH_FOLDER}
 rm -rf ${SCRATCH_FOLDER}/*
 cd ${SCRATCH_FOLDER}
 
-# Test helpers.
+# Test helper functions.
+# Assumes OS where the Ninja executable is named "ninja". This is not true for
+# AL2 for example.
 
 function fail() {
     echo "test failure: $1"
@@ -34,14 +51,14 @@ function aws_lc_build() {
 }
 
 function s2n_tls_build() {
-	cmake s2n -GNinja "-B${S2N_TLS_BUILD_FOLDER}" "-DCMAKE_PREFIX_PATH=${AWS_LC_INSTALL_FOLDER}" "$@"
+	cmake s2n-tls -GNinja "-B${S2N_TLS_BUILD_FOLDER}" "-DCMAKE_PREFIX_PATH=${AWS_LC_INSTALL_FOLDER}" "$@"
 	ninja -C ${S2N_TLS_BUILD_FOLDER}
 	ls -R ${S2N_TLS_BUILD_FOLDER}
 }
 
 function s2n_tls_run_tests() {
 	cd ${S2N_TLS_BUILD_FOLDER}
-	ctest -j 8 --output-on-failure
+	ctest -j ${NUM_CPU_THREADS} --output-on-failure
 	cd ${SCRATCH_FOLDER}
 }
 
@@ -52,10 +69,7 @@ function s2n_tls_prepare_new_build() {
 # Get latest s2n-tls version.
 
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${S2N_TLS_BUILD_FOLDER}
-git clone https://github.com/torben-hansen/s2n.git
-cd s2n
-git checkout fix_cmake_interning_build
-cd ..
+git clone https://github.com/aws/s2n-tls.git
 ls
 
 # s2n-tls's FindLibCrypto.cmake expects to find both the static and shared
@@ -63,7 +77,7 @@ ls
 # (e.g. run_build()) because they make implicit assumptions about e.g. build
 # folders.
 
-aws_lc_build
+aws_lc_build -DBUILD_SHARED_LIBS=0
 aws_lc_build -DBUILD_SHARED_LIBS=1
 
 # Build s2n-tls+aws-lc and run s2n-tls tests. First using static aws-lc
@@ -84,7 +98,7 @@ s2n_tls_run_tests
 s2n_tls_prepare_new_build
 
 s2n_tls_build -DBUILD_SHARED_LIBS=1 -DS2N_INTERN_LIBCRYPTO=1
-# Sanity check that libcrypto does not appear in .dynamic.
+# Sanity check that libcrypto does not appear in the .dynamic ELF section.
 ldd ${S2N_TLS_BUILD_FOLDER}/lib/libs2n.so | grep -q libcrypto && fail "libs2n.so declares a dynamic dependency on libcrypto which should not happen with interned s2n-tls+aws-lc"
 s2n_tls_run_tests
 s2n_tls_prepare_new_build

--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -27,7 +27,7 @@ function aws_lc_build() {
 }
 
 function s2n_tls_build() {
-	cmake s2n-tls -GNinja "-B${S2N_TLS_BUILD_FOLDER}" "-DCMAKE_PREFIX_PATH=${AWS_LC_INSTALL_FOLDER}" "$@"
+	cmake s2n -GNinja "-B${S2N_TLS_BUILD_FOLDER}" "-DCMAKE_PREFIX_PATH=${AWS_LC_INSTALL_FOLDER}" "$@"
 	ninja -C ${S2N_TLS_BUILD_FOLDER}
 	ls -R ${S2N_TLS_BUILD_FOLDER}
 }
@@ -45,7 +45,7 @@ function s2n_tls_prepare_new_build() {
 # Get latest s2n-tls version.
 
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${S2N_TLS_BUILD_FOLDER}
-git clone https://github.com/aws/s2n-tls.git
+git clone https://github.com/torben-hansen/s2n.git
 ls
 
 # s2n-tls's FindLibCrypto.cmake expects to find both the static and shared


### PR DESCRIPTION
### Issues:

CryptoAlg-1088

### Description of changes: 

This PR accomplishes two things:

Firstly, interned `s2n-tls+aws-lc` is a thing now https://github.com/aws/s2n-tls/issues/3262. `s2n-tls` has a complete and comprehensive set of tests. But we ought to have minimal assurance we don't regress making the feedback loop for trivial errors shorter. Hence, we add a few trivial intern tests to the CI.

Secondly, generally re-factors the `s2n-tls` integrations tests to remove code re-use. Also, run `s2n-tls` unit tests for all build flavors, not only the shared flavor.

This PR will affect the running time of the `s2n-tls` integration tests. In the existing test only one execution of the `s2n-tls` unit tests is performed. This PR will execute the unit tests a total of four times and add two extra `s2n-tls` builds. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
