### PR TITLE
Avoid externalizing the s2n-bignum symbols in shared library.

### DIFF
--- a/third_party/s2n-bignum/_internal_s2n_bignum.h
+++ b/third_party/s2n-bignum/_internal_s2n_bignum.h
@@ -1,0 +1,5 @@
+#ifdef __APPLE__
+#define S2N_ASM_HIDDEN(name) .private_extern name
+#else
+#define S2N_ASM_HIDDEN(name) .hidden name
+#endif

--- a/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_add_p384
-        .private_extern bignum_add_p384
+        S2N_ASM_HIDDEN(bignum_add_p384)
 
         .globl _bignum_add_p384
-        .private_extern _bignum_add_p384
+        S2N_ASM_HIDDEN(_bignum_add_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_add_p384
-        .globl  _bignum_add_p384
+        .globl bignum_add_p384
+        .private_extern bignum_add_p384
+
+        .globl _bignum_add_p384
+        .private_extern _bignum_add_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
@@ -36,12 +36,24 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_bigendian_6
-        .globl  _bignum_bigendian_6
-        .globl  bignum_frombebytes_6
-        .globl  _bignum_frombebytes_6
-        .globl  bignum_tobebytes_6
-        .globl  _bignum_tobebytes_6
+        .globl bignum_bigendian_6
+        .private_extern bignum_bigendian_6
+
+        .globl _bignum_bigendian_6
+        .private_extern _bignum_bigendian_6
+
+        .globl bignum_frombebytes_6
+        .private_extern bignum_frombebytes_6
+
+        .globl _bignum_frombebytes_6
+        .private_extern _bignum_frombebytes_6
+
+        .globl bignum_tobebytes_6
+        .private_extern bignum_tobebytes_6
+
+        .globl _bignum_tobebytes_6
+        .private_extern _bignum_tobebytes_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
@@ -35,24 +35,25 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_bigendian_6
-        .private_extern bignum_bigendian_6
+        S2N_ASM_HIDDEN(bignum_bigendian_6)
 
         .globl _bignum_bigendian_6
-        .private_extern _bignum_bigendian_6
+        S2N_ASM_HIDDEN(_bignum_bigendian_6)
 
         .globl bignum_frombebytes_6
-        .private_extern bignum_frombebytes_6
+        S2N_ASM_HIDDEN(bignum_frombebytes_6)
 
         .globl _bignum_frombebytes_6
-        .private_extern _bignum_frombebytes_6
+        S2N_ASM_HIDDEN(_bignum_frombebytes_6)
 
         .globl bignum_tobebytes_6
-        .private_extern bignum_tobebytes_6
+        S2N_ASM_HIDDEN(bignum_tobebytes_6)
 
         .globl _bignum_tobebytes_6
-        .private_extern _bignum_tobebytes_6
+        S2N_ASM_HIDDEN(_bignum_tobebytes_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
@@ -23,18 +23,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p384
-        .private_extern bignum_cmul_p384
+        S2N_ASM_HIDDEN(bignum_cmul_p384)
 
         .globl _bignum_cmul_p384
-        .private_extern _bignum_cmul_p384
+        S2N_ASM_HIDDEN(_bignum_cmul_p384)
 
         .globl bignum_cmul_p384_alt
-        .private_extern bignum_cmul_p384_alt
+        S2N_ASM_HIDDEN(bignum_cmul_p384_alt)
 
         .globl _bignum_cmul_p384_alt
-        .private_extern _bignum_cmul_p384_alt
+        S2N_ASM_HIDDEN(_bignum_cmul_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
@@ -24,10 +24,18 @@
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_cmul_p384
-        .globl  _bignum_cmul_p384
-        .globl  bignum_cmul_p384_alt
-        .globl  _bignum_cmul_p384_alt
+        .globl bignum_cmul_p384
+        .private_extern bignum_cmul_p384
+
+        .globl _bignum_cmul_p384
+        .private_extern _bignum_cmul_p384
+
+        .globl bignum_cmul_p384_alt
+        .private_extern bignum_cmul_p384_alt
+
+        .globl _bignum_cmul_p384_alt
+        .private_extern _bignum_cmul_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
@@ -26,10 +26,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_deamont_p384
-        .globl  _bignum_deamont_p384
-        .globl  bignum_deamont_p384_alt
-        .globl  _bignum_deamont_p384_alt
+        .globl bignum_deamont_p384
+        .private_extern bignum_deamont_p384
+
+        .globl _bignum_deamont_p384
+        .private_extern _bignum_deamont_p384
+
+        .globl bignum_deamont_p384_alt
+        .private_extern bignum_deamont_p384_alt
+
+        .globl _bignum_deamont_p384_alt
+        .private_extern _bignum_deamont_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
@@ -25,18 +25,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_deamont_p384
-        .private_extern bignum_deamont_p384
+        S2N_ASM_HIDDEN(bignum_deamont_p384)
 
         .globl _bignum_deamont_p384
-        .private_extern _bignum_deamont_p384
+        S2N_ASM_HIDDEN(_bignum_deamont_p384)
 
         .globl bignum_deamont_p384_alt
-        .private_extern bignum_deamont_p384_alt
+        S2N_ASM_HIDDEN(bignum_deamont_p384_alt)
 
         .globl _bignum_deamont_p384_alt
-        .private_extern _bignum_deamont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_deamont_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
@@ -25,18 +25,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_demont_p384
-        .private_extern bignum_demont_p384
+        S2N_ASM_HIDDEN(bignum_demont_p384)
 
         .globl _bignum_demont_p384
-        .private_extern _bignum_demont_p384
+        S2N_ASM_HIDDEN(_bignum_demont_p384)
 
         .globl bignum_demont_p384_alt
-        .private_extern bignum_demont_p384_alt
+        S2N_ASM_HIDDEN(bignum_demont_p384_alt)
 
         .globl _bignum_demont_p384_alt
-        .private_extern _bignum_demont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_demont_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
@@ -26,10 +26,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_demont_p384
-        .globl  _bignum_demont_p384
-        .globl  bignum_demont_p384_alt
-        .globl  _bignum_demont_p384_alt
+        .globl bignum_demont_p384
+        .private_extern bignum_demont_p384
+
+        .globl _bignum_demont_p384
+        .private_extern _bignum_demont_p384
+
+        .globl bignum_demont_p384_alt
+        .private_extern bignum_demont_p384_alt
+
+        .globl _bignum_demont_p384_alt
+        .private_extern _bignum_demont_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_double_p384
-        .globl  _bignum_double_p384
+        .globl bignum_double_p384
+        .private_extern bignum_double_p384
+
+        .globl _bignum_double_p384
+        .private_extern _bignum_double_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_double_p384
-        .private_extern bignum_double_p384
+        S2N_ASM_HIDDEN(bignum_double_p384)
 
         .globl _bignum_double_p384
-        .private_extern _bignum_double_p384
+        S2N_ASM_HIDDEN(_bignum_double_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_half_p384
-        .private_extern bignum_half_p384
+        S2N_ASM_HIDDEN(bignum_half_p384)
 
         .globl _bignum_half_p384
-        .private_extern _bignum_half_p384
+        S2N_ASM_HIDDEN(_bignum_half_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_half_p384
-        .globl  _bignum_half_p384
+        .globl bignum_half_p384
+        .private_extern bignum_half_p384
+
+        .globl _bignum_half_p384
+        .private_extern _bignum_half_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
@@ -36,12 +36,24 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_littleendian_6
-        .globl  _bignum_littleendian_6
-        .globl  bignum_fromlebytes_6
-        .globl  _bignum_fromlebytes_6
-        .globl  bignum_tolebytes_6
-        .globl  _bignum_tolebytes_6
+        .globl bignum_littleendian_6
+        .private_extern bignum_littleendian_6
+
+        .globl _bignum_littleendian_6
+        .private_extern _bignum_littleendian_6
+
+        .globl bignum_fromlebytes_6
+        .private_extern bignum_fromlebytes_6
+
+        .globl _bignum_fromlebytes_6
+        .private_extern _bignum_fromlebytes_6
+
+        .globl bignum_tolebytes_6
+        .private_extern bignum_tolebytes_6
+
+        .globl _bignum_tolebytes_6
+        .private_extern _bignum_tolebytes_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
@@ -35,24 +35,25 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_littleendian_6
-        .private_extern bignum_littleendian_6
+        S2N_ASM_HIDDEN(bignum_littleendian_6)
 
         .globl _bignum_littleendian_6
-        .private_extern _bignum_littleendian_6
+        S2N_ASM_HIDDEN(_bignum_littleendian_6)
 
         .globl bignum_fromlebytes_6
-        .private_extern bignum_fromlebytes_6
+        S2N_ASM_HIDDEN(bignum_fromlebytes_6)
 
         .globl _bignum_fromlebytes_6
-        .private_extern _bignum_fromlebytes_6
+        S2N_ASM_HIDDEN(_bignum_fromlebytes_6)
 
         .globl bignum_tolebytes_6
-        .private_extern bignum_tolebytes_6
+        S2N_ASM_HIDDEN(bignum_tolebytes_6)
 
         .globl _bignum_tolebytes_6
-        .private_extern _bignum_tolebytes_6
+        S2N_ASM_HIDDEN(_bignum_tolebytes_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
@@ -24,18 +24,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n384
-        .private_extern bignum_mod_n384
+        S2N_ASM_HIDDEN(bignum_mod_n384)
 
         .globl _bignum_mod_n384
-        .private_extern _bignum_mod_n384
+        S2N_ASM_HIDDEN(_bignum_mod_n384)
 
         .globl bignum_mod_n384_alt
-        .private_extern bignum_mod_n384_alt
+        S2N_ASM_HIDDEN(bignum_mod_n384_alt)
 
         .globl _bignum_mod_n384_alt
-        .private_extern _bignum_mod_n384_alt
+        S2N_ASM_HIDDEN(_bignum_mod_n384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
@@ -25,10 +25,18 @@
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_n384
-        .globl  _bignum_mod_n384
-        .globl  bignum_mod_n384_alt
-        .globl  _bignum_mod_n384_alt
+        .globl bignum_mod_n384
+        .private_extern bignum_mod_n384
+
+        .globl _bignum_mod_n384
+        .private_extern _bignum_mod_n384
+
+        .globl bignum_mod_n384_alt
+        .private_extern bignum_mod_n384_alt
+
+        .globl _bignum_mod_n384_alt
+        .private_extern _bignum_mod_n384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
@@ -25,8 +25,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_n384_6
-        .globl  _bignum_mod_n384_6
+        .globl bignum_mod_n384_6
+        .private_extern bignum_mod_n384_6
+
+        .globl _bignum_mod_n384_6
+        .private_extern _bignum_mod_n384_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
@@ -24,12 +24,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n384_6
-        .private_extern bignum_mod_n384_6
+        S2N_ASM_HIDDEN(bignum_mod_n384_6)
 
         .globl _bignum_mod_n384_6
-        .private_extern _bignum_mod_n384_6
+        S2N_ASM_HIDDEN(_bignum_mod_n384_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
@@ -23,10 +23,18 @@
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_p384
-        .globl  _bignum_mod_p384
-        .globl  bignum_mod_p384_alt
-        .globl  _bignum_mod_p384_alt
+        .globl bignum_mod_p384
+        .private_extern bignum_mod_p384
+
+        .globl _bignum_mod_p384
+        .private_extern _bignum_mod_p384
+
+        .globl bignum_mod_p384_alt
+        .private_extern bignum_mod_p384_alt
+
+        .globl _bignum_mod_p384_alt
+        .private_extern _bignum_mod_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
@@ -22,18 +22,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p384
-        .private_extern bignum_mod_p384
+        S2N_ASM_HIDDEN(bignum_mod_p384)
 
         .globl _bignum_mod_p384
-        .private_extern _bignum_mod_p384
+        S2N_ASM_HIDDEN(_bignum_mod_p384)
 
         .globl bignum_mod_p384_alt
-        .private_extern bignum_mod_p384_alt
+        S2N_ASM_HIDDEN(bignum_mod_p384_alt)
 
         .globl _bignum_mod_p384_alt
-        .private_extern _bignum_mod_p384_alt
+        S2N_ASM_HIDDEN(_bignum_mod_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p384_6
-        .private_extern bignum_mod_p384_6
+        S2N_ASM_HIDDEN(bignum_mod_p384_6)
 
         .globl _bignum_mod_p384_6
-        .private_extern _bignum_mod_p384_6
+        S2N_ASM_HIDDEN(_bignum_mod_p384_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_p384_6
-        .globl  _bignum_mod_p384_6
+        .globl bignum_mod_p384_6
+        .private_extern bignum_mod_p384_6
+
+        .globl _bignum_mod_p384_6
+        .private_extern _bignum_mod_p384_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
@@ -26,12 +26,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p384
-        .private_extern bignum_montmul_p384
+        S2N_ASM_HIDDEN(bignum_montmul_p384)
 
         .globl _bignum_montmul_p384
-        .private_extern _bignum_montmul_p384
+        S2N_ASM_HIDDEN(_bignum_montmul_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
@@ -27,8 +27,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montmul_p384
-        .globl  _bignum_montmul_p384
+        .globl bignum_montmul_p384
+        .private_extern bignum_montmul_p384
+
+        .globl _bignum_montmul_p384
+        .private_extern _bignum_montmul_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
@@ -26,12 +26,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p384_alt
-        .private_extern bignum_montmul_p384_alt
+        S2N_ASM_HIDDEN(bignum_montmul_p384_alt)
 
         .globl _bignum_montmul_p384_alt
-        .private_extern _bignum_montmul_p384_alt
+        S2N_ASM_HIDDEN(_bignum_montmul_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
@@ -27,8 +27,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montmul_p384_alt
-        .globl  _bignum_montmul_p384_alt
+        .globl bignum_montmul_p384_alt
+        .private_extern bignum_montmul_p384_alt
+
+        .globl _bignum_montmul_p384_alt
+        .private_extern _bignum_montmul_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
@@ -25,12 +25,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p384
-        .private_extern bignum_montsqr_p384
+        S2N_ASM_HIDDEN(bignum_montsqr_p384)
 
         .globl _bignum_montsqr_p384
-        .private_extern _bignum_montsqr_p384
+        S2N_ASM_HIDDEN(_bignum_montsqr_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
@@ -26,8 +26,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montsqr_p384
-        .globl  _bignum_montsqr_p384
+        .globl bignum_montsqr_p384
+        .private_extern bignum_montsqr_p384
+
+        .globl _bignum_montsqr_p384
+        .private_extern _bignum_montsqr_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
@@ -25,12 +25,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p384_alt
-        .private_extern bignum_montsqr_p384_alt
+        S2N_ASM_HIDDEN(bignum_montsqr_p384_alt)
 
         .globl _bignum_montsqr_p384_alt
-        .private_extern _bignum_montsqr_p384_alt
+        S2N_ASM_HIDDEN(_bignum_montsqr_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
@@ -26,8 +26,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montsqr_p384_alt
-        .globl  _bignum_montsqr_p384_alt
+        .globl bignum_montsqr_p384_alt
+        .private_extern bignum_montsqr_p384_alt
+
+        .globl _bignum_montsqr_p384_alt
+        .private_extern _bignum_montsqr_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
@@ -26,8 +26,12 @@
 // Standard ARM ABI: X0 = p, X1 = z, X2 = x, X3 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mux_6
-        .globl  _bignum_mux_6
+        .globl bignum_mux_6
+        .private_extern bignum_mux_6
+
+        .globl _bignum_mux_6
+        .private_extern _bignum_mux_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
@@ -25,12 +25,13 @@
 //
 // Standard ARM ABI: X0 = p, X1 = z, X2 = x, X3 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mux_6
-        .private_extern bignum_mux_6
+        S2N_ASM_HIDDEN(bignum_mux_6)
 
         .globl _bignum_mux_6
-        .private_extern _bignum_mux_6
+        S2N_ASM_HIDDEN(_bignum_mux_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
@@ -22,8 +22,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_neg_p384
-        .globl  _bignum_neg_p384
+        .globl bignum_neg_p384
+        .private_extern bignum_neg_p384
+
+        .globl _bignum_neg_p384
+        .private_extern _bignum_neg_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
@@ -21,12 +21,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_neg_p384
-        .private_extern bignum_neg_p384
+        S2N_ASM_HIDDEN(bignum_neg_p384)
 
         .globl _bignum_neg_p384
-        .private_extern _bignum_neg_p384
+        S2N_ASM_HIDDEN(_bignum_neg_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
@@ -21,12 +21,13 @@
 //
 // Standard ARM ABI: X0 = x, returns X0
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_nonzero_6
-        .private_extern bignum_nonzero_6
+        S2N_ASM_HIDDEN(bignum_nonzero_6)
 
         .globl _bignum_nonzero_6
-        .private_extern _bignum_nonzero_6
+        S2N_ASM_HIDDEN(_bignum_nonzero_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
@@ -22,8 +22,12 @@
 // Standard ARM ABI: X0 = x, returns X0
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_nonzero_6
-        .globl  _bignum_nonzero_6
+        .globl bignum_nonzero_6
+        .private_extern bignum_nonzero_6
+
+        .globl _bignum_nonzero_6
+        .private_extern _bignum_nonzero_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
@@ -24,8 +24,12 @@
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_optneg_p384
-        .globl  _bignum_optneg_p384
+        .globl bignum_optneg_p384
+        .private_extern bignum_optneg_p384
+
+        .globl _bignum_optneg_p384
+        .private_extern _bignum_optneg_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
@@ -23,12 +23,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_optneg_p384
-        .private_extern bignum_optneg_p384
+        S2N_ASM_HIDDEN(bignum_optneg_p384)
 
         .globl _bignum_optneg_p384
-        .private_extern _bignum_optneg_p384
+        S2N_ASM_HIDDEN(_bignum_optneg_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_sub_p384
-        .globl  _bignum_sub_p384
+        .globl bignum_sub_p384
+        .private_extern bignum_sub_p384
+
+        .globl _bignum_sub_p384
+        .private_extern _bignum_sub_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sub_p384
-        .private_extern bignum_sub_p384
+        S2N_ASM_HIDDEN(bignum_sub_p384)
 
         .globl _bignum_sub_p384
-        .private_extern _bignum_sub_p384
+        S2N_ASM_HIDDEN(_bignum_sub_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
@@ -23,10 +23,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_tomont_p384
-        .globl  _bignum_tomont_p384
-        .globl  bignum_tomont_p384_alt
-        .globl  _bignum_tomont_p384_alt
+        .globl bignum_tomont_p384
+        .private_extern bignum_tomont_p384
+
+        .globl _bignum_tomont_p384
+        .private_extern _bignum_tomont_p384
+
+        .globl bignum_tomont_p384_alt
+        .private_extern bignum_tomont_p384_alt
+
+        .globl _bignum_tomont_p384_alt
+        .private_extern _bignum_tomont_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
@@ -22,18 +22,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tomont_p384
-        .private_extern bignum_tomont_p384
+        S2N_ASM_HIDDEN(bignum_tomont_p384)
 
         .globl _bignum_tomont_p384
-        .private_extern _bignum_tomont_p384
+        S2N_ASM_HIDDEN(_bignum_tomont_p384)
 
         .globl bignum_tomont_p384_alt
-        .private_extern bignum_tomont_p384_alt
+        S2N_ASM_HIDDEN(bignum_tomont_p384_alt)
 
         .globl _bignum_tomont_p384_alt
-        .private_extern _bignum_tomont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_tomont_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
@@ -26,10 +26,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_triple_p384
-        .globl  _bignum_triple_p384
-        .globl  bignum_triple_p384_alt
-        .globl  _bignum_triple_p384_alt
+        .globl bignum_triple_p384
+        .private_extern bignum_triple_p384
+
+        .globl _bignum_triple_p384
+        .private_extern _bignum_triple_p384
+
+        .globl bignum_triple_p384_alt
+        .private_extern bignum_triple_p384_alt
+
+        .globl _bignum_triple_p384_alt
+        .private_extern _bignum_triple_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
@@ -25,18 +25,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p384
-        .private_extern bignum_triple_p384
+        S2N_ASM_HIDDEN(bignum_triple_p384)
 
         .globl _bignum_triple_p384
-        .private_extern _bignum_triple_p384
+        S2N_ASM_HIDDEN(_bignum_triple_p384)
 
         .globl bignum_triple_p384_alt
-        .private_extern bignum_triple_p384_alt
+        S2N_ASM_HIDDEN(bignum_triple_p384_alt)
 
         .globl _bignum_triple_p384_alt
-        .private_extern _bignum_triple_p384_alt
+        S2N_ASM_HIDDEN(_bignum_triple_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_add_p521
-        .private_extern bignum_add_p521
+        S2N_ASM_HIDDEN(bignum_add_p521)
 
         .globl _bignum_add_p521
-        .private_extern _bignum_add_p521
+        S2N_ASM_HIDDEN(_bignum_add_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_add_p521
-        .globl  _bignum_add_p521
+        .globl bignum_add_p521
+        .private_extern bignum_add_p521
+
+        .globl _bignum_add_p521
+        .private_extern _bignum_add_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
@@ -24,10 +24,18 @@
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_cmul_p521
-        .globl  _bignum_cmul_p521
-        .globl  bignum_cmul_p521_alt
-        .globl  _bignum_cmul_p521_alt
+        .globl bignum_cmul_p521
+        .private_extern bignum_cmul_p521
+
+        .globl _bignum_cmul_p521
+        .private_extern _bignum_cmul_p521
+
+        .globl bignum_cmul_p521_alt
+        .private_extern bignum_cmul_p521_alt
+
+        .globl _bignum_cmul_p521_alt
+        .private_extern _bignum_cmul_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
@@ -23,18 +23,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p521
-        .private_extern bignum_cmul_p521
+        S2N_ASM_HIDDEN(bignum_cmul_p521)
 
         .globl _bignum_cmul_p521
-        .private_extern _bignum_cmul_p521
+        S2N_ASM_HIDDEN(_bignum_cmul_p521)
 
         .globl bignum_cmul_p521_alt
-        .private_extern bignum_cmul_p521_alt
+        S2N_ASM_HIDDEN(bignum_cmul_p521_alt)
 
         .globl _bignum_cmul_p521_alt
-        .private_extern _bignum_cmul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_cmul_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
@@ -25,12 +25,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_deamont_p521
-        .private_extern bignum_deamont_p521
+        S2N_ASM_HIDDEN(bignum_deamont_p521)
 
         .globl _bignum_deamont_p521
-        .private_extern _bignum_deamont_p521
+        S2N_ASM_HIDDEN(_bignum_deamont_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
@@ -26,8 +26,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_deamont_p521
-        .globl  _bignum_deamont_p521
+        .globl bignum_deamont_p521
+        .private_extern bignum_deamont_p521
+
+        .globl _bignum_deamont_p521
+        .private_extern _bignum_deamont_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
@@ -26,8 +26,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_demont_p521
-        .globl  _bignum_demont_p521
+        .globl bignum_demont_p521
+        .private_extern bignum_demont_p521
+
+        .globl _bignum_demont_p521
+        .private_extern _bignum_demont_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
@@ -25,12 +25,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_demont_p521
-        .private_extern bignum_demont_p521
+        S2N_ASM_HIDDEN(bignum_demont_p521)
 
         .globl _bignum_demont_p521
-        .private_extern _bignum_demont_p521
+        S2N_ASM_HIDDEN(_bignum_demont_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_double_p521
-        .globl  _bignum_double_p521
+        .globl bignum_double_p521
+        .private_extern bignum_double_p521
+
+        .globl _bignum_double_p521
+        .private_extern _bignum_double_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_double_p521
-        .private_extern bignum_double_p521
+        S2N_ASM_HIDDEN(bignum_double_p521)
 
         .globl _bignum_double_p521
-        .private_extern _bignum_double_p521
+        S2N_ASM_HIDDEN(_bignum_double_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
@@ -25,8 +25,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_fromlebytes_p521
-        .globl  _bignum_fromlebytes_p521
+        .globl bignum_fromlebytes_p521
+        .private_extern bignum_fromlebytes_p521
+
+        .globl _bignum_fromlebytes_p521
+        .private_extern _bignum_fromlebytes_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
@@ -24,12 +24,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_fromlebytes_p521
-        .private_extern bignum_fromlebytes_p521
+        S2N_ASM_HIDDEN(bignum_fromlebytes_p521)
 
         .globl _bignum_fromlebytes_p521
-        .private_extern _bignum_fromlebytes_p521
+        S2N_ASM_HIDDEN(_bignum_fromlebytes_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_half_p521
-        .private_extern bignum_half_p521
+        S2N_ASM_HIDDEN(bignum_half_p521)
 
         .globl _bignum_half_p521
-        .private_extern _bignum_half_p521
+        S2N_ASM_HIDDEN(_bignum_half_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_half_p521
-        .globl  _bignum_half_p521
+        .globl bignum_half_p521
+        .private_extern bignum_half_p521
+
+        .globl _bignum_half_p521
+        .private_extern _bignum_half_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
@@ -24,18 +24,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n521_9
-        .private_extern bignum_mod_n521_9
+        S2N_ASM_HIDDEN(bignum_mod_n521_9)
 
         .globl _bignum_mod_n521_9
-        .private_extern _bignum_mod_n521_9
+        S2N_ASM_HIDDEN(_bignum_mod_n521_9)
 
         .globl bignum_mod_n521_9_alt
-        .private_extern bignum_mod_n521_9_alt
+        S2N_ASM_HIDDEN(bignum_mod_n521_9_alt)
 
         .globl _bignum_mod_n521_9_alt
-        .private_extern _bignum_mod_n521_9_alt
+        S2N_ASM_HIDDEN(_bignum_mod_n521_9_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
@@ -25,10 +25,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_n521_9
-        .globl  _bignum_mod_n521_9
-        .globl  bignum_mod_n521_9_alt
-        .globl  _bignum_mod_n521_9_alt
+        .globl bignum_mod_n521_9
+        .private_extern bignum_mod_n521_9
+
+        .globl _bignum_mod_n521_9
+        .private_extern _bignum_mod_n521_9
+
+        .globl bignum_mod_n521_9_alt
+        .private_extern bignum_mod_n521_9_alt
+
+        .globl _bignum_mod_n521_9_alt
+        .private_extern _bignum_mod_n521_9_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p521_9
-        .private_extern bignum_mod_p521_9
+        S2N_ASM_HIDDEN(bignum_mod_p521_9)
 
         .globl _bignum_mod_p521_9
-        .private_extern _bignum_mod_p521_9
+        S2N_ASM_HIDDEN(_bignum_mod_p521_9)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_p521_9
-        .globl  _bignum_mod_p521_9
+        .globl bignum_mod_p521_9
+        .private_extern bignum_mod_p521_9
+
+        .globl _bignum_mod_p521_9
+        .private_extern _bignum_mod_p521_9
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
@@ -28,8 +28,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montmul_p521
-        .globl  _bignum_montmul_p521
+        .globl bignum_montmul_p521
+        .private_extern bignum_montmul_p521
+
+        .globl _bignum_montmul_p521
+        .private_extern _bignum_montmul_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
@@ -27,12 +27,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p521
-        .private_extern bignum_montmul_p521
+        S2N_ASM_HIDDEN(bignum_montmul_p521)
 
         .globl _bignum_montmul_p521
-        .private_extern _bignum_montmul_p521
+        S2N_ASM_HIDDEN(_bignum_montmul_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
@@ -28,8 +28,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montmul_p521_alt
-        .globl  _bignum_montmul_p521_alt
+        .globl bignum_montmul_p521_alt
+        .private_extern bignum_montmul_p521_alt
+
+        .globl _bignum_montmul_p521_alt
+        .private_extern _bignum_montmul_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
@@ -27,12 +27,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p521_alt
-        .private_extern bignum_montmul_p521_alt
+        S2N_ASM_HIDDEN(bignum_montmul_p521_alt)
 
         .globl _bignum_montmul_p521_alt
-        .private_extern _bignum_montmul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_montmul_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
@@ -28,8 +28,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montsqr_p521
-        .globl  _bignum_montsqr_p521
+        .globl bignum_montsqr_p521
+        .private_extern bignum_montsqr_p521
+
+        .globl _bignum_montsqr_p521
+        .private_extern _bignum_montsqr_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
@@ -27,12 +27,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p521
-        .private_extern bignum_montsqr_p521
+        S2N_ASM_HIDDEN(bignum_montsqr_p521)
 
         .globl _bignum_montsqr_p521
-        .private_extern _bignum_montsqr_p521
+        S2N_ASM_HIDDEN(_bignum_montsqr_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
@@ -28,8 +28,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montsqr_p521_alt
-        .globl  _bignum_montsqr_p521_alt
+        .globl bignum_montsqr_p521_alt
+        .private_extern bignum_montsqr_p521_alt
+
+        .globl _bignum_montsqr_p521_alt
+        .private_extern _bignum_montsqr_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
@@ -27,12 +27,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p521_alt
-        .private_extern bignum_montsqr_p521_alt
+        S2N_ASM_HIDDEN(bignum_montsqr_p521_alt)
 
         .globl _bignum_montsqr_p521_alt
-        .private_extern _bignum_montsqr_p521_alt
+        S2N_ASM_HIDDEN(_bignum_montsqr_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mul_p521
-        .private_extern bignum_mul_p521
+        S2N_ASM_HIDDEN(bignum_mul_p521)
 
         .globl _bignum_mul_p521
-        .private_extern _bignum_mul_p521
+        S2N_ASM_HIDDEN(_bignum_mul_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mul_p521
-        .globl  _bignum_mul_p521
+        .globl bignum_mul_p521
+        .private_extern bignum_mul_p521
+
+        .globl _bignum_mul_p521
+        .private_extern _bignum_mul_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mul_p521_alt
-        .globl  _bignum_mul_p521_alt
+        .globl bignum_mul_p521_alt
+        .private_extern bignum_mul_p521_alt
+
+        .globl _bignum_mul_p521_alt
+        .private_extern _bignum_mul_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mul_p521_alt
-        .private_extern bignum_mul_p521_alt
+        S2N_ASM_HIDDEN(bignum_mul_p521_alt)
 
         .globl _bignum_mul_p521_alt
-        .private_extern _bignum_mul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_mul_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
@@ -21,12 +21,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_neg_p521
-        .private_extern bignum_neg_p521
+        S2N_ASM_HIDDEN(bignum_neg_p521)
 
         .globl _bignum_neg_p521
-        .private_extern _bignum_neg_p521
+        S2N_ASM_HIDDEN(_bignum_neg_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
@@ -22,8 +22,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_neg_p521
-        .globl  _bignum_neg_p521
+        .globl bignum_neg_p521
+        .private_extern bignum_neg_p521
+
+        .globl _bignum_neg_p521
+        .private_extern _bignum_neg_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
@@ -23,12 +23,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_optneg_p521
-        .private_extern bignum_optneg_p521
+        S2N_ASM_HIDDEN(bignum_optneg_p521)
 
         .globl _bignum_optneg_p521
-        .private_extern _bignum_optneg_p521
+        S2N_ASM_HIDDEN(_bignum_optneg_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
@@ -24,8 +24,12 @@
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_optneg_p521
-        .globl  _bignum_optneg_p521
+        .globl bignum_optneg_p521
+        .private_extern bignum_optneg_p521
+
+        .globl _bignum_optneg_p521
+        .private_extern _bignum_optneg_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
@@ -21,12 +21,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sqr_p521
-        .private_extern bignum_sqr_p521
+        S2N_ASM_HIDDEN(bignum_sqr_p521)
 
         .globl _bignum_sqr_p521
-        .private_extern _bignum_sqr_p521
+        S2N_ASM_HIDDEN(_bignum_sqr_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
@@ -22,8 +22,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_sqr_p521
-        .globl  _bignum_sqr_p521
+        .globl bignum_sqr_p521
+        .private_extern bignum_sqr_p521
+
+        .globl _bignum_sqr_p521
+        .private_extern _bignum_sqr_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
@@ -22,8 +22,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_sqr_p521_alt
-        .globl  _bignum_sqr_p521_alt
+        .globl bignum_sqr_p521_alt
+        .private_extern bignum_sqr_p521_alt
+
+        .globl _bignum_sqr_p521_alt
+        .private_extern _bignum_sqr_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
@@ -21,12 +21,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sqr_p521_alt
-        .private_extern bignum_sqr_p521_alt
+        S2N_ASM_HIDDEN(bignum_sqr_p521_alt)
 
         .globl _bignum_sqr_p521_alt
-        .private_extern _bignum_sqr_p521_alt
+        S2N_ASM_HIDDEN(_bignum_sqr_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_sub_p521
-        .globl  _bignum_sub_p521
+        .globl bignum_sub_p521
+        .private_extern bignum_sub_p521
+
+        .globl _bignum_sub_p521
+        .private_extern _bignum_sub_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sub_p521
-        .private_extern bignum_sub_p521
+        S2N_ASM_HIDDEN(bignum_sub_p521)
 
         .globl _bignum_sub_p521
-        .private_extern _bignum_sub_p521
+        S2N_ASM_HIDDEN(_bignum_sub_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
@@ -24,12 +24,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tolebytes_p521
-        .private_extern bignum_tolebytes_p521
+        S2N_ASM_HIDDEN(bignum_tolebytes_p521)
 
         .globl _bignum_tolebytes_p521
-        .private_extern _bignum_tolebytes_p521
+        S2N_ASM_HIDDEN(_bignum_tolebytes_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
@@ -25,8 +25,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_tolebytes_p521
-        .globl  _bignum_tolebytes_p521
+        .globl bignum_tolebytes_p521
+        .private_extern bignum_tolebytes_p521
+
+        .globl _bignum_tolebytes_p521
+        .private_extern _bignum_tolebytes_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tomont_p521
-        .private_extern bignum_tomont_p521
+        S2N_ASM_HIDDEN(bignum_tomont_p521)
 
         .globl _bignum_tomont_p521
-        .private_extern _bignum_tomont_p521
+        S2N_ASM_HIDDEN(_bignum_tomont_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_tomont_p521
-        .globl  _bignum_tomont_p521
+        .globl bignum_tomont_p521
+        .private_extern bignum_tomont_p521
+
+        .globl _bignum_tomont_p521
+        .private_extern _bignum_tomont_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
@@ -23,10 +23,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_triple_p521
-        .globl  _bignum_triple_p521
-        .globl  bignum_triple_p521_alt
-        .globl  _bignum_triple_p521_alt
+        .globl bignum_triple_p521
+        .private_extern bignum_triple_p521
+
+        .globl _bignum_triple_p521
+        .private_extern _bignum_triple_p521
+
+        .globl bignum_triple_p521_alt
+        .private_extern bignum_triple_p521_alt
+
+        .globl _bignum_triple_p521_alt
+        .private_extern _bignum_triple_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
@@ -22,18 +22,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p521
-        .private_extern bignum_triple_p521
+        S2N_ASM_HIDDEN(bignum_triple_p521)
 
         .globl _bignum_triple_p521
-        .private_extern _bignum_triple_p521
+        S2N_ASM_HIDDEN(_bignum_triple_p521)
 
         .globl bignum_triple_p521_alt
-        .private_extern bignum_triple_p521_alt
+        S2N_ASM_HIDDEN(bignum_triple_p521_alt)
 
         .globl _bignum_triple_p521_alt
-        .private_extern _bignum_triple_p521_alt
+        S2N_ASM_HIDDEN(_bignum_triple_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
@@ -22,16 +22,16 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_add_p384
-        .private_extern bignum_add_p384
+        S2N_ASM_HIDDEN(bignum_add_p384)
 
-        .private_extern  bignum_add_p384
+        S2N_ASM_HIDDEN(bignum_add_p384)
         .globl _bignum_add_p384
-        .private_extern _bignum_add_p384
+        S2N_ASM_HIDDEN(_bignum_add_p384)
 
-        .private_extern  _bignum_add_p384
+        S2N_ASM_HIDDEN(_bignum_add_p384)
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
@@ -24,8 +24,14 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_add_p384
-        .globl  _bignum_add_p384
+        .globl bignum_add_p384
+        .private_extern bignum_add_p384
+
+        .private_extern  bignum_add_p384
+        .globl _bignum_add_p384
+        .private_extern _bignum_add_p384
+
+        .private_extern  _bignum_add_p384
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
@@ -36,12 +36,24 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_bigendian_6
-        .globl  _bignum_bigendian_6
-        .globl  bignum_frombebytes_6
-        .globl  _bignum_frombebytes_6
-        .globl  bignum_tobebytes_6
-        .globl  _bignum_tobebytes_6
+        .globl bignum_bigendian_6
+        .private_extern bignum_bigendian_6
+
+        .globl _bignum_bigendian_6
+        .private_extern _bignum_bigendian_6
+
+        .globl bignum_frombebytes_6
+        .private_extern bignum_frombebytes_6
+
+        .globl _bignum_frombebytes_6
+        .private_extern _bignum_frombebytes_6
+
+        .globl bignum_tobebytes_6
+        .private_extern bignum_tobebytes_6
+
+        .globl _bignum_tobebytes_6
+        .private_extern _bignum_tobebytes_6
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
@@ -34,25 +34,25 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_bigendian_6
-        .private_extern bignum_bigendian_6
+        S2N_ASM_HIDDEN(bignum_bigendian_6)
 
         .globl _bignum_bigendian_6
-        .private_extern _bignum_bigendian_6
+        S2N_ASM_HIDDEN(_bignum_bigendian_6)
 
         .globl bignum_frombebytes_6
-        .private_extern bignum_frombebytes_6
+        S2N_ASM_HIDDEN(bignum_frombebytes_6)
 
         .globl _bignum_frombebytes_6
-        .private_extern _bignum_frombebytes_6
+        S2N_ASM_HIDDEN(_bignum_frombebytes_6)
 
         .globl bignum_tobebytes_6
-        .private_extern bignum_tobebytes_6
+        S2N_ASM_HIDDEN(bignum_tobebytes_6)
 
         .globl _bignum_tobebytes_6
-        .private_extern _bignum_tobebytes_6
+        S2N_ASM_HIDDEN(_bignum_tobebytes_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_cmul_p384
-        .globl  _bignum_cmul_p384
+        .globl bignum_cmul_p384
+        .private_extern bignum_cmul_p384
+
+        .globl _bignum_cmul_p384
+        .private_extern _bignum_cmul_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p384
-        .private_extern bignum_cmul_p384
+        S2N_ASM_HIDDEN(bignum_cmul_p384)
 
         .globl _bignum_cmul_p384
-        .private_extern _bignum_cmul_p384
+        S2N_ASM_HIDDEN(_bignum_cmul_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p384_alt
-        .private_extern bignum_cmul_p384_alt
+        S2N_ASM_HIDDEN(bignum_cmul_p384_alt)
 
         .globl _bignum_cmul_p384_alt
-        .private_extern _bignum_cmul_p384_alt
+        S2N_ASM_HIDDEN(_bignum_cmul_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_cmul_p384_alt
-        .globl  _bignum_cmul_p384_alt
+        .globl bignum_cmul_p384_alt
+        .private_extern bignum_cmul_p384_alt
+
+        .globl _bignum_cmul_p384_alt
+        .private_extern _bignum_cmul_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_deamont_p384
-        .private_extern bignum_deamont_p384
+        S2N_ASM_HIDDEN(bignum_deamont_p384)
 
         .globl _bignum_deamont_p384
-        .private_extern _bignum_deamont_p384
+        S2N_ASM_HIDDEN(_bignum_deamont_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_deamont_p384
-        .globl  _bignum_deamont_p384
+        .globl bignum_deamont_p384
+        .private_extern bignum_deamont_p384
+
+        .globl _bignum_deamont_p384
+        .private_extern _bignum_deamont_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_deamont_p384_alt
-        .private_extern bignum_deamont_p384_alt
+        S2N_ASM_HIDDEN(bignum_deamont_p384_alt)
 
         .globl _bignum_deamont_p384_alt
-        .private_extern _bignum_deamont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_deamont_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_deamont_p384_alt
-        .globl  _bignum_deamont_p384_alt
+        .globl bignum_deamont_p384_alt
+        .private_extern bignum_deamont_p384_alt
+
+        .globl _bignum_deamont_p384_alt
+        .private_extern _bignum_deamont_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_demont_p384
-        .private_extern bignum_demont_p384
+        S2N_ASM_HIDDEN(bignum_demont_p384)
 
         .globl _bignum_demont_p384
-        .private_extern _bignum_demont_p384
+        S2N_ASM_HIDDEN(_bignum_demont_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_demont_p384
-        .globl  _bignum_demont_p384
+        .globl bignum_demont_p384
+        .private_extern bignum_demont_p384
+
+        .globl _bignum_demont_p384
+        .private_extern _bignum_demont_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_demont_p384_alt
-        .globl  _bignum_demont_p384_alt
+        .globl bignum_demont_p384_alt
+        .private_extern bignum_demont_p384_alt
+
+        .globl _bignum_demont_p384_alt
+        .private_extern _bignum_demont_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_demont_p384_alt
-        .private_extern bignum_demont_p384_alt
+        S2N_ASM_HIDDEN(bignum_demont_p384_alt)
 
         .globl _bignum_demont_p384_alt
-        .private_extern _bignum_demont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_demont_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_double_p384
-        .private_extern bignum_double_p384
+        S2N_ASM_HIDDEN(bignum_double_p384)
 
         .globl _bignum_double_p384
-        .private_extern _bignum_double_p384
+        S2N_ASM_HIDDEN(_bignum_double_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_double_p384
-        .globl  _bignum_double_p384
+        .globl bignum_double_p384
+        .private_extern bignum_double_p384
+
+        .globl _bignum_double_p384
+        .private_extern _bignum_double_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_half_p384
-        .globl  _bignum_half_p384
+        .globl bignum_half_p384
+        .private_extern bignum_half_p384
+
+        .globl _bignum_half_p384
+        .private_extern _bignum_half_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_half_p384
-        .private_extern bignum_half_p384
+        S2N_ASM_HIDDEN(bignum_half_p384)
 
         .globl _bignum_half_p384
-        .private_extern _bignum_half_p384
+        S2N_ASM_HIDDEN(_bignum_half_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
@@ -35,12 +35,24 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_littleendian_6
-        .globl  _bignum_littleendian_6
-        .globl  bignum_fromlebytes_6
-        .globl  _bignum_fromlebytes_6
-        .globl  bignum_tolebytes_6
-        .globl  _bignum_tolebytes_6
+        .globl bignum_littleendian_6
+        .private_extern bignum_littleendian_6
+
+        .globl _bignum_littleendian_6
+        .private_extern _bignum_littleendian_6
+
+        .globl bignum_fromlebytes_6
+        .private_extern bignum_fromlebytes_6
+
+        .globl _bignum_fromlebytes_6
+        .private_extern _bignum_fromlebytes_6
+
+        .globl bignum_tolebytes_6
+        .private_extern bignum_tolebytes_6
+
+        .globl _bignum_tolebytes_6
+        .private_extern _bignum_tolebytes_6
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
@@ -33,25 +33,25 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_littleendian_6
-        .private_extern bignum_littleendian_6
+        S2N_ASM_HIDDEN(bignum_littleendian_6)
 
         .globl _bignum_littleendian_6
-        .private_extern _bignum_littleendian_6
+        S2N_ASM_HIDDEN(_bignum_littleendian_6)
 
         .globl bignum_fromlebytes_6
-        .private_extern bignum_fromlebytes_6
+        S2N_ASM_HIDDEN(bignum_fromlebytes_6)
 
         .globl _bignum_fromlebytes_6
-        .private_extern _bignum_fromlebytes_6
+        S2N_ASM_HIDDEN(_bignum_fromlebytes_6)
 
         .globl bignum_tolebytes_6
-        .private_extern bignum_tolebytes_6
+        S2N_ASM_HIDDEN(bignum_tolebytes_6)
 
         .globl _bignum_tolebytes_6
-        .private_extern _bignum_tolebytes_6
+        S2N_ASM_HIDDEN(_bignum_tolebytes_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
@@ -26,8 +26,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_n384
-        .globl  _bignum_mod_n384
+        .globl bignum_mod_n384
+        .private_extern bignum_mod_n384
+
+        .globl _bignum_mod_n384
+        .private_extern _bignum_mod_n384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
@@ -24,13 +24,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n384
-        .private_extern bignum_mod_n384
+        S2N_ASM_HIDDEN(bignum_mod_n384)
 
         .globl _bignum_mod_n384
-        .private_extern _bignum_mod_n384
+        S2N_ASM_HIDDEN(_bignum_mod_n384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
@@ -24,13 +24,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n384_6
-        .private_extern bignum_mod_n384_6
+        S2N_ASM_HIDDEN(bignum_mod_n384_6)
 
         .globl _bignum_mod_n384_6
-        .private_extern _bignum_mod_n384_6
+        S2N_ASM_HIDDEN(_bignum_mod_n384_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
@@ -26,8 +26,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_n384_6
-        .globl  _bignum_mod_n384_6
+        .globl bignum_mod_n384_6
+        .private_extern bignum_mod_n384_6
+
+        .globl _bignum_mod_n384_6
+        .private_extern _bignum_mod_n384_6
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
@@ -26,8 +26,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_n384_alt
-        .globl  _bignum_mod_n384_alt
+        .globl bignum_mod_n384_alt
+        .private_extern bignum_mod_n384_alt
+
+        .globl _bignum_mod_n384_alt
+        .private_extern _bignum_mod_n384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
@@ -24,13 +24,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n384_alt
-        .private_extern bignum_mod_n384_alt
+        S2N_ASM_HIDDEN(bignum_mod_n384_alt)
 
         .globl _bignum_mod_n384_alt
-        .private_extern _bignum_mod_n384_alt
+        S2N_ASM_HIDDEN(_bignum_mod_n384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_p384
-        .globl  _bignum_mod_p384
+        .globl bignum_mod_p384
+        .private_extern bignum_mod_p384
+
+        .globl _bignum_mod_p384
+        .private_extern _bignum_mod_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p384
-        .private_extern bignum_mod_p384
+        S2N_ASM_HIDDEN(bignum_mod_p384)
 
         .globl _bignum_mod_p384
-        .private_extern _bignum_mod_p384
+        S2N_ASM_HIDDEN(_bignum_mod_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_p384_6
-        .globl  _bignum_mod_p384_6
+        .globl bignum_mod_p384_6
+        .private_extern bignum_mod_p384_6
+
+        .globl _bignum_mod_p384_6
+        .private_extern _bignum_mod_p384_6
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p384_6
-        .private_extern bignum_mod_p384_6
+        S2N_ASM_HIDDEN(bignum_mod_p384_6)
 
         .globl _bignum_mod_p384_6
-        .private_extern _bignum_mod_p384_6
+        S2N_ASM_HIDDEN(_bignum_mod_p384_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p384_alt
-        .private_extern bignum_mod_p384_alt
+        S2N_ASM_HIDDEN(bignum_mod_p384_alt)
 
         .globl _bignum_mod_p384_alt
-        .private_extern _bignum_mod_p384_alt
+        S2N_ASM_HIDDEN(_bignum_mod_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_p384_alt
-        .globl  _bignum_mod_p384_alt
+        .globl bignum_mod_p384_alt
+        .private_extern bignum_mod_p384_alt
+
+        .globl _bignum_mod_p384_alt
+        .private_extern _bignum_mod_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
@@ -28,8 +28,12 @@
 // -----------------------------------------------------------------------------
 
 
-        .globl  bignum_montmul_p384
-        .globl  _bignum_montmul_p384
+        .globl bignum_montmul_p384
+        .private_extern bignum_montmul_p384
+
+        .globl _bignum_montmul_p384
+        .private_extern _bignum_montmul_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
@@ -26,13 +26,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // -----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p384
-        .private_extern bignum_montmul_p384
+        S2N_ASM_HIDDEN(bignum_montmul_p384)
 
         .globl _bignum_montmul_p384
-        .private_extern _bignum_montmul_p384
+        S2N_ASM_HIDDEN(_bignum_montmul_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
@@ -26,13 +26,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // -----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p384_alt
-        .private_extern bignum_montmul_p384_alt
+        S2N_ASM_HIDDEN(bignum_montmul_p384_alt)
 
         .globl _bignum_montmul_p384_alt
-        .private_extern _bignum_montmul_p384_alt
+        S2N_ASM_HIDDEN(_bignum_montmul_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
@@ -28,8 +28,12 @@
 // -----------------------------------------------------------------------------
 
 
-        .globl  bignum_montmul_p384_alt
-        .globl  _bignum_montmul_p384_alt
+        .globl bignum_montmul_p384_alt
+        .private_extern bignum_montmul_p384_alt
+
+        .globl _bignum_montmul_p384_alt
+        .private_extern _bignum_montmul_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montsqr_p384
-        .globl  _bignum_montsqr_p384
+        .globl bignum_montsqr_p384
+        .private_extern bignum_montsqr_p384
+
+        .globl _bignum_montsqr_p384
+        .private_extern _bignum_montsqr_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p384
-        .private_extern bignum_montsqr_p384
+        S2N_ASM_HIDDEN(bignum_montsqr_p384)
 
         .globl _bignum_montsqr_p384
-        .private_extern _bignum_montsqr_p384
+        S2N_ASM_HIDDEN(_bignum_montsqr_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p384_alt
-        .private_extern bignum_montsqr_p384_alt
+        S2N_ASM_HIDDEN(bignum_montsqr_p384_alt)
 
         .globl _bignum_montsqr_p384_alt
-        .private_extern _bignum_montsqr_p384_alt
+        S2N_ASM_HIDDEN(_bignum_montsqr_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montsqr_p384_alt
-        .globl  _bignum_montsqr_p384_alt
+        .globl bignum_montsqr_p384_alt
+        .private_extern bignum_montsqr_p384_alt
+
+        .globl _bignum_montsqr_p384_alt
+        .private_extern _bignum_montsqr_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mux_6
-        .globl  _bignum_mux_6
+        .globl bignum_mux_6
+        .private_extern bignum_mux_6
+
+        .globl _bignum_mux_6
+        .private_extern _bignum_mux_6
+
         .text
 
 #define p %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = p, RSI = z, RDX = x, RCX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mux_6
-        .private_extern bignum_mux_6
+        S2N_ASM_HIDDEN(bignum_mux_6)
 
         .globl _bignum_mux_6
-        .private_extern _bignum_mux_6
+        S2N_ASM_HIDDEN(_bignum_mux_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
@@ -21,13 +21,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_neg_p384
-        .private_extern bignum_neg_p384
+        S2N_ASM_HIDDEN(bignum_neg_p384)
 
         .globl _bignum_neg_p384
-        .private_extern _bignum_neg_p384
+        S2N_ASM_HIDDEN(_bignum_neg_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
@@ -23,8 +23,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_neg_p384
-        .globl  _bignum_neg_p384
+        .globl bignum_neg_p384
+        .private_extern bignum_neg_p384
+
+        .globl _bignum_neg_p384
+        .private_extern _bignum_neg_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
@@ -21,13 +21,13 @@
 //
 // Standard x86-64 ABI: RDI = x, returns RAX
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_nonzero_6
-        .private_extern bignum_nonzero_6
+        S2N_ASM_HIDDEN(bignum_nonzero_6)
 
         .globl _bignum_nonzero_6
-        .private_extern _bignum_nonzero_6
+        S2N_ASM_HIDDEN(_bignum_nonzero_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
@@ -23,8 +23,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_nonzero_6
-        .globl  _bignum_nonzero_6
+        .globl bignum_nonzero_6
+        .private_extern bignum_nonzero_6
+
+        .globl _bignum_nonzero_6
+        .private_extern _bignum_nonzero_6
+
         .text
 
 #define x %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_optneg_p384
-        .private_extern bignum_optneg_p384
+        S2N_ASM_HIDDEN(bignum_optneg_p384)
 
         .globl _bignum_optneg_p384
-        .private_extern _bignum_optneg_p384
+        S2N_ASM_HIDDEN(_bignum_optneg_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_optneg_p384
-        .globl  _bignum_optneg_p384
+        .globl bignum_optneg_p384
+        .private_extern bignum_optneg_p384
+
+        .globl _bignum_optneg_p384
+        .private_extern _bignum_optneg_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sub_p384
-        .private_extern bignum_sub_p384
+        S2N_ASM_HIDDEN(bignum_sub_p384)
 
         .globl _bignum_sub_p384
-        .private_extern _bignum_sub_p384
+        S2N_ASM_HIDDEN(_bignum_sub_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_sub_p384
-        .globl  _bignum_sub_p384
+        .globl bignum_sub_p384
+        .private_extern bignum_sub_p384
+
+        .globl _bignum_sub_p384
+        .private_extern _bignum_sub_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tomont_p384
-        .private_extern bignum_tomont_p384
+        S2N_ASM_HIDDEN(bignum_tomont_p384)
 
         .globl _bignum_tomont_p384
-        .private_extern _bignum_tomont_p384
+        S2N_ASM_HIDDEN(_bignum_tomont_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_tomont_p384
-        .globl  _bignum_tomont_p384
+        .globl bignum_tomont_p384
+        .private_extern bignum_tomont_p384
+
+        .globl _bignum_tomont_p384
+        .private_extern _bignum_tomont_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tomont_p384_alt
-        .private_extern bignum_tomont_p384_alt
+        S2N_ASM_HIDDEN(bignum_tomont_p384_alt)
 
         .globl _bignum_tomont_p384_alt
-        .private_extern _bignum_tomont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_tomont_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_tomont_p384_alt
-        .globl  _bignum_tomont_p384_alt
+        .globl bignum_tomont_p384_alt
+        .private_extern bignum_tomont_p384_alt
+
+        .globl _bignum_tomont_p384_alt
+        .private_extern _bignum_tomont_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p384
-        .private_extern bignum_triple_p384
+        S2N_ASM_HIDDEN(bignum_triple_p384)
 
         .globl _bignum_triple_p384
-        .private_extern _bignum_triple_p384
+        S2N_ASM_HIDDEN(_bignum_triple_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_triple_p384
-        .globl  _bignum_triple_p384
+        .globl bignum_triple_p384
+        .private_extern bignum_triple_p384
+
+        .globl _bignum_triple_p384
+        .private_extern _bignum_triple_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p384_alt
-        .private_extern bignum_triple_p384_alt
+        S2N_ASM_HIDDEN(bignum_triple_p384_alt)
 
         .globl _bignum_triple_p384_alt
-        .private_extern _bignum_triple_p384_alt
+        S2N_ASM_HIDDEN(_bignum_triple_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_triple_p384_alt
-        .globl  _bignum_triple_p384_alt
+        .globl bignum_triple_p384_alt
+        .private_extern bignum_triple_p384_alt
+
+        .globl _bignum_triple_p384_alt
+        .private_extern _bignum_triple_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_add_p521
-        .globl  _bignum_add_p521
+        .globl bignum_add_p521
+        .private_extern bignum_add_p521
+
+        .globl _bignum_add_p521
+        .private_extern _bignum_add_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_add_p521
-        .private_extern bignum_add_p521
+        S2N_ASM_HIDDEN(bignum_add_p521)
 
         .globl _bignum_add_p521
-        .private_extern _bignum_add_p521
+        S2N_ASM_HIDDEN(_bignum_add_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p521
-        .private_extern bignum_cmul_p521
+        S2N_ASM_HIDDEN(bignum_cmul_p521)
 
         .globl _bignum_cmul_p521
-        .private_extern _bignum_cmul_p521
+        S2N_ASM_HIDDEN(_bignum_cmul_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_cmul_p521
-        .globl  _bignum_cmul_p521
+        .globl bignum_cmul_p521
+        .private_extern bignum_cmul_p521
+
+        .globl _bignum_cmul_p521
+        .private_extern _bignum_cmul_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p521_alt
-        .private_extern bignum_cmul_p521_alt
+        S2N_ASM_HIDDEN(bignum_cmul_p521_alt)
 
         .globl _bignum_cmul_p521_alt
-        .private_extern _bignum_cmul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_cmul_p521_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_cmul_p521_alt
-        .globl  _bignum_cmul_p521_alt
+        .globl bignum_cmul_p521_alt
+        .private_extern bignum_cmul_p521_alt
+
+        .globl _bignum_cmul_p521_alt
+        .private_extern _bignum_cmul_p521_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_deamont_p521
-        .private_extern bignum_deamont_p521
+        S2N_ASM_HIDDEN(bignum_deamont_p521)
 
         .globl _bignum_deamont_p521
-        .private_extern _bignum_deamont_p521
+        S2N_ASM_HIDDEN(_bignum_deamont_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_deamont_p521
-        .globl  _bignum_deamont_p521
+        .globl bignum_deamont_p521
+        .private_extern bignum_deamont_p521
+
+        .globl _bignum_deamont_p521
+        .private_extern _bignum_deamont_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_demont_p521
-        .private_extern bignum_demont_p521
+        S2N_ASM_HIDDEN(bignum_demont_p521)
 
         .globl _bignum_demont_p521
-        .private_extern _bignum_demont_p521
+        S2N_ASM_HIDDEN(_bignum_demont_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_demont_p521
-        .globl  _bignum_demont_p521
+        .globl bignum_demont_p521
+        .private_extern bignum_demont_p521
+
+        .globl _bignum_demont_p521
+        .private_extern _bignum_demont_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_double_p521
-        .private_extern bignum_double_p521
+        S2N_ASM_HIDDEN(bignum_double_p521)
 
         .globl _bignum_double_p521
-        .private_extern _bignum_double_p521
+        S2N_ASM_HIDDEN(_bignum_double_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_double_p521
-        .globl  _bignum_double_p521
+        .globl bignum_double_p521
+        .private_extern bignum_double_p521
+
+        .globl _bignum_double_p521
+        .private_extern _bignum_double_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
@@ -28,8 +28,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_fromlebytes_p521
-        .globl  _bignum_fromlebytes_p521
+        .globl bignum_fromlebytes_p521
+        .private_extern bignum_fromlebytes_p521
+
+        .globl _bignum_fromlebytes_p521
+        .private_extern _bignum_fromlebytes_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
@@ -26,13 +26,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_fromlebytes_p521
-        .private_extern bignum_fromlebytes_p521
+        S2N_ASM_HIDDEN(bignum_fromlebytes_p521)
 
         .globl _bignum_fromlebytes_p521
-        .private_extern _bignum_fromlebytes_p521
+        S2N_ASM_HIDDEN(_bignum_fromlebytes_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_half_p521
-        .private_extern bignum_half_p521
+        S2N_ASM_HIDDEN(bignum_half_p521)
 
         .globl _bignum_half_p521
-        .private_extern _bignum_half_p521
+        S2N_ASM_HIDDEN(_bignum_half_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_half_p521
-        .globl  _bignum_half_p521
+        .globl bignum_half_p521
+        .private_extern bignum_half_p521
+
+        .globl _bignum_half_p521
+        .private_extern _bignum_half_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
@@ -26,8 +26,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_n521_9
-        .globl  _bignum_mod_n521_9
+        .globl bignum_mod_n521_9
+        .private_extern bignum_mod_n521_9
+
+        .globl _bignum_mod_n521_9
+        .private_extern _bignum_mod_n521_9
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
@@ -24,13 +24,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n521_9
-        .private_extern bignum_mod_n521_9
+        S2N_ASM_HIDDEN(bignum_mod_n521_9)
 
         .globl _bignum_mod_n521_9
-        .private_extern _bignum_mod_n521_9
+        S2N_ASM_HIDDEN(_bignum_mod_n521_9)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
@@ -24,13 +24,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n521_9_alt
-        .private_extern bignum_mod_n521_9_alt
+        S2N_ASM_HIDDEN(bignum_mod_n521_9_alt)
 
         .globl _bignum_mod_n521_9_alt
-        .private_extern _bignum_mod_n521_9_alt
+        S2N_ASM_HIDDEN(_bignum_mod_n521_9_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
@@ -26,8 +26,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_n521_9_alt
-        .globl  _bignum_mod_n521_9_alt
+        .globl bignum_mod_n521_9_alt
+        .private_extern bignum_mod_n521_9_alt
+
+        .globl _bignum_mod_n521_9_alt
+        .private_extern _bignum_mod_n521_9_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_p521_9
-        .globl  _bignum_mod_p521_9
+        .globl bignum_mod_p521_9
+        .private_extern bignum_mod_p521_9
+
+        .globl _bignum_mod_p521_9
+        .private_extern _bignum_mod_p521_9
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p521_9
-        .private_extern bignum_mod_p521_9
+        S2N_ASM_HIDDEN(bignum_mod_p521_9)
 
         .globl _bignum_mod_p521_9
-        .private_extern _bignum_mod_p521_9
+        S2N_ASM_HIDDEN(_bignum_mod_p521_9)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
@@ -29,8 +29,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montmul_p521
-        .globl  _bignum_montmul_p521
+        .globl bignum_montmul_p521
+        .private_extern bignum_montmul_p521
+
+        .globl _bignum_montmul_p521
+        .private_extern _bignum_montmul_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
@@ -27,13 +27,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p521
-        .private_extern bignum_montmul_p521
+        S2N_ASM_HIDDEN(bignum_montmul_p521)
 
         .globl _bignum_montmul_p521
-        .private_extern _bignum_montmul_p521
+        S2N_ASM_HIDDEN(_bignum_montmul_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
@@ -27,13 +27,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p521_alt
-        .private_extern bignum_montmul_p521_alt
+        S2N_ASM_HIDDEN(bignum_montmul_p521_alt)
 
         .globl _bignum_montmul_p521_alt
-        .private_extern _bignum_montmul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_montmul_p521_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
@@ -29,8 +29,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montmul_p521_alt
-        .globl  _bignum_montmul_p521_alt
+        .globl bignum_montmul_p521_alt
+        .private_extern bignum_montmul_p521_alt
+
+        .globl _bignum_montmul_p521_alt
+        .private_extern _bignum_montmul_p521_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
@@ -29,8 +29,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montsqr_p521
-        .globl  _bignum_montsqr_p521
+        .globl bignum_montsqr_p521
+        .private_extern bignum_montsqr_p521
+
+        .globl _bignum_montsqr_p521
+        .private_extern _bignum_montsqr_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
@@ -27,13 +27,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p521
-        .private_extern bignum_montsqr_p521
+        S2N_ASM_HIDDEN(bignum_montsqr_p521)
 
         .globl _bignum_montsqr_p521
-        .private_extern _bignum_montsqr_p521
+        S2N_ASM_HIDDEN(_bignum_montsqr_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
@@ -29,8 +29,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montsqr_p521_alt
-        .globl  _bignum_montsqr_p521_alt
+        .globl bignum_montsqr_p521_alt
+        .private_extern bignum_montsqr_p521_alt
+
+        .globl _bignum_montsqr_p521_alt
+        .private_extern _bignum_montsqr_p521_alt
+
         .text
 
 // Input arguments

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
@@ -27,13 +27,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p521_alt
-        .private_extern bignum_montsqr_p521_alt
+        S2N_ASM_HIDDEN(bignum_montsqr_p521_alt)
 
         .globl _bignum_montsqr_p521_alt
-        .private_extern _bignum_montsqr_p521_alt
+        S2N_ASM_HIDDEN(_bignum_montsqr_p521_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mul_p521
-        .globl  _bignum_mul_p521
+        .globl bignum_mul_p521
+        .private_extern bignum_mul_p521
+
+        .globl _bignum_mul_p521
+        .private_extern _bignum_mul_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mul_p521
-        .private_extern bignum_mul_p521
+        S2N_ASM_HIDDEN(bignum_mul_p521)
 
         .globl _bignum_mul_p521
-        .private_extern _bignum_mul_p521
+        S2N_ASM_HIDDEN(_bignum_mul_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mul_p521_alt
-        .globl  _bignum_mul_p521_alt
+        .globl bignum_mul_p521_alt
+        .private_extern bignum_mul_p521_alt
+
+        .globl _bignum_mul_p521_alt
+        .private_extern _bignum_mul_p521_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mul_p521_alt
-        .private_extern bignum_mul_p521_alt
+        S2N_ASM_HIDDEN(bignum_mul_p521_alt)
 
         .globl _bignum_mul_p521_alt
-        .private_extern _bignum_mul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_mul_p521_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
@@ -23,8 +23,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_neg_p521
-        .globl  _bignum_neg_p521
+        .globl bignum_neg_p521
+        .private_extern bignum_neg_p521
+
+        .globl _bignum_neg_p521
+        .private_extern _bignum_neg_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
@@ -21,13 +21,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_neg_p521
-        .private_extern bignum_neg_p521
+        S2N_ASM_HIDDEN(bignum_neg_p521)
 
         .globl _bignum_neg_p521
-        .private_extern _bignum_neg_p521
+        S2N_ASM_HIDDEN(_bignum_neg_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_optneg_p521
-        .globl  _bignum_optneg_p521
+        .globl bignum_optneg_p521
+        .private_extern bignum_optneg_p521
+
+        .globl _bignum_optneg_p521
+        .private_extern _bignum_optneg_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_optneg_p521
-        .private_extern bignum_optneg_p521
+        S2N_ASM_HIDDEN(bignum_optneg_p521)
 
         .globl _bignum_optneg_p521
-        .private_extern _bignum_optneg_p521
+        S2N_ASM_HIDDEN(_bignum_optneg_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
@@ -23,8 +23,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_sqr_p521
-        .globl  _bignum_sqr_p521
+        .globl bignum_sqr_p521
+        .private_extern bignum_sqr_p521
+
+        .globl _bignum_sqr_p521
+        .private_extern _bignum_sqr_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
@@ -21,13 +21,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sqr_p521
-        .private_extern bignum_sqr_p521
+        S2N_ASM_HIDDEN(bignum_sqr_p521)
 
         .globl _bignum_sqr_p521
-        .private_extern _bignum_sqr_p521
+        S2N_ASM_HIDDEN(_bignum_sqr_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
@@ -23,8 +23,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_sqr_p521_alt
-        .globl  _bignum_sqr_p521_alt
+        .globl bignum_sqr_p521_alt
+        .private_extern bignum_sqr_p521_alt
+
+        .globl _bignum_sqr_p521_alt
+        .private_extern _bignum_sqr_p521_alt
+
         .text
 
 // Input arguments

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
@@ -21,13 +21,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sqr_p521_alt
-        .private_extern bignum_sqr_p521_alt
+        S2N_ASM_HIDDEN(bignum_sqr_p521_alt)
 
         .globl _bignum_sqr_p521_alt
-        .private_extern _bignum_sqr_p521_alt
+        S2N_ASM_HIDDEN(_bignum_sqr_p521_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_sub_p521
-        .globl  _bignum_sub_p521
+        .globl bignum_sub_p521
+        .private_extern bignum_sub_p521
+
+        .globl _bignum_sub_p521
+        .private_extern _bignum_sub_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sub_p521
-        .private_extern bignum_sub_p521
+        S2N_ASM_HIDDEN(bignum_sub_p521)
 
         .globl _bignum_sub_p521
-        .private_extern _bignum_sub_p521
+        S2N_ASM_HIDDEN(_bignum_sub_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
@@ -26,13 +26,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tolebytes_p521
-        .private_extern bignum_tolebytes_p521
+        S2N_ASM_HIDDEN(bignum_tolebytes_p521)
 
         .globl _bignum_tolebytes_p521
-        .private_extern _bignum_tolebytes_p521
+        S2N_ASM_HIDDEN(_bignum_tolebytes_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
@@ -28,8 +28,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_tolebytes_p521
-        .globl  _bignum_tolebytes_p521
+        .globl bignum_tolebytes_p521
+        .private_extern bignum_tolebytes_p521
+
+        .globl _bignum_tolebytes_p521
+        .private_extern _bignum_tolebytes_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tomont_p521
-        .private_extern bignum_tomont_p521
+        S2N_ASM_HIDDEN(bignum_tomont_p521)
 
         .globl _bignum_tomont_p521
-        .private_extern _bignum_tomont_p521
+        S2N_ASM_HIDDEN(_bignum_tomont_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_tomont_p521
-        .globl  _bignum_tomont_p521
+        .globl bignum_tomont_p521
+        .private_extern bignum_tomont_p521
+
+        .globl _bignum_tomont_p521
+        .private_extern _bignum_tomont_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p521
-        .private_extern bignum_triple_p521
+        S2N_ASM_HIDDEN(bignum_triple_p521)
 
         .globl _bignum_triple_p521
-        .private_extern _bignum_triple_p521
+        S2N_ASM_HIDDEN(_bignum_triple_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_triple_p521
-        .globl  _bignum_triple_p521
+        .globl bignum_triple_p521
+        .private_extern bignum_triple_p521
+
+        .globl _bignum_triple_p521
+        .private_extern _bignum_triple_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_triple_p521_alt
-        .globl  _bignum_triple_p521_alt
+        .globl bignum_triple_p521_alt
+        .private_extern bignum_triple_p521_alt
+
+        .globl _bignum_triple_p521_alt
+        .private_extern _bignum_triple_p521_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p521_alt
-        .private_extern bignum_triple_p521_alt
+        S2N_ASM_HIDDEN(bignum_triple_p521_alt)
 
         .globl _bignum_triple_p521_alt
-        .private_extern _bignum_triple_p521_alt
+        S2N_ASM_HIDDEN(_bignum_triple_p521_alt)
 
         .text
 


### PR DESCRIPTION
### Description of changes: 
The shared library produced by the current build process externalizes the s2n-bignum symbols (`bignum_*`).

### Call-outs:
The s2n-bignum symbols are still exposed from our *static* library.

### Testing:
I built the shared library on Mac (x86) and Linux (x86 and aarch64). Verified that the s2n-bignum symbols were not being externalized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
