### PR TITLE
Fix prefix build

### DIFF
--- a/crypto/fipsmodule/hmac/hmac.c
+++ b/crypto/fipsmodule/hmac/hmac.c
@@ -104,8 +104,6 @@ struct hmac_methods_st {
       sizeof(HASH_CTX) <= sizeof(union md_ctx_union),                         \
       HASH_NAME##_has_overlarge_context_t)
 
-#define MD_TRAMPOLINES(HASH_NAME) MD_TRAMPOLINES_EXPLICIT(HASH_NAME, HASH_NAME)
-
 // The maximum number of HMAC implementations
 #define HMAC_METHOD_MAX 7
 

--- a/crypto/fipsmodule/hmac/hmac.c
+++ b/crypto/fipsmodule/hmac/hmac.c
@@ -81,27 +81,27 @@ struct hmac_methods_st {
 // while the destination functions have specific pointer types for the relevant contexts.
 //
 // This also includes hash-specific static assertions as they can be added.
-#define MD_TRAMPOLINES_EXPLICIT(HASH_NAME, CTX_PREFIX)                        \
+#define MD_TRAMPOLINES_EXPLICIT(HASH_NAME, HASH_CTX, HASH_CBLOCK)             \
   static int AWS_LC_TRAMPOLINE_##HASH_NAME##_Init(void *);                    \
   static int AWS_LC_TRAMPOLINE_##HASH_NAME##_Update(void *, const void *,     \
                                                     size_t);                  \
   static int AWS_LC_TRAMPOLINE_##HASH_NAME##_Final(uint8_t *, void *);        \
   static int AWS_LC_TRAMPOLINE_##HASH_NAME##_Init(void *ctx) {                \
-    return HASH_NAME##_Init((CTX_PREFIX##_CTX *)ctx);                         \
+    return HASH_NAME##_Init((HASH_CTX *)ctx);                                 \
   }                                                                           \
   static int AWS_LC_TRAMPOLINE_##HASH_NAME##_Update(                          \
       void *ctx, const void *key, size_t key_len) {                           \
-    return HASH_NAME##_Update((CTX_PREFIX##_CTX *)ctx, key, key_len);         \
+    return HASH_NAME##_Update((HASH_CTX *)ctx, key, key_len);                 \
   }                                                                           \
   static int AWS_LC_TRAMPOLINE_##HASH_NAME##_Final(uint8_t *out, void *ctx) { \
-    return HASH_NAME##_Final(out, (CTX_PREFIX##_CTX *)ctx);                   \
+    return HASH_NAME##_Final(out, (HASH_CTX *)ctx);                           \
   }                                                                           \
-  OPENSSL_STATIC_ASSERT(CTX_PREFIX##_CBLOCK % 8 == 0,                         \
+  OPENSSL_STATIC_ASSERT(HASH_CBLOCK% 8 == 0,                                  \
                         HASH_NAME##_has_blocksize_not_divisible_by_eight_t)   \
-  OPENSSL_STATIC_ASSERT(CTX_PREFIX##_CBLOCK <= EVP_MAX_MD_BLOCK_SIZE,         \
+  OPENSSL_STATIC_ASSERT(HASH_CBLOCK <= EVP_MAX_MD_BLOCK_SIZE,                 \
                         HASH_NAME##_has_overlarge_blocksize_t)                \
   OPENSSL_STATIC_ASSERT(                                                      \
-      sizeof(CTX_PREFIX##_CTX) <= sizeof(union md_ctx_union),                 \
+      sizeof(HASH_CTX) <= sizeof(union md_ctx_union),                         \
       HASH_NAME##_has_overlarge_context_t)
 
 #define MD_TRAMPOLINES(HASH_NAME) MD_TRAMPOLINES_EXPLICIT(HASH_NAME, HASH_NAME)
@@ -109,13 +109,13 @@ struct hmac_methods_st {
 // The maximum number of HMAC implementations
 #define HMAC_METHOD_MAX 7
 
-MD_TRAMPOLINES(MD5);
-MD_TRAMPOLINES_EXPLICIT(SHA1, SHA);
-MD_TRAMPOLINES_EXPLICIT(SHA224, SHA256);
-MD_TRAMPOLINES(SHA256);
-MD_TRAMPOLINES_EXPLICIT(SHA384, SHA512);
-MD_TRAMPOLINES(SHA512);
-MD_TRAMPOLINES_EXPLICIT(SHA512_256, SHA512);
+MD_TRAMPOLINES_EXPLICIT(MD5, MD5_CTX, MD5_CBLOCK);
+MD_TRAMPOLINES_EXPLICIT(SHA1, SHA_CTX, SHA_CBLOCK);
+MD_TRAMPOLINES_EXPLICIT(SHA224, SHA256_CTX, SHA256_CBLOCK);
+MD_TRAMPOLINES_EXPLICIT(SHA256, SHA256_CTX, SHA256_CBLOCK);
+MD_TRAMPOLINES_EXPLICIT(SHA384, SHA512_CTX, SHA512_CBLOCK);
+MD_TRAMPOLINES_EXPLICIT(SHA512, SHA512_CTX, SHA512_CBLOCK);
+MD_TRAMPOLINES_EXPLICIT(SHA512_256, SHA512_CTX, SHA512_CBLOCK);
 
 struct hmac_method_array_st {
   HmacMethods methods[HMAC_METHOD_MAX];


### PR DESCRIPTION
### Description of changes: 

https://github.com/awslabs/aws-lc/pull/368 broke the prefix build. For example, the symbol list will contain the public symbol `MD5`. But then the object type [expanded here](https://github.com/awslabs/aws-lc/blob/e14e153cda6c0921a10209c78762de37707d48c4/crypto/fipsmodule/hmac/hmac.c#L90) will be
`<prefix>_MD5_CTX`. But the prefixing tool will only match exact, so the [corresponding declaration](https://github.com/awslabs/aws-lc/blob/e14e153cda6c0921a10209c78762de37707d48c4/include/openssl/base.h#L441) is not prefixed. 

The result are undefined identifiers.

### Call-outs:

Need to be more specific and avoid general tokens e.g. `MD5` to avoided them being prefixed. Unfortunately, this involves moving away from the more general `MD_TRAMPOLINES` to using only the explicit version and making it even more explicit.

We need to add the prefix build to the CI...

### Testing:

@justsmth verified that this fixes the prefix build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
