### PR TITLE
CMAKE_ASM_COMPILER_ID not always set

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT OPENSSL_NO_ASM)
     set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")
 
     # Clang's integerated assembler does not support debug symbols.
-    if (CMAKE_ASM_COMPILER_ID MATCHES "Clang" || CMAKE_ASM_COMPILER MATCHES "clang")
+    if (CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang")
       message(STATUS "Disabling debug symbols for Clang internal assembler")
     else()
       set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,-g")

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -33,8 +33,16 @@ if(NOT OPENSSL_NO_ASM)
     set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")
 
     # Clang's integerated assembler does not support debug symbols.
-    if(NOT CMAKE_ASM_COMPILER_ID MATCHES "Clang")
-      set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,-g")
+    if(CMAKE_ASM_COMPILER_ID)
+      if(NOT CMAKE_ASM_COMPILER_ID MATCHES "Clang")
+        set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,-g")
+      endif()
+    elseif(CMAKE_ASM_COMPILER)
+      if(NOT CMAKE_ASM_COMPILER MATCHES "clang")
+        set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,-g")
+      endif()
+    else()
+        set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,-g")
     endif()
 
     # CMake does not add -isysroot and -arch flags to assembly.

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -33,16 +33,10 @@ if(NOT OPENSSL_NO_ASM)
     set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")
 
     # Clang's integerated assembler does not support debug symbols.
-    if(CMAKE_ASM_COMPILER_ID)
-      if(NOT CMAKE_ASM_COMPILER_ID MATCHES "Clang")
-        set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,-g")
-      endif()
-    elseif(CMAKE_ASM_COMPILER)
-      if(NOT CMAKE_ASM_COMPILER MATCHES "clang")
-        set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,-g")
-      endif()
+    if (CMAKE_ASM_COMPILER_ID MATCHES "Clang" || CMAKE_ASM_COMPILER MATCHES "clang")
+      message(STATUS "Disabling debug symbols for Clang internal assembler")
     else()
-        set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,-g")
+      set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,-g")
     endif()
 
     # CMake does not add -isysroot and -arch flags to assembly.


### PR DESCRIPTION
### Description of changes: 
Clang-7's assembler doesn't support the generation of debug symbols. Our current cmake logic depends on the value of `CMAKE_ASM_COMPILER_ID` to indicate whether Clang's assembler is being used. However, this variable is not always set. When not set, `-Wa,-g` gets added to `CMAKE_ASM_FLAGS` causing the build to fail.

### Call-outs:
If it's unable to determine which assembler is being used, the logic assumes that debug symbols are supported by the assembler.

### Testing:
Successfully completed a debug build using clang-7:
```
cmake . -DBUILD_SHARED_LIBS=TRUE "-DCMAKE_C_COMPILER=clang-7" "-DCMAKE_CXX_COMPILER=clang++-7" "-DCMAKE_ASM_COMPILER=clang-7" "-DFIPS=1" "-DCMAKE_INSTALL_PREFIX=/tmp/fips-build"
```

```
cmake --build . --target ssl --config Debug
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
