### PR TITLE
Allow the FIPS integrity test to be run on demand

### DIFF
--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -89,3 +89,10 @@ TEST(CryptoTest, FIPSdownstreamPrecompilationFlag) {
 #endif
 }
 #endif // defined(BORINGSSL_FIPS)
+
+#if defined(BORINGSSL_FIPS) && !defined(OPENSSL_ASAN)
+TEST(Crypto, OnDemandIntegrityTest) {
+  BORINGSSL_integrity_test();
+}
+#endif
+

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -59,6 +59,12 @@ OPENSSL_EXPORT int CRYPTO_has_asm(void);
 // success and zero on error.
 OPENSSL_EXPORT int BORINGSSL_self_test(void);
 
+// BORINGSSL_integrity_test triggers the module's integrity test where the code
+// and data of the module is matched against a hash injected at build time. It
+// returns one on success or zero if there's a mismatch. This function only
+// exists if the module was built in FIPS mode without ASAN.
+OPENSSL_EXPORT int BORINGSSL_integrity_test(void);
+
 // CRYPTO_pre_sandbox_init initializes the crypto library, pre-acquiring some
 // unusual resources to aid running in sandboxed environments. It is safe to
 // call this function multiple times and concurrently from multiple threads.


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Allow the FIPS integrity test to be run on demand, as per FIPS 140-3 requirements.

### Call-outs:
The change is basically copied from BoringSSL commit:
https://github.com/awslabs/aws-lc/commit/972ab522382ace61745be58c330a9e3cdfb1bd1b

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
