### PR TITLE
Hide s2n bignum

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories(../include)
 
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -DS2N_BN_HIDE_SYMBOLS=1")
+
 if(NOT OPENSSL_NO_ASM)
   if(UNIX)
     if(ARCH STREQUAL "aarch64")

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -1,7 +1,5 @@
 include_directories(../include)
 
-set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -DS2N_BN_HIDE_SYMBOLS=1")
-
 if(NOT OPENSSL_NO_ASM)
   if(UNIX)
     if(ARCH STREQUAL "aarch64")

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -228,7 +228,7 @@ function(s2n_asm_cpreprocess dest src)
   add_custom_command(
           OUTPUT ${dest}
           COMMAND ${CMAKE_COMMAND} -E make_directory ${dir}
-          COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -E ${S2N_BIGNUM_DIR}/${src} -I${PROJECT_SOURCE_DIR}/include| tr \"\;\" \"\\n\" > ${dest}
+          COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -DS2N_BN_HIDE_SYMBOLS=1 -E ${S2N_BIGNUM_DIR}/${src} -I${PROJECT_SOURCE_DIR}/include| tr \"\;\" \"\\n\" > ${dest}
           DEPENDS
           ${S2N_BIGNUM_DIR}/${src}
           WORKING_DIRECTORY .

--- a/third_party/s2n-bignum/_internal_s2n_bignum.h
+++ b/third_party/s2n-bignum/_internal_s2n_bignum.h
@@ -1,0 +1,5 @@
+#ifdef __APPLE__
+#define S2N_ASM_HIDDEN(name) .private_extern name
+#else
+#define S2N_ASM_HIDDEN(name) .hidden name
+#endif

--- a/third_party/s2n-bignum/_internal_s2n_bignum.h
+++ b/third_party/s2n-bignum/_internal_s2n_bignum.h
@@ -1,5 +1,0 @@
-#ifdef __APPLE__
-#define S2N_ASM_HIDDEN(name) .private_extern name
-#else
-#define S2N_ASM_HIDDEN(name) .hidden name
-#endif

--- a/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_add_p384
-        S2N_ASM_HIDDEN(bignum_add_p384)
-
-        .globl _bignum_add_p384
-        S2N_ASM_HIDDEN(_bignum_add_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p384)
         .text
         .balign 4
 
@@ -46,64 +42,63 @@
 #define d5 x10
 
 
-bignum_add_p384:
-_bignum_add_p384:
+S2N_BN_SYMBOL(bignum_add_p384):
 
 // First just add the numbers as c + [d5; d4; d3; d2; d1; d0]
 
-                ldp     d0, d1, [x]
-                ldp     l, c, [y]
-                adds    d0, d0, l
-                adcs    d1, d1, c
-                ldp     d2, d3, [x, #16]
-                ldp     l, c, [y, #16]
-                adcs    d2, d2, l
-                adcs    d3, d3, c
-                ldp     d4, d5, [x, #32]
-                ldp     l, c, [y, #32]
-                adcs    d4, d4, l
-                adcs    d5, d5, c
-                adc     c, xzr, xzr
+        ldp     d0, d1, [x]
+        ldp     l, c, [y]
+        adds    d0, d0, l
+        adcs    d1, d1, c
+        ldp     d2, d3, [x, #16]
+        ldp     l, c, [y, #16]
+        adcs    d2, d2, l
+        adcs    d3, d3, c
+        ldp     d4, d5, [x, #32]
+        ldp     l, c, [y, #32]
+        adcs    d4, d4, l
+        adcs    d5, d5, c
+        adc     c, xzr, xzr
 
 // Now compare [d5; d4; d3; d2; d1; d0] with p_384
 
-                mov     l, #0x00000000ffffffff
-                subs    xzr, d0, l
-                mov     l, #0xffffffff00000000
-                sbcs    xzr, d1, l
-                mov     l, #0xfffffffffffffffe
-                sbcs    xzr, d2, l
-                adcs    xzr, d3, xzr
-                adcs    xzr, d4, xzr
-                adcs    xzr, d5, xzr
+        mov     l, #0x00000000ffffffff
+        subs    xzr, d0, l
+        mov     l, #0xffffffff00000000
+        sbcs    xzr, d1, l
+        mov     l, #0xfffffffffffffffe
+        sbcs    xzr, d2, l
+        adcs    xzr, d3, xzr
+        adcs    xzr, d4, xzr
+        adcs    xzr, d5, xzr
 
 // Now CF is set (because of inversion) if (x + y) % 2^384 >= p_384
 // Thus we want to correct if either this is set or the original carry c was
 
-                adcs    c, c, xzr
-                csetm   c, ne
+        adcs    c, c, xzr
+        csetm   c, ne
 
 // Now correct by subtracting masked p_384
 
-                mov     l, #0x00000000ffffffff
-                and     l, l, c
-                subs    d0, d0, l
-                eor     l, l, c
-                sbcs    d1, d1, l
-                mov     l, #0xfffffffffffffffe
-                and     l, l, c
-                sbcs    d2, d2, l
-                sbcs    d3, d3, c
-                sbcs    d4, d4, c
-                sbc     d5, d5, c
+        mov     l, #0x00000000ffffffff
+        and     l, l, c
+        subs    d0, d0, l
+        eor     l, l, c
+        sbcs    d1, d1, l
+        mov     l, #0xfffffffffffffffe
+        and     l, l, c
+        sbcs    d2, d2, l
+        sbcs    d3, d3, c
+        sbcs    d4, d4, c
+        sbc     d5, d5, c
 
 // Store the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_add_p384
-        .private_extern bignum_add_p384
+        S2N_ASM_HIDDEN(bignum_add_p384)
 
         .globl _bignum_add_p384
-        .private_extern _bignum_add_p384
+        S2N_ASM_HIDDEN(_bignum_add_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_add_p384
-        .globl  _bignum_add_p384
+        .globl bignum_add_p384
+        .private_extern bignum_add_p384
+
+        .globl _bignum_add_p384
+        .private_extern _bignum_add_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
@@ -36,12 +36,24 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_bigendian_6
-        .globl  _bignum_bigendian_6
-        .globl  bignum_frombebytes_6
-        .globl  _bignum_frombebytes_6
-        .globl  bignum_tobebytes_6
-        .globl  _bignum_tobebytes_6
+        .globl bignum_bigendian_6
+        .private_extern bignum_bigendian_6
+
+        .globl _bignum_bigendian_6
+        .private_extern _bignum_bigendian_6
+
+        .globl bignum_frombebytes_6
+        .private_extern bignum_frombebytes_6
+
+        .globl _bignum_frombebytes_6
+        .private_extern _bignum_frombebytes_6
+
+        .globl bignum_tobebytes_6
+        .private_extern bignum_tobebytes_6
+
+        .globl _bignum_tobebytes_6
+        .private_extern _bignum_tobebytes_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
@@ -35,24 +35,25 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_bigendian_6
-        .private_extern bignum_bigendian_6
+        S2N_ASM_HIDDEN(bignum_bigendian_6)
 
         .globl _bignum_bigendian_6
-        .private_extern _bignum_bigendian_6
+        S2N_ASM_HIDDEN(_bignum_bigendian_6)
 
         .globl bignum_frombebytes_6
-        .private_extern bignum_frombebytes_6
+        S2N_ASM_HIDDEN(bignum_frombebytes_6)
 
         .globl _bignum_frombebytes_6
-        .private_extern _bignum_frombebytes_6
+        S2N_ASM_HIDDEN(_bignum_frombebytes_6)
 
         .globl bignum_tobebytes_6
-        .private_extern bignum_tobebytes_6
+        S2N_ASM_HIDDEN(bignum_tobebytes_6)
 
         .globl _bignum_tobebytes_6
-        .private_extern _bignum_tobebytes_6
+        S2N_ASM_HIDDEN(_bignum_tobebytes_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
@@ -59,10 +59,9 @@
 // to allow x and z to point to the same buffer without using more
 // intermediate registers.
 
-S2N_BN_SYMBOL(bignum_bignum_bigendian_6):
-
-S2N_BN_SYMBOL(bignum_bignum_frombebytes_6):
-S2N_BN_SYMBOL(bignum_bignum_tobebytes_6):
+S2N_BN_SYMBOL(bignum_bigendian_6):
+S2N_BN_SYMBOL(bignum_frombebytes_6):
+S2N_BN_SYMBOL(bignum_tobebytes_6):
 
 // 0 and 5 words
 

--- a/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
@@ -35,25 +35,14 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_bigendian_6
-        S2N_ASM_HIDDEN(bignum_bigendian_6)
-
-        .globl _bignum_bigendian_6
-        S2N_ASM_HIDDEN(_bignum_bigendian_6)
-
-        .globl bignum_frombebytes_6
-        S2N_ASM_HIDDEN(bignum_frombebytes_6)
-
-        .globl _bignum_frombebytes_6
-        S2N_ASM_HIDDEN(_bignum_frombebytes_6)
-
-        .globl bignum_tobebytes_6
-        S2N_ASM_HIDDEN(bignum_tobebytes_6)
-
-        .globl _bignum_tobebytes_6
-        S2N_ASM_HIDDEN(_bignum_tobebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_bigendian_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_bigendian_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_frombebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_frombebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tobebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tobebytes_6)
 
         .text
         .balign 4
@@ -70,131 +59,129 @@
 // to allow x and z to point to the same buffer without using more
 // intermediate registers.
 
-bignum_bigendian_6:
-_bignum_bigendian_6:
-bignum_frombebytes_6:
-_bignum_frombebytes_6:
-bignum_tobebytes_6:
-_bignum_tobebytes_6:
+S2N_BN_SYMBOL(bignum_bignum_bigendian_6):
+
+S2N_BN_SYMBOL(bignum_bignum_frombebytes_6):
+S2N_BN_SYMBOL(bignum_bignum_tobebytes_6):
 
 // 0 and 5 words
 
-                ldrb    dshort, [x, #7]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #6]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #5]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #4]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #3]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #2]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #1]
-                extr    a, d, a, #8
-                ldrb    dshort, [x]
-                extr    a, d, a, #8
+        ldrb    dshort, [x, #7]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #6]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #5]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #4]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #3]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #2]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #1]
+        extr    a, d, a, #8
+        ldrb    dshort, [x]
+        extr    a, d, a, #8
 
-                ldrb    dshort, [x, #47]
-                extr    c, d, xzr, #8
-                ldrb    dshort, [x, #46]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #45]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #44]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #43]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #42]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #41]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #40]
-                extr    c, d, c, #8
+        ldrb    dshort, [x, #47]
+        extr    c, d, xzr, #8
+        ldrb    dshort, [x, #46]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #45]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #44]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #43]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #42]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #41]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #40]
+        extr    c, d, c, #8
 
-                str     a, [z, #40]
-                str     c, [z]
+        str     a, [z, #40]
+        str     c, [z]
 
 // 1 and 4 words
 
-                ldrb    dshort, [x, #15]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #14]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #13]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #12]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #11]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #10]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #9]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #8]
-                extr    a, d, a, #8
+        ldrb    dshort, [x, #15]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #14]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #13]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #12]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #11]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #10]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #9]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #8]
+        extr    a, d, a, #8
 
-                ldrb    dshort, [x, #39]
-                extr    c, d, xzr, #8
-                ldrb    dshort, [x, #38]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #37]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #36]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #35]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #34]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #33]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #32]
-                extr    c, d, c, #8
+        ldrb    dshort, [x, #39]
+        extr    c, d, xzr, #8
+        ldrb    dshort, [x, #38]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #37]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #36]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #35]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #34]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #33]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #32]
+        extr    c, d, c, #8
 
-                str     a, [z, #32]
-                str     c, [z, #8]
+        str     a, [z, #32]
+        str     c, [z, #8]
 
 // 2 and 3 words
 
-                ldrb    dshort, [x, #23]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #22]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #21]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #20]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #19]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #18]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #17]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #16]
-                extr    a, d, a, #8
+        ldrb    dshort, [x, #23]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #22]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #21]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #20]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #19]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #18]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #17]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #16]
+        extr    a, d, a, #8
 
-                ldrb    dshort, [x, #31]
-                extr    c, d, xzr, #8
-                ldrb    dshort, [x, #30]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #29]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #28]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #27]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #26]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #25]
-                extr    c, d, c, #8
-                ldrb    dshort, [x, #24]
-                extr    c, d, c, #8
+        ldrb    dshort, [x, #31]
+        extr    c, d, xzr, #8
+        ldrb    dshort, [x, #30]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #29]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #28]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #27]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #26]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #25]
+        extr    c, d, c, #8
+        ldrb    dshort, [x, #24]
+        extr    c, d, c, #8
 
-                str     a, [z, #24]
-                str     c, [z, #16]
+        str     a, [z, #24]
+        str     c, [z, #16]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
@@ -23,18 +23,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p384
-        .private_extern bignum_cmul_p384
+        S2N_ASM_HIDDEN(bignum_cmul_p384)
 
         .globl _bignum_cmul_p384
-        .private_extern _bignum_cmul_p384
+        S2N_ASM_HIDDEN(_bignum_cmul_p384)
 
         .globl bignum_cmul_p384_alt
-        .private_extern bignum_cmul_p384_alt
+        S2N_ASM_HIDDEN(bignum_cmul_p384_alt)
 
         .globl _bignum_cmul_p384_alt
-        .private_extern _bignum_cmul_p384_alt
+        S2N_ASM_HIDDEN(_bignum_cmul_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
@@ -24,10 +24,18 @@
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_cmul_p384
-        .globl  _bignum_cmul_p384
-        .globl  bignum_cmul_p384_alt
-        .globl  _bignum_cmul_p384_alt
+        .globl bignum_cmul_p384
+        .private_extern bignum_cmul_p384
+
+        .globl _bignum_cmul_p384
+        .private_extern _bignum_cmul_p384
+
+        .globl bignum_cmul_p384_alt
+        .private_extern bignum_cmul_p384_alt
+
+        .globl _bignum_cmul_p384_alt
+        .private_extern _bignum_cmul_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
@@ -23,20 +23,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_cmul_p384
-        S2N_ASM_HIDDEN(bignum_cmul_p384)
-
-        .globl _bignum_cmul_p384
-        S2N_ASM_HIDDEN(_bignum_cmul_p384)
-
-        .globl bignum_cmul_p384_alt
-        S2N_ASM_HIDDEN(bignum_cmul_p384_alt)
-
-        .globl _bignum_cmul_p384_alt
-        S2N_ASM_HIDDEN(_bignum_cmul_p384_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384_alt)
         .text
         .balign 4
 
@@ -66,34 +58,33 @@
 #define l x9
 
 
-bignum_cmul_p384:
-_bignum_cmul_p384:
-bignum_cmul_p384_alt:
-_bignum_cmul_p384_alt:
+S2N_BN_SYMBOL(bignum_cmul_p384):
+
+S2N_BN_SYMBOL(bignum_cmul_p384_alt):
 
 // First do the multiply, straightforwardly, getting [h; d5; ...; d0]
 
-                ldp     a0, a1, [x]
-                ldp     a2, a3, [x, #16]
-                ldp     a4, a5, [x, #32]
-                mul     d0, c, a0
-                mul     d1, c, a1
-                mul     d2, c, a2
-                mul     d3, c, a3
-                mul     d4, c, a4
-                mul     d5, c, a5
-                umulh   a0, c, a0
-                umulh   a1, c, a1
-                umulh   a2, c, a2
-                umulh   a3, c, a3
-                umulh   a4, c, a4
-                umulh   h, c, a5
-                adds    d1, d1, a0
-                adcs    d2, d2, a1
-                adcs    d3, d3, a2
-                adcs    d4, d4, a3
-                adcs    d5, d5, a4
-                adc     h, h, xzr
+        ldp     a0, a1, [x]
+        ldp     a2, a3, [x, #16]
+        ldp     a4, a5, [x, #32]
+        mul     d0, c, a0
+        mul     d1, c, a1
+        mul     d2, c, a2
+        mul     d3, c, a3
+        mul     d4, c, a4
+        mul     d5, c, a5
+        umulh   a0, c, a0
+        umulh   a1, c, a1
+        umulh   a2, c, a2
+        umulh   a3, c, a3
+        umulh   a4, c, a4
+        umulh   h, c, a5
+        adds    d1, d1, a0
+        adcs    d2, d2, a1
+        adcs    d3, d3, a2
+        adcs    d4, d4, a3
+        adcs    d5, d5, a4
+        adc     h, h, xzr
 
 // Let h be the top word of this intermediate product and l the low 6 words.
 // By the range hypothesis on the input, we know h1 = h + 1 does not wrap
@@ -115,47 +106,47 @@ _bignum_cmul_p384_alt:
 //       = l + 2^128 * (h + 1) + 2^96 * (h + 1) - 2^32 * (h + 1) + (h + 1)
 //       = l + 2^128 * (h + 1) + 2^96 * h + 2^32 * ~h + (h + 1)
 
-                add     h1, h, #1
-                orn     hn, xzr, h
-                lsl     a0, hn, #32
-                extr    a1, h, hn, #32
-                lsr     a2, h, #32
+        add     h1, h, #1
+        orn     hn, xzr, h
+        lsl     a0, hn, #32
+        extr    a1, h, hn, #32
+        lsr     a2, h, #32
 
-                adds    a0, a0, h1
-                adcs    a1, a1, xzr
-                adcs    a2, a2, h1
-                adc     a3, xzr, xzr
+        adds    a0, a0, h1
+        adcs    a1, a1, xzr
+        adcs    a2, a2, h1
+        adc     a3, xzr, xzr
 
-                adds    d0, d0, a0
-                adcs    d1, d1, a1
-                adcs    d2, d2, a2
-                adcs    d3, d3, a3
-                adcs    d4, d4, xzr
-                adcs    d5, d5, xzr
+        adds    d0, d0, a0
+        adcs    d1, d1, a1
+        adcs    d2, d2, a2
+        adcs    d3, d3, a3
+        adcs    d4, d4, xzr
+        adcs    d5, d5, xzr
 
 // Catch the carry and do a masked addition of p_384
 
-                csetm   m, cc
+        csetm   m, cc
 
-                mov     l, #0x00000000ffffffff
-                and     l, l, m
-                adds    d0, d0, l
-                eor     l, l, m
-                adcs    d1, d1, l
-                mov     l, #0xfffffffffffffffe
-                and     l, l, m
-                adcs    d2, d2, l
-                adcs    d3, d3, m
-                adcs    d4, d4, m
-                adc     d5, d5, m
+        mov     l, #0x00000000ffffffff
+        and     l, l, m
+        adds    d0, d0, l
+        eor     l, l, m
+        adcs    d1, d1, l
+        mov     l, #0xfffffffffffffffe
+        and     l, l, m
+        adcs    d2, d2, l
+        adcs    d3, d3, m
+        adcs    d4, d4, m
+        adc     d5, d5, m
 
 // Store the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
@@ -25,20 +25,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_deamont_p384
-        S2N_ASM_HIDDEN(bignum_deamont_p384)
-
-        .globl _bignum_deamont_p384
-        S2N_ASM_HIDDEN(_bignum_deamont_p384)
-
-        .globl bignum_deamont_p384_alt
-        S2N_ASM_HIDDEN(bignum_deamont_p384_alt)
-
-        .globl _bignum_deamont_p384_alt
-        S2N_ASM_HIDDEN(_bignum_deamont_p384_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384_alt)
         .text
         .balign 4
 
@@ -55,29 +47,29 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Recycle d0 (which we know gets implicitly cancelled) to store it     */  \
-                lsl     t1, d0, #32;                                        \
-                add     d0, t1, d0;                                         \
+        lsl     t1, d0, #32;                                        \
+        add     d0, t1, d0;                                         \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
 /* bits since by design it will cancel anyway; we only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
-                lsr     t1, d0, #32;                                        \
-                subs    t1, t1, d0;                                         \
-                sbc     t2, d0, xzr;                                        \
+        lsr     t1, d0, #32;                                        \
+        subs    t1, t1, d0;                                         \
+        sbc     t2, d0, xzr;                                        \
 /* Now select in t1 the field to subtract from d1                       */  \
-                extr    t1, t2, t1, #32;                                    \
+        extr    t1, t2, t1, #32;                                    \
 /* And now get the terms to subtract from d2 and d3                     */  \
-                lsr     t2, t2, #32;                                        \
-                adds    t2, t2, d0;                                         \
-                adc     t3, xzr, xzr;                                       \
+        lsr     t2, t2, #32;                                        \
+        adds    t2, t2, d0;                                         \
+        adc     t3, xzr, xzr;                                       \
 /* Do the subtraction of that portion                                   */  \
-                subs    d1, d1, t1;                                         \
-                sbcs    d2, d2, t2;                                         \
-                sbcs    d3, d3, t3;                                         \
-                sbcs    d4, d4, xzr;                                        \
-                sbcs    d5, d5, xzr;                                        \
+        subs    d1, d1, t1;                                         \
+        sbcs    d2, d2, t2;                                         \
+        sbcs    d3, d3, t3;                                         \
+        sbcs    d4, d4, xzr;                                        \
+        sbcs    d5, d5, xzr;                                        \
 /* Now effectively add 2^384 * w by taking d0 as the input for last sbc */  \
-                sbc     d6, d0, xzr
+        sbc     d6, d0, xzr
 
 // Input parameters
 
@@ -99,67 +91,66 @@
 #define v x9
 #define w x10
 
-bignum_deamont_p384:
-_bignum_deamont_p384:
-bignum_deamont_p384_alt:
-_bignum_deamont_p384_alt:
+S2N_BN_SYMBOL(bignum_deamont_p384):
+
+S2N_BN_SYMBOL(bignum_deamont_p384_alt):
 
 // Set up an initial window with the input x and an extra leading zero
 
-                ldp     d0, d1, [x]
-                ldp     d2, d3, [x, #16]
-                ldp     d4, d5, [x, #32]
+        ldp     d0, d1, [x]
+        ldp     d2, d3, [x, #16]
+        ldp     d4, d5, [x, #32]
 
 // Systematically scroll left doing 1-step reductions
 
-                montreds(d0,d5,d4,d3,d2,d1,d0, u,v,w)
+        montreds(d0,d5,d4,d3,d2,d1,d0, u,v,w)
 
-                montreds(d1,d0,d5,d4,d3,d2,d1, u,v,w)
+        montreds(d1,d0,d5,d4,d3,d2,d1, u,v,w)
 
-                montreds(d2,d1,d0,d5,d4,d3,d2, u,v,w)
+        montreds(d2,d1,d0,d5,d4,d3,d2, u,v,w)
 
-                montreds(d3,d2,d1,d0,d5,d4,d3, u,v,w)
+        montreds(d3,d2,d1,d0,d5,d4,d3, u,v,w)
 
-                montreds(d4,d3,d2,d1,d0,d5,d4, u,v,w)
+        montreds(d4,d3,d2,d1,d0,d5,d4, u,v,w)
 
-                montreds(d5,d4,d3,d2,d1,d0,d5, u,v,w)
+        montreds(d5,d4,d3,d2,d1,d0,d5, u,v,w)
 
 // Now compare end result in [d5;d4;d3;d2;d1;d0] = dd with p_384 by *adding*
 // 2^384 - p_384 = [0;0;0;w;v;u]. This will set CF if
 // dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384
 
-                mov     u, #0xffffffff00000001
-                mov     v, #0x00000000ffffffff
-                mov     w, #0x0000000000000001
+        mov     u, #0xffffffff00000001
+        mov     v, #0x00000000ffffffff
+        mov     w, #0x0000000000000001
 
-                adds    xzr, d0, u
-                adcs    xzr, d1, v
-                adcs    xzr, d2, w
-                adcs    xzr, d3, xzr
-                adcs    xzr, d4, xzr
-                adcs    xzr, d5, xzr
+        adds    xzr, d0, u
+        adcs    xzr, d1, v
+        adcs    xzr, d2, w
+        adcs    xzr, d3, xzr
+        adcs    xzr, d4, xzr
+        adcs    xzr, d5, xzr
 
 // Convert the condition dd >= p_384 into a bitmask in w and do a masked
 // subtraction of p_384, via a masked addition of 2^384 - p_384:
 
-                csetm   w, cs
-                and     u, u, w
-                adds    d0, d0, u
-                and     v, v, w
-                adcs    d1, d1, v
-                and     w, w, #1
-                adcs    d2, d2, w
-                adcs    d3, d3, xzr
-                adcs    d4, d4, xzr
-                adc     d5, d5, xzr
+        csetm   w, cs
+        and     u, u, w
+        adds    d0, d0, u
+        and     v, v, w
+        adcs    d1, d1, v
+        and     w, w, #1
+        adcs    d2, d2, w
+        adcs    d3, d3, xzr
+        adcs    d4, d4, xzr
+        adc     d5, d5, xzr
 
 // Store it back
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
@@ -26,10 +26,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_deamont_p384
-        .globl  _bignum_deamont_p384
-        .globl  bignum_deamont_p384_alt
-        .globl  _bignum_deamont_p384_alt
+        .globl bignum_deamont_p384
+        .private_extern bignum_deamont_p384
+
+        .globl _bignum_deamont_p384
+        .private_extern _bignum_deamont_p384
+
+        .globl bignum_deamont_p384_alt
+        .private_extern bignum_deamont_p384_alt
+
+        .globl _bignum_deamont_p384_alt
+        .private_extern _bignum_deamont_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
@@ -25,18 +25,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_deamont_p384
-        .private_extern bignum_deamont_p384
+        S2N_ASM_HIDDEN(bignum_deamont_p384)
 
         .globl _bignum_deamont_p384
-        .private_extern _bignum_deamont_p384
+        S2N_ASM_HIDDEN(_bignum_deamont_p384)
 
         .globl bignum_deamont_p384_alt
-        .private_extern bignum_deamont_p384_alt
+        S2N_ASM_HIDDEN(bignum_deamont_p384_alt)
 
         .globl _bignum_deamont_p384_alt
-        .private_extern _bignum_deamont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_deamont_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
@@ -25,20 +25,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_demont_p384
-        S2N_ASM_HIDDEN(bignum_demont_p384)
-
-        .globl _bignum_demont_p384
-        S2N_ASM_HIDDEN(_bignum_demont_p384)
-
-        .globl bignum_demont_p384_alt
-        S2N_ASM_HIDDEN(bignum_demont_p384_alt)
-
-        .globl _bignum_demont_p384_alt
-        S2N_ASM_HIDDEN(_bignum_demont_p384_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384_alt)
         .text
         .balign 4
 
@@ -55,29 +47,29 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Recycle d0 (which we know gets implicitly cancelled) to store it     */  \
-                lsl     t1, d0, #32;                                        \
-                add     d0, t1, d0;                                         \
+        lsl     t1, d0, #32;                                        \
+        add     d0, t1, d0;                                         \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
 /* bits since by design it will cancel anyway; we only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
-                lsr     t1, d0, #32;                                        \
-                subs    t1, t1, d0;                                         \
-                sbc     t2, d0, xzr;                                        \
+        lsr     t1, d0, #32;                                        \
+        subs    t1, t1, d0;                                         \
+        sbc     t2, d0, xzr;                                        \
 /* Now select in t1 the field to subtract from d1                       */  \
-                extr    t1, t2, t1, #32;                                    \
+        extr    t1, t2, t1, #32;                                    \
 /* And now get the terms to subtract from d2 and d3                     */  \
-                lsr     t2, t2, #32;                                        \
-                adds    t2, t2, d0;                                         \
-                adc     t3, xzr, xzr;                                       \
+        lsr     t2, t2, #32;                                        \
+        adds    t2, t2, d0;                                         \
+        adc     t3, xzr, xzr;                                       \
 /* Do the subtraction of that portion                                   */  \
-                subs    d1, d1, t1;                                         \
-                sbcs    d2, d2, t2;                                         \
-                sbcs    d3, d3, t3;                                         \
-                sbcs    d4, d4, xzr;                                        \
-                sbcs    d5, d5, xzr;                                        \
+        subs    d1, d1, t1;                                         \
+        sbcs    d2, d2, t2;                                         \
+        sbcs    d3, d3, t3;                                         \
+        sbcs    d4, d4, xzr;                                        \
+        sbcs    d5, d5, xzr;                                        \
 /* Now effectively add 2^384 * w by taking d0 as the input for last sbc */  \
-                sbc     d6, d0, xzr
+        sbc     d6, d0, xzr
 
 // Input parameters
 
@@ -99,38 +91,37 @@
 #define v x9
 #define w x10
 
-bignum_demont_p384:
-_bignum_demont_p384:
-bignum_demont_p384_alt:
-_bignum_demont_p384_alt:
+S2N_BN_SYMBOL(bignum_demont_p384):
+
+S2N_BN_SYMBOL(bignum_demont_p384_alt):
 
 // Set up an initial window with the input x and an extra leading zero
 
-                ldp     d0, d1, [x]
-                ldp     d2, d3, [x, #16]
-                ldp     d4, d5, [x, #32]
+        ldp     d0, d1, [x]
+        ldp     d2, d3, [x, #16]
+        ldp     d4, d5, [x, #32]
 
 // Systematically scroll left doing 1-step reductions
 
-                montreds(d0,d5,d4,d3,d2,d1,d0, u,v,w)
+        montreds(d0,d5,d4,d3,d2,d1,d0, u,v,w)
 
-                montreds(d1,d0,d5,d4,d3,d2,d1, u,v,w)
+        montreds(d1,d0,d5,d4,d3,d2,d1, u,v,w)
 
-                montreds(d2,d1,d0,d5,d4,d3,d2, u,v,w)
+        montreds(d2,d1,d0,d5,d4,d3,d2, u,v,w)
 
-                montreds(d3,d2,d1,d0,d5,d4,d3, u,v,w)
+        montreds(d3,d2,d1,d0,d5,d4,d3, u,v,w)
 
-                montreds(d4,d3,d2,d1,d0,d5,d4, u,v,w)
+        montreds(d4,d3,d2,d1,d0,d5,d4, u,v,w)
 
-                montreds(d5,d4,d3,d2,d1,d0,d5, u,v,w)
+        montreds(d5,d4,d3,d2,d1,d0,d5, u,v,w)
 
 // This is already our answer with no correction needed
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
@@ -25,18 +25,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_demont_p384
-        .private_extern bignum_demont_p384
+        S2N_ASM_HIDDEN(bignum_demont_p384)
 
         .globl _bignum_demont_p384
-        .private_extern _bignum_demont_p384
+        S2N_ASM_HIDDEN(_bignum_demont_p384)
 
         .globl bignum_demont_p384_alt
-        .private_extern bignum_demont_p384_alt
+        S2N_ASM_HIDDEN(bignum_demont_p384_alt)
 
         .globl _bignum_demont_p384_alt
-        .private_extern _bignum_demont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_demont_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
@@ -26,10 +26,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_demont_p384
-        .globl  _bignum_demont_p384
-        .globl  bignum_demont_p384_alt
-        .globl  _bignum_demont_p384_alt
+        .globl bignum_demont_p384
+        .private_extern bignum_demont_p384
+
+        .globl _bignum_demont_p384
+        .private_extern _bignum_demont_p384
+
+        .globl bignum_demont_p384_alt
+        .private_extern bignum_demont_p384_alt
+
+        .globl _bignum_demont_p384_alt
+        .private_extern _bignum_demont_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_double_p384
-        .globl  _bignum_double_p384
+        .globl bignum_double_p384
+        .private_extern bignum_double_p384
+
+        .globl _bignum_double_p384
+        .private_extern _bignum_double_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_double_p384
-        S2N_ASM_HIDDEN(bignum_double_p384)
-
-        .globl _bignum_double_p384
-        S2N_ASM_HIDDEN(_bignum_double_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p384)
         .text
         .balign 4
 
@@ -50,54 +46,53 @@
 #define n5 x14
 
 
-bignum_double_p384:
-_bignum_double_p384:
+S2N_BN_SYMBOL(bignum_double_p384):
 
 // Double the input number as 2 * x = c + [d5; d4; d3; d2; d1; d0]
 // It's worth considering doing this with extr...63 instead
 
-                ldp     d0, d1, [x]
-                ldp     d2, d3, [x, #16]
-                ldp     d4, d5, [x, #32]
-                adds    d0, d0, d0
-                adcs    d1, d1, d1
-                adcs    d2, d2, d2
-                adcs    d3, d3, d3
-                adcs    d4, d4, d4
-                adcs    d5, d5, d5
-                adc     c, xzr, xzr
+        ldp     d0, d1, [x]
+        ldp     d2, d3, [x, #16]
+        ldp     d4, d5, [x, #32]
+        adds    d0, d0, d0
+        adcs    d1, d1, d1
+        adcs    d2, d2, d2
+        adcs    d3, d3, d3
+        adcs    d4, d4, d4
+        adcs    d5, d5, d5
+        adc     c, xzr, xzr
 
 // Subtract p_384 to give 2 * x - p_384 = c + [n5; n4; n3; n2; n1; n0]
 
-                mov     n0, #0x00000000ffffffff
-                subs    n0, d0, n0
-                mov     n1, #0xffffffff00000000
-                sbcs    n1, d1, n1
-                mov     n2, #0xfffffffffffffffe
-                sbcs    n2, d2, n2
-                adcs    n3, d3, xzr
-                adcs    n4, d4, xzr
-                adcs    n5, d5, xzr
-                sbcs    c, c, xzr
+        mov     n0, #0x00000000ffffffff
+        subs    n0, d0, n0
+        mov     n1, #0xffffffff00000000
+        sbcs    n1, d1, n1
+        mov     n2, #0xfffffffffffffffe
+        sbcs    n2, d2, n2
+        adcs    n3, d3, xzr
+        adcs    n4, d4, xzr
+        adcs    n5, d5, xzr
+        sbcs    c, c, xzr
 
 // Now CF is set (because of inversion) if 2 * x >= p_384, in which case the
 // correct result is [n5; n4; n3; n2; n1; n0], otherwise
 // [d5; d4; d3; d2; d1; d0]
 
-                csel    d0, d0, n0, cc
-                csel    d1, d1, n1, cc
-                csel    d2, d2, n2, cc
-                csel    d3, d3, n3, cc
-                csel    d4, d4, n4, cc
-                csel    d5, d5, n5, cc
+        csel    d0, d0, n0, cc
+        csel    d1, d1, n1, cc
+        csel    d2, d2, n2, cc
+        csel    d3, d3, n3, cc
+        csel    d4, d4, n4, cc
+        csel    d5, d5, n5, cc
 
 // Store the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_double_p384
-        .private_extern bignum_double_p384
+        S2N_ASM_HIDDEN(bignum_double_p384)
 
         .globl _bignum_double_p384
-        .private_extern _bignum_double_p384
+        S2N_ASM_HIDDEN(_bignum_double_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_half_p384
-        .private_extern bignum_half_p384
+        S2N_ASM_HIDDEN(bignum_half_p384)
 
         .globl _bignum_half_p384
-        .private_extern _bignum_half_p384
+        S2N_ASM_HIDDEN(_bignum_half_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_half_p384
-        S2N_ASM_HIDDEN(bignum_half_p384)
-
-        .globl _bignum_half_p384
-        S2N_ASM_HIDDEN(_bignum_half_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p384)
         .text
         .balign 4
 
@@ -48,54 +44,53 @@
 #define n x11
 
 
-bignum_half_p384:
-_bignum_half_p384:
+S2N_BN_SYMBOL(bignum_half_p384):
 
 // Load the 4 digits of x
 
-                ldp     d0, d1, [x]
-                ldp     d2, d3, [x, #16]
-                ldp     d4, d5, [x, #32]
+        ldp     d0, d1, [x]
+        ldp     d2, d3, [x, #16]
+        ldp     d4, d5, [x, #32]
 
 // Get a bitmask corresponding to the lowest bit of the input
 
-                and     m, d0, #1
-                neg     m, m
+        and     m, d0, #1
+        neg     m, m
 
 // Do a masked addition of p_384, catching carry in a 7th word
 
-                mov     n, #0x00000000ffffffff
-                and     n, n, m
-                adds    d0, d0, n
-                mov     n, #0xffffffff00000000
-                and     n, n, m
-                adcs    d1, d1, n
-                mov     n, #0xfffffffffffffffe
-                and     n, n, m
-                adcs    d2, d2, n
-                adcs    d3, d3, m
-                adcs    d4, d4, m
-                adcs    d5, d5, m
-                adc     d6, xzr, xzr
+        mov     n, #0x00000000ffffffff
+        and     n, n, m
+        adds    d0, d0, n
+        mov     n, #0xffffffff00000000
+        and     n, n, m
+        adcs    d1, d1, n
+        mov     n, #0xfffffffffffffffe
+        and     n, n, m
+        adcs    d2, d2, n
+        adcs    d3, d3, m
+        adcs    d4, d4, m
+        adcs    d5, d5, m
+        adc     d6, xzr, xzr
 
 // Now shift that sum right one place
 
-                extr    d0, d1, d0, #1
-                extr    d1, d2, d1, #1
-                extr    d2, d3, d2, #1
-                extr    d3, d4, d3, #1
-                extr    d4, d5, d4, #1
-                extr    d5, d6, d5, #1
+        extr    d0, d1, d0, #1
+        extr    d1, d2, d1, #1
+        extr    d2, d3, d2, #1
+        extr    d3, d4, d3, #1
+        extr    d4, d5, d4, #1
+        extr    d5, d6, d5, #1
 
 // Store back
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
 
 // Return
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_half_p384
-        .globl  _bignum_half_p384
+        .globl bignum_half_p384
+        .private_extern bignum_half_p384
+
+        .globl _bignum_half_p384
+        .private_extern _bignum_half_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
@@ -36,12 +36,24 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_littleendian_6
-        .globl  _bignum_littleendian_6
-        .globl  bignum_fromlebytes_6
-        .globl  _bignum_fromlebytes_6
-        .globl  bignum_tolebytes_6
-        .globl  _bignum_tolebytes_6
+        .globl bignum_littleendian_6
+        .private_extern bignum_littleendian_6
+
+        .globl _bignum_littleendian_6
+        .private_extern _bignum_littleendian_6
+
+        .globl bignum_fromlebytes_6
+        .private_extern bignum_fromlebytes_6
+
+        .globl _bignum_fromlebytes_6
+        .private_extern _bignum_fromlebytes_6
+
+        .globl bignum_tolebytes_6
+        .private_extern bignum_tolebytes_6
+
+        .globl _bignum_tolebytes_6
+        .private_extern _bignum_tolebytes_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
@@ -54,10 +54,9 @@
 #define dshort w2
 #define a x3
 
-S2N_BN_SYMBOL(bignum_bignum_littleendian_6):
-
-S2N_BN_SYMBOL(bignum_bignum_fromlebytes_6):
-S2N_BN_SYMBOL(bignum_bignum_tolebytes_6):
+S2N_BN_SYMBOL(bignum_littleendian_6):
+S2N_BN_SYMBOL(bignum_fromlebytes_6):
+S2N_BN_SYMBOL(bignum_tolebytes_6):
 
 // word 0
 

--- a/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
@@ -35,25 +35,14 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_littleendian_6
-        S2N_ASM_HIDDEN(bignum_littleendian_6)
-
-        .globl _bignum_littleendian_6
-        S2N_ASM_HIDDEN(_bignum_littleendian_6)
-
-        .globl bignum_fromlebytes_6
-        S2N_ASM_HIDDEN(bignum_fromlebytes_6)
-
-        .globl _bignum_fromlebytes_6
-        S2N_ASM_HIDDEN(_bignum_fromlebytes_6)
-
-        .globl bignum_tolebytes_6
-        S2N_ASM_HIDDEN(bignum_tolebytes_6)
-
-        .globl _bignum_tolebytes_6
-        S2N_ASM_HIDDEN(_bignum_tolebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_littleendian_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_littleendian_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_fromlebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tolebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tolebytes_6)
 
         .text
         .balign 4
@@ -65,134 +54,132 @@
 #define dshort w2
 #define a x3
 
-bignum_littleendian_6:
-_bignum_littleendian_6:
-bignum_fromlebytes_6:
-_bignum_fromlebytes_6:
-bignum_tolebytes_6:
-_bignum_tolebytes_6:
+S2N_BN_SYMBOL(bignum_bignum_littleendian_6):
+
+S2N_BN_SYMBOL(bignum_bignum_fromlebytes_6):
+S2N_BN_SYMBOL(bignum_bignum_tolebytes_6):
 
 // word 0
 
-                ldrb    dshort, [x]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #1]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #2]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #3]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #4]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #5]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #6]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #7]
-                extr    a, d, a, #8
-                str     a, [z]
+        ldrb    dshort, [x]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #1]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #2]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #3]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #4]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #5]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #6]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #7]
+        extr    a, d, a, #8
+        str     a, [z]
 
 // word 1
 
-                ldrb    dshort, [x, #8]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #9]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #10]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #11]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #12]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #13]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #14]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #15]
-                extr    a, d, a, #8
-                str     a, [z, #8]
+        ldrb    dshort, [x, #8]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #9]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #10]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #11]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #12]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #13]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #14]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #15]
+        extr    a, d, a, #8
+        str     a, [z, #8]
 
 // word 2
 
-                ldrb    dshort, [x, #16]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #17]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #18]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #19]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #20]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #21]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #22]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #23]
-                extr    a, d, a, #8
-                str     a, [z, #16]
+        ldrb    dshort, [x, #16]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #17]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #18]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #19]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #20]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #21]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #22]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #23]
+        extr    a, d, a, #8
+        str     a, [z, #16]
 
 // word 3
 
-                ldrb    dshort, [x, #24]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #25]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #26]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #27]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #28]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #29]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #30]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #31]
-                extr    a, d, a, #8
-                str     a, [z, #24]
+        ldrb    dshort, [x, #24]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #25]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #26]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #27]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #28]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #29]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #30]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #31]
+        extr    a, d, a, #8
+        str     a, [z, #24]
 
 // word 4
 
-                ldrb    dshort, [x, #32]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #33]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #34]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #35]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #36]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #37]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #38]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #39]
-                extr    a, d, a, #8
-                str     a, [z, #32]
+        ldrb    dshort, [x, #32]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #33]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #34]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #35]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #36]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #37]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #38]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #39]
+        extr    a, d, a, #8
+        str     a, [z, #32]
 
 // word 5
 
-                ldrb    dshort, [x, #40]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #41]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #42]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #43]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #44]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #45]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #46]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #47]
-                extr    a, d, a, #8
-                str     a, [z, #40]
+        ldrb    dshort, [x, #40]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #41]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #42]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #43]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #44]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #45]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #46]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #47]
+        extr    a, d, a, #8
+        str     a, [z, #40]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
@@ -35,24 +35,25 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_littleendian_6
-        .private_extern bignum_littleendian_6
+        S2N_ASM_HIDDEN(bignum_littleendian_6)
 
         .globl _bignum_littleendian_6
-        .private_extern _bignum_littleendian_6
+        S2N_ASM_HIDDEN(_bignum_littleendian_6)
 
         .globl bignum_fromlebytes_6
-        .private_extern bignum_fromlebytes_6
+        S2N_ASM_HIDDEN(bignum_fromlebytes_6)
 
         .globl _bignum_fromlebytes_6
-        .private_extern _bignum_fromlebytes_6
+        S2N_ASM_HIDDEN(_bignum_fromlebytes_6)
 
         .globl bignum_tolebytes_6
-        .private_extern bignum_tolebytes_6
+        S2N_ASM_HIDDEN(bignum_tolebytes_6)
 
         .globl _bignum_tolebytes_6
-        .private_extern _bignum_tolebytes_6
+        S2N_ASM_HIDDEN(_bignum_tolebytes_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
@@ -24,18 +24,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n384
-        .private_extern bignum_mod_n384
+        S2N_ASM_HIDDEN(bignum_mod_n384)
 
         .globl _bignum_mod_n384
-        .private_extern _bignum_mod_n384
+        S2N_ASM_HIDDEN(_bignum_mod_n384)
 
         .globl bignum_mod_n384_alt
-        .private_extern bignum_mod_n384_alt
+        S2N_ASM_HIDDEN(bignum_mod_n384_alt)
 
         .globl _bignum_mod_n384_alt
-        .private_extern _bignum_mod_n384_alt
+        S2N_ASM_HIDDEN(_bignum_mod_n384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
@@ -24,20 +24,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_mod_n384
-        S2N_ASM_HIDDEN(bignum_mod_n384)
-
-        .globl _bignum_mod_n384
-        S2N_ASM_HIDDEN(_bignum_mod_n384)
-
-        .globl bignum_mod_n384_alt
-        S2N_ASM_HIDDEN(bignum_mod_n384_alt)
-
-        .globl _bignum_mod_n384_alt
-        S2N_ASM_HIDDEN(_bignum_mod_n384_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384_alt)
         .text
         .balign 4
 
@@ -79,145 +71,144 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                              \
-                movz    nn, n0;                                             \
-                movk    nn, n1, lsl #16;                                    \
-                movk    nn, n2, lsl #32;                                    \
-                movk    nn, n3, lsl #48
+        movz    nn, n0;                                             \
+        movk    nn, n1, lsl #16;                                    \
+        movk    nn, n2, lsl #32;                                    \
+        movk    nn, n3, lsl #48
 
-bignum_mod_n384:
-_bignum_mod_n384:
-bignum_mod_n384_alt:
-_bignum_mod_n384_alt:
+S2N_BN_SYMBOL(bignum_mod_n384):
+
+S2N_BN_SYMBOL(bignum_mod_n384_alt):
 
 // If the input is already <= 5 words long, go to a trivial "copy" path
 
-                cmp     k, #6
-                bcc     short
+        cmp     k, #6
+        bcc     short
 
 // Otherwise load the top 6 digits (top-down) and reduce k by 6
 
-                sub     k, k, #6
-                lsl     t0, k, #3
-                add     t0, t0, x
-                ldp     m4, m5, [t0, #32]
-                ldp     m2, m3, [t0, #16]
-                ldp     m0, m1, [t0]
+        sub     k, k, #6
+        lsl     t0, k, #3
+        add     t0, t0, x
+        ldp     m4, m5, [t0, #32]
+        ldp     m2, m3, [t0, #16]
+        ldp     m0, m1, [t0]
 
 // Load the complicated three words of 2^384 - n_384 = [0; 0; 0; n2; n1; n0]
 
-                movbig( n0, #0x1313, #0xe695, #0x333a, #0xd68d)
-                movbig( n1, #0xa7e5, #0xf24d, #0xb74f, #0x5885)
-                movbig( n2, #0x389c, #0xb27e, #0x0bc8, #0xd220)
+        movbig( n0, #0x1313, #0xe695, #0x333a, #0xd68d)
+        movbig( n1, #0xa7e5, #0xf24d, #0xb74f, #0x5885)
+        movbig( n2, #0x389c, #0xb27e, #0x0bc8, #0xd220)
 
 // Reduce the top 6 digits mod n_384 (a conditional subtraction of n_384)
 
-                adds    t0, m0, n0
-                adcs    t1, m1, n1
-                adcs    t2, m2, n2
-                adcs    t3, m3, xzr
-                adcs    t4, m4, xzr
-                adcs    t5, m5, xzr
-                csel    m0, m0, t0, cc
-                csel    m1, m1, t1, cc
-                csel    m2, m2, t2, cc
-                csel    m3, m3, t3, cc
-                csel    m4, m4, t4, cc
-                csel    m5, m5, t5, cc
+        adds    t0, m0, n0
+        adcs    t1, m1, n1
+        adcs    t2, m2, n2
+        adcs    t3, m3, xzr
+        adcs    t4, m4, xzr
+        adcs    t5, m5, xzr
+        csel    m0, m0, t0, cc
+        csel    m1, m1, t1, cc
+        csel    m2, m2, t2, cc
+        csel    m3, m3, t3, cc
+        csel    m4, m4, t4, cc
+        csel    m5, m5, t5, cc
 
 // Now do (k-6) iterations of 7->6 word modular reduction
 
-                cbz     k, writeback
+        cbz     k, writeback
 loop:
 
 // Compute q = min (m5 + 1) (2^64 - 1)
 
-                adds    q, m5, #1
-                csetm   t0, cs
-                orr     q, q, t0
+        adds    q, m5, #1
+        csetm   t0, cs
+        orr     q, q, t0
 
 // [t3;t2;t1;t0] = q * (2^384 - n_384)
 
-                mul     t0, n0, q
-                mul     t1, n1, q
-                mul     t2, n2, q
+        mul     t0, n0, q
+        mul     t1, n1, q
+        mul     t2, n2, q
 
-                umulh   t3, n0, q
-                adds    t1, t1, t3
-                umulh   t3, n1, q
-                adcs    t2, t2, t3
-                umulh   t3, n2, q
-                adc     t3, xzr, t3
+        umulh   t3, n0, q
+        adds    t1, t1, t3
+        umulh   t3, n1, q
+        adcs    t2, t2, t3
+        umulh   t3, n2, q
+        adc     t3, xzr, t3
 
 // Decrement k and load the next digit
 
-                sub     k, k, #1
-                ldr     d, [x, k, lsl #3]
+        sub     k, k, #1
+        ldr     d, [x, k, lsl #3]
 
 // Compensate for 2^384 * q
 
-                sub     m5, m5, q
+        sub     m5, m5, q
 
 // [m5;m4;t4;t3;t2;t1;t0] = [m5;m4;m3;m2;m1;m0;d] - q * n_384
 
-                adds    t0, d, t0
-                adcs    t1, m0, t1
-                adcs    t2, m1, t2
-                adcs    t3, m2, t3
-                adcs    t4, m3, xzr
-                adcs    m4, m4, xzr
-                adc     m5, m5, xzr
+        adds    t0, d, t0
+        adcs    t1, m0, t1
+        adcs    t2, m1, t2
+        adcs    t3, m2, t3
+        adcs    t4, m3, xzr
+        adcs    m4, m4, xzr
+        adc     m5, m5, xzr
 
 // Now our top word m5 is either zero or all 1s. Use it for a masked
 // addition of n_384, which we can do by a *subtraction* of
 // 2^384 - n_384 from our portion, re-using the constants
 
-                and     t, m5, n0
-                subs    m0, t0, t
-                and     t, m5, n1
-                sbcs    m1, t1, t
-                and     t, m5, n2
-                sbcs    m2, t2, t
-                sbcs    m3, t3, xzr
-                sbcs    t, t4, xzr
-                sbc     m5, m4, xzr
-                mov     m4, t
+        and     t, m5, n0
+        subs    m0, t0, t
+        and     t, m5, n1
+        sbcs    m1, t1, t
+        and     t, m5, n2
+        sbcs    m2, t2, t
+        sbcs    m3, t3, xzr
+        sbcs    t, t4, xzr
+        sbc     m5, m4, xzr
+        mov     m4, t
 
-                cbnz    k, loop
+        cbnz    k, loop
 
 // Finally write back [m5;m4;m3;m2;m1;m0] and return
 
 writeback:
-                stp     m0, m1, [z]
-                stp     m2, m3, [z, #16]
-                stp     m4, m5, [z, #32]
+        stp     m0, m1, [z]
+        stp     m2, m3, [z, #16]
+        stp     m4, m5, [z, #32]
 
-                ret
+        ret
 
 // Short case: just copy the input with zero-padding
 
 short:
-                mov     m0, xzr
-                mov     m1, xzr
-                mov     m2, xzr
-                mov     m3, xzr
-                mov     m4, xzr
-                mov     m5, xzr
+        mov     m0, xzr
+        mov     m1, xzr
+        mov     m2, xzr
+        mov     m3, xzr
+        mov     m4, xzr
+        mov     m5, xzr
 
-                cbz     k, writeback
-                ldr     m0, [x]
-                subs    k, k, #1
-                beq     writeback
-                ldr     m1, [x, #8]
-                subs    k, k, #1
-                beq     writeback
-                ldr     m2, [x, #16]
-                subs    k, k, #1
-                beq     writeback
-                ldr     m3, [x, #24]
-                subs    k, k, #1
-                beq     writeback
-                ldr     m4, [x, #32]
-                b       writeback
+        cbz     k, writeback
+        ldr     m0, [x]
+        subs    k, k, #1
+        beq     writeback
+        ldr     m1, [x, #8]
+        subs    k, k, #1
+        beq     writeback
+        ldr     m2, [x, #16]
+        subs    k, k, #1
+        beq     writeback
+        ldr     m3, [x, #24]
+        subs    k, k, #1
+        beq     writeback
+        ldr     m4, [x, #32]
+        b       writeback
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
@@ -25,10 +25,18 @@
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_n384
-        .globl  _bignum_mod_n384
-        .globl  bignum_mod_n384_alt
-        .globl  _bignum_mod_n384_alt
+        .globl bignum_mod_n384
+        .private_extern bignum_mod_n384
+
+        .globl _bignum_mod_n384
+        .private_extern _bignum_mod_n384
+
+        .globl bignum_mod_n384_alt
+        .private_extern bignum_mod_n384_alt
+
+        .globl _bignum_mod_n384_alt
+        .private_extern _bignum_mod_n384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
@@ -25,8 +25,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_n384_6
-        .globl  _bignum_mod_n384_6
+        .globl bignum_mod_n384_6
+        .private_extern bignum_mod_n384_6
+
+        .globl _bignum_mod_n384_6
+        .private_extern _bignum_mod_n384_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
@@ -24,14 +24,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_mod_n384_6
-        S2N_ASM_HIDDEN(bignum_mod_n384_6)
-
-        .globl _bignum_mod_n384_6
-        S2N_ASM_HIDDEN(_bignum_mod_n384_6)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384_6)
         .text
         .balign 4
 
@@ -53,53 +49,52 @@
 #define d5 x13
 
 #define movbig(nn,n3,n2,n1,n0)                                              \
-                movz    nn, n0;                                             \
-                movk    nn, n1, lsl #16;                                    \
-                movk    nn, n2, lsl #32;                                    \
-                movk    nn, n3, lsl #48
+        movz    nn, n0;                                             \
+        movk    nn, n1, lsl #16;                                    \
+        movk    nn, n2, lsl #32;                                    \
+        movk    nn, n3, lsl #48
 
-bignum_mod_n384_6:
-_bignum_mod_n384_6:
+S2N_BN_SYMBOL(bignum_mod_n384_6):
 
 // Load the complicated lower three words of n_384
 
-                movbig( n0, #0xecec, #0x196a, #0xccc5, #0x2973)
-                movbig( n1, #0x581a, #0x0db2, #0x48b0, #0xa77a)
-                movbig( n2, #0xc763, #0x4d81, #0xf437, #0x2ddf)
+        movbig( n0, #0xecec, #0x196a, #0xccc5, #0x2973)
+        movbig( n1, #0x581a, #0x0db2, #0x48b0, #0xa77a)
+        movbig( n2, #0xc763, #0x4d81, #0xf437, #0x2ddf)
 
 // Load the input number
 
-                ldp     d0, d1, [x]
-                ldp     d2, d3, [x, #16]
-                ldp     d4, d5, [x, #32]
+        ldp     d0, d1, [x]
+        ldp     d2, d3, [x, #16]
+        ldp     d4, d5, [x, #32]
 
 // Do the subtraction. Since the top three words of n_384 are all 1s
 // we can devolve the top to adding 0, thanks to the inverted carry.
 
-                subs    n0, d0, n0
-                sbcs    n1, d1, n1
-                sbcs    n2, d2, n2
-                adcs    n3, d3, xzr
-                adcs    n4, d4, xzr
-                adcs    n5, d5, xzr
+        subs    n0, d0, n0
+        sbcs    n1, d1, n1
+        sbcs    n2, d2, n2
+        adcs    n3, d3, xzr
+        adcs    n4, d4, xzr
+        adcs    n5, d5, xzr
 
 // Now if the carry is *clear* (inversion at work) the subtraction carried
 // and hence we should have done nothing, so we reset each n_i = d_i
 
-                csel    n0, d0, n0, cc
-                csel    n1, d1, n1, cc
-                csel    n2, d2, n2, cc
-                csel    n3, d3, n3, cc
-                csel    n4, d4, n4, cc
-                csel    n5, d5, n5, cc
+        csel    n0, d0, n0, cc
+        csel    n1, d1, n1, cc
+        csel    n2, d2, n2, cc
+        csel    n3, d3, n3, cc
+        csel    n4, d4, n4, cc
+        csel    n5, d5, n5, cc
 
 // Store the end result
 
-                stp     n0, n1, [z]
-                stp     n2, n3, [z, #16]
-                stp     n4, n5, [z, #32]
+        stp     n0, n1, [z]
+        stp     n2, n3, [z, #16]
+        stp     n4, n5, [z, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
@@ -24,12 +24,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n384_6
-        .private_extern bignum_mod_n384_6
+        S2N_ASM_HIDDEN(bignum_mod_n384_6)
 
         .globl _bignum_mod_n384_6
-        .private_extern _bignum_mod_n384_6
+        S2N_ASM_HIDDEN(_bignum_mod_n384_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
@@ -23,10 +23,18 @@
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_p384
-        .globl  _bignum_mod_p384
-        .globl  bignum_mod_p384_alt
-        .globl  _bignum_mod_p384_alt
+        .globl bignum_mod_p384
+        .private_extern bignum_mod_p384
+
+        .globl _bignum_mod_p384
+        .private_extern _bignum_mod_p384
+
+        .globl bignum_mod_p384_alt
+        .private_extern bignum_mod_p384_alt
+
+        .globl _bignum_mod_p384_alt
+        .private_extern _bignum_mod_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
@@ -22,18 +22,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p384
-        .private_extern bignum_mod_p384
+        S2N_ASM_HIDDEN(bignum_mod_p384)
 
         .globl _bignum_mod_p384
-        .private_extern _bignum_mod_p384
+        S2N_ASM_HIDDEN(_bignum_mod_p384)
 
         .globl bignum_mod_p384_alt
-        .private_extern bignum_mod_p384_alt
+        S2N_ASM_HIDDEN(bignum_mod_p384_alt)
 
         .globl _bignum_mod_p384_alt
-        .private_extern _bignum_mod_p384_alt
+        S2N_ASM_HIDDEN(_bignum_mod_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
@@ -22,20 +22,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_mod_p384
-        S2N_ASM_HIDDEN(bignum_mod_p384)
-
-        .globl _bignum_mod_p384
-        S2N_ASM_HIDDEN(_bignum_mod_p384)
-
-        .globl bignum_mod_p384_alt
-        S2N_ASM_HIDDEN(bignum_mod_p384_alt)
-
-        .globl _bignum_mod_p384_alt
-        S2N_ASM_HIDDEN(_bignum_mod_p384_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384_alt)
         .text
         .balign 4
 
@@ -62,135 +54,134 @@
 #define n2 x17
 
 
-bignum_mod_p384:
-_bignum_mod_p384:
-bignum_mod_p384_alt:
-_bignum_mod_p384_alt:
+S2N_BN_SYMBOL(bignum_mod_p384):
+
+S2N_BN_SYMBOL(bignum_mod_p384_alt):
 
 // If the input is already <= 5 words long, go to a trivial "copy" path
 
-                cmp     k, #6
-                bcc     short
+        cmp     k, #6
+        bcc     short
 
 // Otherwise load the top 6 digits (top-down) and reduce k by 6
 
-                sub     k, k, #6
-                lsl     t0, k, #3
-                add     t0, t0, x
-                ldp     m4, m5, [t0, #32]
-                ldp     m2, m3, [t0, #16]
-                ldp     m0, m1, [t0]
+        sub     k, k, #6
+        lsl     t0, k, #3
+        add     t0, t0, x
+        ldp     m4, m5, [t0, #32]
+        ldp     m2, m3, [t0, #16]
+        ldp     m0, m1, [t0]
 
 // Load the complicated lower three words of p_384 = [-1;-1;-1;n2;n1;n0]
 
-                mov     n0, #0x00000000ffffffff
-                mov     n1, #0xffffffff00000000
-                mov     n2, #0xfffffffffffffffe
+        mov     n0, #0x00000000ffffffff
+        mov     n1, #0xffffffff00000000
+        mov     n2, #0xfffffffffffffffe
 
 // Reduce the top 6 digits mod p_384 (a conditional subtraction of p_384)
 
-                subs    t0, m0, n0
-                sbcs    t1, m1, n1
-                sbcs    t2, m2, n2
-                adcs    t3, m3, xzr
-                adcs    t4, m4, xzr
-                adcs    t5, m5, xzr
-                csel    m0, m0, t0, cc
-                csel    m1, m1, t1, cc
-                csel    m2, m2, t2, cc
-                csel    m3, m3, t3, cc
-                csel    m4, m4, t4, cc
-                csel    m5, m5, t5, cc
+        subs    t0, m0, n0
+        sbcs    t1, m1, n1
+        sbcs    t2, m2, n2
+        adcs    t3, m3, xzr
+        adcs    t4, m4, xzr
+        adcs    t5, m5, xzr
+        csel    m0, m0, t0, cc
+        csel    m1, m1, t1, cc
+        csel    m2, m2, t2, cc
+        csel    m3, m3, t3, cc
+        csel    m4, m4, t4, cc
+        csel    m5, m5, t5, cc
 
 // Now do (k-6) iterations of 7->6 word modular reduction
 
-                cbz     k, writeback
+        cbz     k, writeback
 loop:
 
 // Decrement k and load the next digit as t5. We now want to reduce
 // [m5;m4;m3;m2;m1;m0;t5] |-> [m5;m4;m3;m2;m1;m0]; the shuffling downwards is
 // absorbed into the various ALU operations
 
-                sub     k, k, #1
-                ldr     t5, [x, k, lsl #3]
+        sub     k, k, #1
+        ldr     t5, [x, k, lsl #3]
 
 // Initial quotient approximation q = min (h + 1) (2^64 - 1)
 
-                adds    m5, m5, #1
-                csetm   t3, cs
-                add     m5, m5, t3
-                orn     n1, xzr, t3
-                sub     t2, m5, #1
-                sub     t1, xzr, m5
+        adds    m5, m5, #1
+        csetm   t3, cs
+        add     m5, m5, t3
+        orn     n1, xzr, t3
+        sub     t2, m5, #1
+        sub     t1, xzr, m5
 
 // Correction term [m5;t2;t1;t0] = q * (2^384 - p_384), using m5 as a temp
 
-                lsl     t0, t1, #32
-                extr    t1, t2, t1, #32
-                lsr     t2, t2, #32
-                adds    t0, t0, m5
-                adcs    t1, t1, xzr
-                adcs    t2, t2, m5
-                adc     m5, xzr, xzr
+        lsl     t0, t1, #32
+        extr    t1, t2, t1, #32
+        lsr     t2, t2, #32
+        adds    t0, t0, m5
+        adcs    t1, t1, xzr
+        adcs    t2, t2, m5
+        adc     m5, xzr, xzr
 
 // Addition to the initial value
 
-                adds    t0, t5, t0
-                adcs    t1, m0, t1
-                adcs    t2, m1, t2
-                adcs    t3, m2, m5
-                adcs    t4, m3, xzr
-                adcs    t5, m4, xzr
-                adc     n1, n1, xzr
+        adds    t0, t5, t0
+        adcs    t1, m0, t1
+        adcs    t2, m1, t2
+        adcs    t3, m2, m5
+        adcs    t4, m3, xzr
+        adcs    t5, m4, xzr
+        adc     n1, n1, xzr
 
 // Use net top of the 7-word answer (now in n1) for masked correction
 
-                and     m5, n0, n1
-                adds    m0, t0, m5
-                eor     m5, m5, n1
-                adcs    m1, t1, m5
-                and     m5, n2, n1
-                adcs    m2, t2, m5
-                adcs    m3, t3, n1
-                adcs    m4, t4, n1
-                adc     m5, t5, n1
+        and     m5, n0, n1
+        adds    m0, t0, m5
+        eor     m5, m5, n1
+        adcs    m1, t1, m5
+        and     m5, n2, n1
+        adcs    m2, t2, m5
+        adcs    m3, t3, n1
+        adcs    m4, t4, n1
+        adc     m5, t5, n1
 
-                cbnz    k, loop
+        cbnz    k, loop
 
 // Finally write back [m5;m4;m3;m2;m1;m0] and return
 
 writeback:
-                stp     m0, m1, [z]
-                stp     m2, m3, [z, #16]
-                stp     m4, m5, [z, #32]
+        stp     m0, m1, [z]
+        stp     m2, m3, [z, #16]
+        stp     m4, m5, [z, #32]
 
-                ret
+        ret
 
 // Short case: just copy the input with zero-padding
 
 short:
-                mov     m0, xzr
-                mov     m1, xzr
-                mov     m2, xzr
-                mov     m3, xzr
-                mov     m4, xzr
-                mov     m5, xzr
+        mov     m0, xzr
+        mov     m1, xzr
+        mov     m2, xzr
+        mov     m3, xzr
+        mov     m4, xzr
+        mov     m5, xzr
 
-                cbz     k, writeback
-                ldr     m0, [x]
-                subs    k, k, #1
-                beq     writeback
-                ldr     m1, [x, #8]
-                subs    k, k, #1
-                beq     writeback
-                ldr     m2, [x, #16]
-                subs    k, k, #1
-                beq     writeback
-                ldr     m3, [x, #24]
-                subs    k, k, #1
-                beq     writeback
-                ldr     m4, [x, #32]
-                b       writeback
+        cbz     k, writeback
+        ldr     m0, [x]
+        subs    k, k, #1
+        beq     writeback
+        ldr     m1, [x, #8]
+        subs    k, k, #1
+        beq     writeback
+        ldr     m2, [x, #16]
+        subs    k, k, #1
+        beq     writeback
+        ldr     m3, [x, #24]
+        subs    k, k, #1
+        beq     writeback
+        ldr     m4, [x, #32]
+        b       writeback
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_mod_p384_6
-        S2N_ASM_HIDDEN(bignum_mod_p384_6)
-
-        .globl _bignum_mod_p384_6
-        S2N_ASM_HIDDEN(_bignum_mod_p384_6)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384_6)
         .text
         .balign 4
 
@@ -51,48 +47,47 @@
 #define d5 x13
 
 
-bignum_mod_p384_6:
-_bignum_mod_p384_6:
+S2N_BN_SYMBOL(bignum_mod_p384_6):
 
 // Load the complicated lower three words of p_384 = [-1;-1;-1;n2;n1;n0]
 
-                mov     n0, #0x00000000ffffffff
-                mov     n1, #0xffffffff00000000
-                mov     n2, #0xfffffffffffffffe
+        mov     n0, #0x00000000ffffffff
+        mov     n1, #0xffffffff00000000
+        mov     n2, #0xfffffffffffffffe
 
 // Load the input number
 
-                ldp     d0, d1, [x]
-                ldp     d2, d3, [x, #16]
-                ldp     d4, d5, [x, #32]
+        ldp     d0, d1, [x]
+        ldp     d2, d3, [x, #16]
+        ldp     d4, d5, [x, #32]
 
 // Do the subtraction. Since the top three words of p_384 are all 1s
 // we can devolve the top to adding 0, thanks to the inverted carry.
 
-                subs    n0, d0, n0
-                sbcs    n1, d1, n1
-                sbcs    n2, d2, n2
-                adcs    n3, d3, xzr
-                adcs    n4, d4, xzr
-                adcs    n5, d5, xzr
+        subs    n0, d0, n0
+        sbcs    n1, d1, n1
+        sbcs    n2, d2, n2
+        adcs    n3, d3, xzr
+        adcs    n4, d4, xzr
+        adcs    n5, d5, xzr
 
 // Now if the carry is *clear* (inversion at work) the subtraction carried
 // and hence we should have done nothing, so we reset each n_i = d_i
 
-                csel    n0, d0, n0, cc
-                csel    n1, d1, n1, cc
-                csel    n2, d2, n2, cc
-                csel    n3, d3, n3, cc
-                csel    n4, d4, n4, cc
-                csel    n5, d5, n5, cc
+        csel    n0, d0, n0, cc
+        csel    n1, d1, n1, cc
+        csel    n2, d2, n2, cc
+        csel    n3, d3, n3, cc
+        csel    n4, d4, n4, cc
+        csel    n5, d5, n5, cc
 
 // Store the end result
 
-                stp     n0, n1, [z]
-                stp     n2, n3, [z, #16]
-                stp     n4, n5, [z, #32]
+        stp     n0, n1, [z]
+        stp     n2, n3, [z, #16]
+        stp     n4, n5, [z, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p384_6
-        .private_extern bignum_mod_p384_6
+        S2N_ASM_HIDDEN(bignum_mod_p384_6)
 
         .globl _bignum_mod_p384_6
-        .private_extern _bignum_mod_p384_6
+        S2N_ASM_HIDDEN(_bignum_mod_p384_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_p384_6
-        .globl  _bignum_mod_p384_6
+        .globl bignum_mod_p384_6
+        .private_extern bignum_mod_p384_6
+
+        .globl _bignum_mod_p384_6
+        .private_extern _bignum_mod_p384_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
@@ -26,12 +26,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p384
-        .private_extern bignum_montmul_p384
+        S2N_ASM_HIDDEN(bignum_montmul_p384)
 
         .globl _bignum_montmul_p384
-        .private_extern _bignum_montmul_p384
+        S2N_ASM_HIDDEN(_bignum_montmul_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
@@ -27,8 +27,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montmul_p384
-        .globl  _bignum_montmul_p384
+        .globl bignum_montmul_p384
+        .private_extern bignum_montmul_p384
+
+        .globl _bignum_montmul_p384
+        .private_extern _bignum_montmul_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
@@ -26,14 +26,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_montmul_p384
-        S2N_ASM_HIDDEN(bignum_montmul_p384)
-
-        .globl _bignum_montmul_p384
-        S2N_ASM_HIDDEN(_bignum_montmul_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p384)
         .text
         .balign 4
 
@@ -68,29 +64,29 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Recycle d0 (which we know gets implicitly cancelled) to store it     */  \
-                lsl     t1, d0, #32;                                        \
-                add     d0, t1, d0;                                         \
+        lsl     t1, d0, #32;                                        \
+        add     d0, t1, d0;                                         \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
 /* bits since by design it will cancel anyway; we only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
-                lsr     t1, d0, #32;                                        \
-                subs    t1, t1, d0;                                         \
-                sbc     t2, d0, xzr;                                        \
+        lsr     t1, d0, #32;                                        \
+        subs    t1, t1, d0;                                         \
+        sbc     t2, d0, xzr;                                        \
 /* Now select in t1 the field to subtract from d1                       */  \
-                extr    t1, t2, t1, #32;                                    \
+        extr    t1, t2, t1, #32;                                    \
 /* And now get the terms to subtract from d2 and d3                     */  \
-                lsr     t2, t2, #32;                                        \
-                adds    t2, t2, d0;                                         \
-                adc     t3, xzr, xzr;                                       \
+        lsr     t2, t2, #32;                                        \
+        adds    t2, t2, d0;                                         \
+        adc     t3, xzr, xzr;                                       \
 /* Do the subtraction of that portion                                   */  \
-                subs    d1, d1, t1;                                         \
-                sbcs    d2, d2, t2;                                         \
-                sbcs    d3, d3, t3;                                         \
-                sbcs    d4, d4, xzr;                                        \
-                sbcs    d5, d5, xzr;                                        \
+        subs    d1, d1, t1;                                         \
+        sbcs    d2, d2, t2;                                         \
+        sbcs    d3, d3, t3;                                         \
+        sbcs    d4, d4, xzr;                                        \
+        sbcs    d5, d5, xzr;                                        \
 /* Now effectively add 2^384 * w by taking d0 as the input for last sbc */  \
-                sbc     d6, d0, xzr
+        sbc     d6, d0, xzr
 
 #define a0 x3
 #define a1 x4
@@ -118,67 +114,66 @@
 #define t3 x23
 #define t4 x24
 
-bignum_montmul_p384:
-_bignum_montmul_p384:
+S2N_BN_SYMBOL(bignum_montmul_p384):
 
 // Save some registers
 
-                stp     x19, x20, [sp, -16]!
-                stp     x21, x22, [sp, -16]!
-                stp     x23, x24, [sp, -16]!
+        stp     x19, x20, [sp, -16]!
+        stp     x21, x22, [sp, -16]!
+        stp     x23, x24, [sp, -16]!
 
 // Load in all words of both inputs
 
-                ldp     a0, a1, [x1]
-                ldp     a2, a3, [x1, #16]
-                ldp     a4, a5, [x1, #32]
-                ldp     b0, b1, [x2]
-                ldp     b2, b3, [x2, #16]
-                ldp     b4, b5, [x2, #32]
+        ldp     a0, a1, [x1]
+        ldp     a2, a3, [x1, #16]
+        ldp     a4, a5, [x1, #32]
+        ldp     b0, b1, [x2]
+        ldp     b2, b3, [x2, #16]
+        ldp     b4, b5, [x2, #32]
 
 // Multiply low halves with a 3x3->6 ADK multiplier as [s5;s4;s3;s2;s1;s0]
 
-                mul     s0, a0, b0
-                mul     t1, a1, b1
-                mul     t2, a2, b2
-                umulh   t3, a0, b0
-                umulh   t4, a1, b1
-                umulh   s5, a2, b2
+        mul     s0, a0, b0
+        mul     t1, a1, b1
+        mul     t2, a2, b2
+        umulh   t3, a0, b0
+        umulh   t4, a1, b1
+        umulh   s5, a2, b2
 
-                adds    t3, t3, t1
-                adcs    t4, t4, t2
-                adc     s5, s5, xzr
+        adds    t3, t3, t1
+        adcs    t4, t4, t2
+        adc     s5, s5, xzr
 
-                adds    s1, t3, s0
-                adcs    s2, t4, t3
-                adcs    s3, s5, t4
-                adc     s4, s5, xzr
+        adds    s1, t3, s0
+        adcs    s2, t4, t3
+        adcs    s3, s5, t4
+        adc     s4, s5, xzr
 
-                adds    s2, s2, s0
-                adcs    s3, s3, t3
-                adcs    s4, s4, t4
-                adc     s5, s5, xzr
+        adds    s2, s2, s0
+        adcs    s3, s3, t3
+        adcs    s4, s4, t4
+        adc     s5, s5, xzr
 
-                muldiffn(t3,t2,t1, t4, a0,a1, b1,b0)
-                adds    xzr, t3, #1
-                adcs    s1, s1, t1
-                adcs    s2, s2, t2
-                adcs    s3, s3, t3
-                adcs    s4, s4, t3
-                adc     s5, s5, t3
+        muldiffn(t3,t2,t1, t4, a0,a1, b1,b0)
+        adds    xzr, t3, #1
+        adcs    s1, s1, t1
+        adcs    s2, s2, t2
+        adcs    s3, s3, t3
+        adcs    s4, s4, t3
+        adc     s5, s5, t3
 
-                muldiffn(t3,t2,t1, t4, a0,a2, b2,b0)
-                adds    xzr, t3, #1
-                adcs    s2, s2, t1
-                adcs    s3, s3, t2
-                adcs    s4, s4, t3
-                adc     s5, s5, t3
+        muldiffn(t3,t2,t1, t4, a0,a2, b2,b0)
+        adds    xzr, t3, #1
+        adcs    s2, s2, t1
+        adcs    s3, s3, t2
+        adcs    s4, s4, t3
+        adc     s5, s5, t3
 
-                muldiffn(t3,t2,t1, t4, a1,a2, b2,b1)
-                adds    xzr, t3, #1
-                adcs    s3, s3, t1
-                adcs    s4, s4, t2
-                adc     s5, s5, t3
+        muldiffn(t3,t2,t1, t4, a1,a2, b2,b1)
+        adds    xzr, t3, #1
+        adcs    s3, s3, t1
+        adcs    s4, s4, t2
+        adc     s5, s5, t3
 
 // Perform three "short" Montgomery steps on the low product
 // This shifts it to an offset compatible with middle terms
@@ -186,202 +181,202 @@ _bignum_montmul_p384:
 // We could keep this in registers by directly adding to it in the next
 // ADK block, but if anything that seems to be slightly slower
 
-                montreds(s0,s5,s4,s3,s2,s1,s0, t1,t2,t3)
+        montreds(s0,s5,s4,s3,s2,s1,s0, t1,t2,t3)
 
-                montreds(s1,s0,s5,s4,s3,s2,s1, t1,t2,t3)
+        montreds(s1,s0,s5,s4,s3,s2,s1, t1,t2,t3)
 
-                montreds(s2,s1,s0,s5,s4,s3,s2, t1,t2,t3)
+        montreds(s2,s1,s0,s5,s4,s3,s2, t1,t2,t3)
 
-                stp     s3, s4, [x0]
-                stp     s5, s0, [x0, #16]
-                stp     s1, s2, [x0, #32]
+        stp     s3, s4, [x0]
+        stp     s5, s0, [x0, #16]
+        stp     s1, s2, [x0, #32]
 
 // Multiply high halves with a 3x3->6 ADK multiplier as [s5;s4;s3;s2;s1;s0]
 
-                mul     s0, a3, b3
-                mul     t1, a4, b4
-                mul     t2, a5, b5
-                umulh   t3, a3, b3
-                umulh   t4, a4, b4
-                umulh   s5, a5, b5
+        mul     s0, a3, b3
+        mul     t1, a4, b4
+        mul     t2, a5, b5
+        umulh   t3, a3, b3
+        umulh   t4, a4, b4
+        umulh   s5, a5, b5
 
-                adds    t3, t3, t1
-                adcs    t4, t4, t2
-                adc     s5, s5, xzr
+        adds    t3, t3, t1
+        adcs    t4, t4, t2
+        adc     s5, s5, xzr
 
-                adds    s1, t3, s0
-                adcs    s2, t4, t3
-                adcs    s3, s5, t4
-                adc     s4, s5, xzr
+        adds    s1, t3, s0
+        adcs    s2, t4, t3
+        adcs    s3, s5, t4
+        adc     s4, s5, xzr
 
-                adds    s2, s2, s0
-                adcs    s3, s3, t3
-                adcs    s4, s4, t4
-                adc     s5, s5, xzr
+        adds    s2, s2, s0
+        adcs    s3, s3, t3
+        adcs    s4, s4, t4
+        adc     s5, s5, xzr
 
-                muldiffn(t3,t2,t1, t4, a3,a4, b4,b3)
-                adds    xzr, t3, #1
-                adcs    s1, s1, t1
-                adcs    s2, s2, t2
-                adcs    s3, s3, t3
-                adcs    s4, s4, t3
-                adc     s5, s5, t3
+        muldiffn(t3,t2,t1, t4, a3,a4, b4,b3)
+        adds    xzr, t3, #1
+        adcs    s1, s1, t1
+        adcs    s2, s2, t2
+        adcs    s3, s3, t3
+        adcs    s4, s4, t3
+        adc     s5, s5, t3
 
-                muldiffn(t3,t2,t1, t4, a3,a5, b5,b3)
-                adds    xzr, t3, #1
-                adcs    s2, s2, t1
-                adcs    s3, s3, t2
-                adcs    s4, s4, t3
-                adc     s5, s5, t3
+        muldiffn(t3,t2,t1, t4, a3,a5, b5,b3)
+        adds    xzr, t3, #1
+        adcs    s2, s2, t1
+        adcs    s3, s3, t2
+        adcs    s4, s4, t3
+        adc     s5, s5, t3
 
-                muldiffn(t3,t2,t1, t4, a4,a5, b5,b4)
-                adds    xzr, t3, #1
-                adcs    s3, s3, t1
-                adcs    s4, s4, t2
-                adc     s5, s5, t3
+        muldiffn(t3,t2,t1, t4, a4,a5, b5,b4)
+        adds    xzr, t3, #1
+        adcs    s3, s3, t1
+        adcs    s4, s4, t2
+        adc     s5, s5, t3
 
 // Compute sign-magnitude a0,[a5,a4,a3] = x_hi - x_lo
 
-                subs    a3, a3, a0
-                sbcs    a4, a4, a1
-                sbcs    a5, a5, a2
-                sbc     a0, xzr, xzr
-                adds    xzr, a0, #1
-                eor     a3, a3, a0
-                adcs    a3, a3, xzr
-                eor     a4, a4, a0
-                adcs    a4, a4, xzr
-                eor     a5, a5, a0
-                adc     a5, a5, xzr
+        subs    a3, a3, a0
+        sbcs    a4, a4, a1
+        sbcs    a5, a5, a2
+        sbc     a0, xzr, xzr
+        adds    xzr, a0, #1
+        eor     a3, a3, a0
+        adcs    a3, a3, xzr
+        eor     a4, a4, a0
+        adcs    a4, a4, xzr
+        eor     a5, a5, a0
+        adc     a5, a5, xzr
 
 // Compute sign-magnitude b5,[b2,b1,b0] = y_lo - y_hi
 
-                subs    b0, b0, b3
-                sbcs    b1, b1, b4
-                sbcs    b2, b2, b5
-                sbc     b5, xzr, xzr
+        subs    b0, b0, b3
+        sbcs    b1, b1, b4
+        sbcs    b2, b2, b5
+        sbc     b5, xzr, xzr
 
-                adds    xzr, b5, #1
-                eor     b0, b0, b5
-                adcs    b0, b0, xzr
-                eor     b1, b1, b5
-                adcs    b1, b1, xzr
-                eor     b2, b2, b5
-                adc     b2, b2, xzr
+        adds    xzr, b5, #1
+        eor     b0, b0, b5
+        adcs    b0, b0, xzr
+        eor     b1, b1, b5
+        adcs    b1, b1, xzr
+        eor     b2, b2, b5
+        adc     b2, b2, xzr
 
 // Save the correct sign for the sub-product in b5
 
-                eor     b5, a0, b5
+        eor     b5, a0, b5
 
 // Add the high H to the modified low term L' and re-stash 6 words,
 // keeping top word in s6
 
-                ldp     t1, t2, [x0]
-                adds    s0, s0, t1
-                adcs    s1, s1, t2
-                ldp     t1, t2, [x0, #16]
-                adcs    s2, s2, t1
-                adcs    s3, s3, t2
-                ldp     t1, t2, [x0, #32]
-                adcs    s4, s4, t1
-                adcs    s5, s5, t2
-                adc     s6, xzr, xzr
-                stp     s0, s1, [x0]
-                stp     s2, s3, [x0, #16]
-                stp     s4, s5, [x0, #32]
+        ldp     t1, t2, [x0]
+        adds    s0, s0, t1
+        adcs    s1, s1, t2
+        ldp     t1, t2, [x0, #16]
+        adcs    s2, s2, t1
+        adcs    s3, s3, t2
+        ldp     t1, t2, [x0, #32]
+        adcs    s4, s4, t1
+        adcs    s5, s5, t2
+        adc     s6, xzr, xzr
+        stp     s0, s1, [x0]
+        stp     s2, s3, [x0, #16]
+        stp     s4, s5, [x0, #32]
 
 // Multiply with yet a third 3x3 ADK for the complex mid-term
 
-                mul     s0, a3, b0
-                mul     t1, a4, b1
-                mul     t2, a5, b2
-                umulh   t3, a3, b0
-                umulh   t4, a4, b1
-                umulh   s5, a5, b2
+        mul     s0, a3, b0
+        mul     t1, a4, b1
+        mul     t2, a5, b2
+        umulh   t3, a3, b0
+        umulh   t4, a4, b1
+        umulh   s5, a5, b2
 
-                adds    t3, t3, t1
-                adcs    t4, t4, t2
-                adc     s5, s5, xzr
+        adds    t3, t3, t1
+        adcs    t4, t4, t2
+        adc     s5, s5, xzr
 
-                adds    s1, t3, s0
-                adcs    s2, t4, t3
-                adcs    s3, s5, t4
-                adc     s4, s5, xzr
+        adds    s1, t3, s0
+        adcs    s2, t4, t3
+        adcs    s3, s5, t4
+        adc     s4, s5, xzr
 
-                adds    s2, s2, s0
-                adcs    s3, s3, t3
-                adcs    s4, s4, t4
-                adc     s5, s5, xzr
+        adds    s2, s2, s0
+        adcs    s3, s3, t3
+        adcs    s4, s4, t4
+        adc     s5, s5, xzr
 
-                muldiffn(t3,t2,t1, t4, a3,a4, b1,b0)
-                adds    xzr, t3, #1
-                adcs    s1, s1, t1
-                adcs    s2, s2, t2
-                adcs    s3, s3, t3
-                adcs    s4, s4, t3
-                adc     s5, s5, t3
+        muldiffn(t3,t2,t1, t4, a3,a4, b1,b0)
+        adds    xzr, t3, #1
+        adcs    s1, s1, t1
+        adcs    s2, s2, t2
+        adcs    s3, s3, t3
+        adcs    s4, s4, t3
+        adc     s5, s5, t3
 
-                muldiffn(t3,t2,t1, t4, a3,a5, b2,b0)
-                adds    xzr, t3, #1
-                adcs    s2, s2, t1
-                adcs    s3, s3, t2
-                adcs    s4, s4, t3
-                adc     s5, s5, t3
+        muldiffn(t3,t2,t1, t4, a3,a5, b2,b0)
+        adds    xzr, t3, #1
+        adcs    s2, s2, t1
+        adcs    s3, s3, t2
+        adcs    s4, s4, t3
+        adc     s5, s5, t3
 
-                muldiffn(t3,t2,t1, t4, a4,a5, b2,b1)
-                adds    xzr, t3, #1
-                adcs    s3, s3, t1
-                adcs    s4, s4, t2
-                adc     s5, s5, t3
+        muldiffn(t3,t2,t1, t4, a4,a5, b2,b1)
+        adds    xzr, t3, #1
+        adcs    s3, s3, t1
+        adcs    s4, s4, t2
+        adc     s5, s5, t3
 
 // Unstash the H + L' sum to add in twice
 
-                ldp     a0, a1, [x0]
-                ldp     a2, a3, [x0, #16]
-                ldp     a4, a5, [x0, #32]
+        ldp     a0, a1, [x0]
+        ldp     a2, a3, [x0, #16]
+        ldp     a4, a5, [x0, #32]
 
 // Set up a sign-modified version of the mid-product in a long accumulator
 // as [b3;b2;b1;b0;s5;s4;s3;s2;s1;s0], adding in the H + L' term once with
 // zero offset as this signed value is created
 
-                adds    xzr, b5, #1
-                eor     s0, s0, b5
-                adcs    s0, s0, a0
-                eor     s1, s1, b5
-                adcs    s1, s1, a1
-                eor     s2, s2, b5
-                adcs    s2, s2, a2
-                eor     s3, s3, b5
-                adcs    s3, s3, a3
-                eor     s4, s4, b5
-                adcs    s4, s4, a4
-                eor     s5, s5, b5
-                adcs    s5, s5, a5
-                adcs    b0, b5, s6
-                adcs    b1, b5, xzr
-                adcs    b2, b5, xzr
-                adc     b3, b5, xzr
+        adds    xzr, b5, #1
+        eor     s0, s0, b5
+        adcs    s0, s0, a0
+        eor     s1, s1, b5
+        adcs    s1, s1, a1
+        eor     s2, s2, b5
+        adcs    s2, s2, a2
+        eor     s3, s3, b5
+        adcs    s3, s3, a3
+        eor     s4, s4, b5
+        adcs    s4, s4, a4
+        eor     s5, s5, b5
+        adcs    s5, s5, a5
+        adcs    b0, b5, s6
+        adcs    b1, b5, xzr
+        adcs    b2, b5, xzr
+        adc     b3, b5, xzr
 
 // Add in the stashed H + L' term an offset of 3 words as well
 
-                adds    s3, s3, a0
-                adcs    s4, s4, a1
-                adcs    s5, s5, a2
-                adcs    b0, b0, a3
-                adcs    b1, b1, a4
-                adcs    b2, b2, a5
-                adc     b3, b3, s6
+        adds    s3, s3, a0
+        adcs    s4, s4, a1
+        adcs    s5, s5, a2
+        adcs    b0, b0, a3
+        adcs    b1, b1, a4
+        adcs    b2, b2, a5
+        adc     b3, b3, s6
 
 // Do three more Montgomery steps on the composed term
 
-                montreds(s0,s5,s4,s3,s2,s1,s0, t1,t2,t3)
-                montreds(s1,s0,s5,s4,s3,s2,s1, t1,t2,t3)
-                montreds(s2,s1,s0,s5,s4,s3,s2, t1,t2,t3)
+        montreds(s0,s5,s4,s3,s2,s1,s0, t1,t2,t3)
+        montreds(s1,s0,s5,s4,s3,s2,s1, t1,t2,t3)
+        montreds(s2,s1,s0,s5,s4,s3,s2, t1,t2,t3)
 
-                adds    b0, b0, s0
-                adcs    b1, b1, s1
-                adcs    b2, b2, s2
-                adc     b3, b3, xzr
+        adds    b0, b0, s0
+        adcs    b1, b1, s1
+        adcs    b2, b2, s2
+        adc     b3, b3, xzr
 
 // Because of the way we added L' in two places, we can overspill by
 // more than usual in Montgomery, with the result being only known to
@@ -389,45 +384,45 @@ _bignum_montmul_p384:
 // elaborate final correction in the style of bignum_cmul_p384, just
 // a little bit simpler because we know q is small.
 
-                add     t2, b3, #1
-                lsl     t1, t2, #32
-                subs    t4, t2, t1
-                sbc     t1, t1, xzr
+        add     t2, b3, #1
+        lsl     t1, t2, #32
+        subs    t4, t2, t1
+        sbc     t1, t1, xzr
 
-                adds    s3, s3, t4
-                adcs    s4, s4, t1
-                adcs    s5, s5, t2
-                adcs    b0, b0, xzr
-                adcs    b1, b1, xzr
-                adcs    b2, b2, xzr
+        adds    s3, s3, t4
+        adcs    s4, s4, t1
+        adcs    s5, s5, t2
+        adcs    b0, b0, xzr
+        adcs    b1, b1, xzr
+        adcs    b2, b2, xzr
 
-                csetm   t2, cc
+        csetm   t2, cc
 
-                mov     t3, #0x00000000ffffffff
-                and     t3, t3, t2
-                adds    s3, s3, t3
-                eor     t3, t3, t2
-                adcs    s4, s4, t3
-                mov     t3, #0xfffffffffffffffe
-                and     t3, t3, t2
-                adcs    s5, s5, t3
-                adcs    b0, b0, t2
-                adcs    b1, b1, t2
-                adc     b2, b2, t2
+        mov     t3, #0x00000000ffffffff
+        and     t3, t3, t2
+        adds    s3, s3, t3
+        eor     t3, t3, t2
+        adcs    s4, s4, t3
+        mov     t3, #0xfffffffffffffffe
+        and     t3, t3, t2
+        adcs    s5, s5, t3
+        adcs    b0, b0, t2
+        adcs    b1, b1, t2
+        adc     b2, b2, t2
 
 // Write back the result
 
-                stp     s3, s4, [x0]
-                stp     s5, b0, [x0, #16]
-                stp     b1, b2, [x0, #32]
+        stp     s3, s4, [x0]
+        stp     s5, b0, [x0, #16]
+        stp     b1, b2, [x0, #32]
 
 // Restore registers and return
 
-                ldp     x23, x24, [sp], #16
-                ldp     x21, x22, [sp], #16
-                ldp     x19, x20, [sp], #16
+        ldp     x23, x24, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
@@ -26,14 +26,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_montmul_p384_alt
-        S2N_ASM_HIDDEN(bignum_montmul_p384_alt)
-
-        .globl _bignum_montmul_p384_alt
-        S2N_ASM_HIDDEN(_bignum_montmul_p384_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p384_alt)
         .text
         .balign 4
 
@@ -50,25 +46,25 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Store it in d6 to make the 2^384 * w contribution already            */  \
-                lsl     t1, d0, #32;                                        \
-                add     d6, t1, d0;                                         \
+        lsl     t1, d0, #32;                                        \
+        add     d6, t1, d0;                                         \
 /* Now let [t3;t2;t1;-] = (2^384 - p_384) * w                    */         \
 /* We know the lowest word will cancel d0 so we don't need it    */         \
-                mov     t1, #0xffffffff00000001;                            \
-                umulh   t1, t1, d6;                                         \
-                mov     t2, #0x00000000ffffffff;                            \
-                mul     t3, t2, d6;                                         \
-                umulh   t2, t2, d6;                                         \
-                adds    t1, t1, t3;                                         \
-                adcs    t2, t2, d6;                                         \
-                adc     t3, xzr, xzr;                                       \
+        mov     t1, #0xffffffff00000001;                            \
+        umulh   t1, t1, d6;                                         \
+        mov     t2, #0x00000000ffffffff;                            \
+        mul     t3, t2, d6;                                         \
+        umulh   t2, t2, d6;                                         \
+        adds    t1, t1, t3;                                         \
+        adcs    t2, t2, d6;                                         \
+        adc     t3, xzr, xzr;                                       \
 /* Now add it, by subtracting from 2^384 * w + x */                         \
-                subs    d1, d1, t1;                                         \
-                sbcs    d2, d2, t2;                                         \
-                sbcs    d3, d3, t3;                                         \
-                sbcs    d4, d4, xzr;                                        \
-                sbcs    d5, d5, xzr;                                        \
-                sbc     d6, d6, xzr
+        subs    d1, d1, t1;                                         \
+        sbcs    d2, d2, t2;                                         \
+        sbcs    d3, d3, t3;                                         \
+        sbcs    d4, d4, xzr;                                        \
+        sbcs    d5, d5, xzr;                                        \
+        sbc     d6, d6, xzr
 
 
 #define z x0
@@ -107,249 +103,248 @@
 #define u11 x1 // same as x
 #define h b5 // same as b5
 
-bignum_montmul_p384_alt:
-_bignum_montmul_p384_alt:
+S2N_BN_SYMBOL(bignum_montmul_p384_alt):
 
 // Save more registers
 
-                stp     x19, x20, [sp, #-16]!
-                stp     x21, x22, [sp, #-16]!
+        stp     x19, x20, [sp, #-16]!
+        stp     x21, x22, [sp, #-16]!
 
 // Load operands and set up row 0 = [u6;...;u0] = a0 * [b5;...;b0]
 
-                ldp     a0, a1, [x]
-                ldp     b0, b1, [y]
+        ldp     a0, a1, [x]
+        ldp     b0, b1, [y]
 
-                mul     u0, a0, b0
-                umulh   u1, a0, b0
-                mul     l, a0, b1
-                umulh   u2, a0, b1
-                adds    u1, u1, l
+        mul     u0, a0, b0
+        umulh   u1, a0, b0
+        mul     l, a0, b1
+        umulh   u2, a0, b1
+        adds    u1, u1, l
 
-                ldp     b2, b3, [y, #16]
+        ldp     b2, b3, [y, #16]
 
-                mul     l, a0, b2
-                umulh   u3, a0, b2
-                adcs    u2, u2, l
+        mul     l, a0, b2
+        umulh   u3, a0, b2
+        adcs    u2, u2, l
 
-                mul     l, a0, b3
-                umulh   u4, a0, b3
-                adcs    u3, u3, l
+        mul     l, a0, b3
+        umulh   u4, a0, b3
+        adcs    u3, u3, l
 
-                ldp     b4, b5, [y, #32]
+        ldp     b4, b5, [y, #32]
 
-                mul     l, a0, b4
-                umulh   u5, a0, b4
-                adcs    u4, u4, l
+        mul     l, a0, b4
+        umulh   u5, a0, b4
+        adcs    u4, u4, l
 
-                mul     l, a0, b5
-                umulh   u6, a0, b5
-                adcs    u5, u5, l
+        mul     l, a0, b5
+        umulh   u6, a0, b5
+        adcs    u5, u5, l
 
-                adc     u6, u6, xzr
+        adc     u6, u6, xzr
 
 // Row 1 = [u7;...;u0] = [a1;a0] * [b5;...;b0]
 
-                mul     l, a1, b0
-                adds    u1, u1, l
-                mul     l, a1, b1
-                adcs    u2, u2, l
-                mul     l, a1, b2
-                adcs    u3, u3, l
-                mul     l, a1, b3
-                adcs    u4, u4, l
-                mul     l, a1, b4
-                adcs    u5, u5, l
-                mul     l, a1, b5
-                adcs    u6, u6, l
-                cset    u7, cs
+        mul     l, a1, b0
+        adds    u1, u1, l
+        mul     l, a1, b1
+        adcs    u2, u2, l
+        mul     l, a1, b2
+        adcs    u3, u3, l
+        mul     l, a1, b3
+        adcs    u4, u4, l
+        mul     l, a1, b4
+        adcs    u5, u5, l
+        mul     l, a1, b5
+        adcs    u6, u6, l
+        cset    u7, cs
 
-                umulh   l, a1, b0
-                adds    u2, u2, l
-                umulh   l, a1, b1
-                adcs    u3, u3, l
-                umulh   l, a1, b2
-                adcs    u4, u4, l
-                umulh   l, a1, b3
-                adcs    u5, u5, l
-                umulh   l, a1, b4
-                adcs    u6, u6, l
-                umulh   l, a1, b5
-                adc     u7, u7, l
+        umulh   l, a1, b0
+        adds    u2, u2, l
+        umulh   l, a1, b1
+        adcs    u3, u3, l
+        umulh   l, a1, b2
+        adcs    u4, u4, l
+        umulh   l, a1, b3
+        adcs    u5, u5, l
+        umulh   l, a1, b4
+        adcs    u6, u6, l
+        umulh   l, a1, b5
+        adc     u7, u7, l
 
 // Row 2 = [u8;...;u0] = [a2;a1;a0] * [b5;...;b0]
 
-                ldp     a2, a3, [x, #16]
+        ldp     a2, a3, [x, #16]
 
-                mul     l, a2, b0
-                adds    u2, u2, l
-                mul     l, a2, b1
-                adcs    u3, u3, l
-                mul     l, a2, b2
-                adcs    u4, u4, l
-                mul     l, a2, b3
-                adcs    u5, u5, l
-                mul     l, a2, b4
-                adcs    u6, u6, l
-                mul     l, a2, b5
-                adcs    u7, u7, l
-                cset    u8, cs
+        mul     l, a2, b0
+        adds    u2, u2, l
+        mul     l, a2, b1
+        adcs    u3, u3, l
+        mul     l, a2, b2
+        adcs    u4, u4, l
+        mul     l, a2, b3
+        adcs    u5, u5, l
+        mul     l, a2, b4
+        adcs    u6, u6, l
+        mul     l, a2, b5
+        adcs    u7, u7, l
+        cset    u8, cs
 
-                umulh   l, a2, b0
-                adds    u3, u3, l
-                umulh   l, a2, b1
-                adcs    u4, u4, l
-                umulh   l, a2, b2
-                adcs    u5, u5, l
-                umulh   l, a2, b3
-                adcs    u6, u6, l
-                umulh   l, a2, b4
-                adcs    u7, u7, l
-                umulh   l, a2, b5
-                adc     u8, u8, l
+        umulh   l, a2, b0
+        adds    u3, u3, l
+        umulh   l, a2, b1
+        adcs    u4, u4, l
+        umulh   l, a2, b2
+        adcs    u5, u5, l
+        umulh   l, a2, b3
+        adcs    u6, u6, l
+        umulh   l, a2, b4
+        adcs    u7, u7, l
+        umulh   l, a2, b5
+        adc     u8, u8, l
 
 // Row 3 = [u9;...;u0] = [a3;a2;a1;a0] * [b5;...;b0]
 
-                mul     l, a3, b0
-                adds    u3, u3, l
-                mul     l, a3, b1
-                adcs    u4, u4, l
-                mul     l, a3, b2
-                adcs    u5, u5, l
-                mul     l, a3, b3
-                adcs    u6, u6, l
-                mul     l, a3, b4
-                adcs    u7, u7, l
-                mul     l, a3, b5
-                adcs    u8, u8, l
-                cset    u9, cs
+        mul     l, a3, b0
+        adds    u3, u3, l
+        mul     l, a3, b1
+        adcs    u4, u4, l
+        mul     l, a3, b2
+        adcs    u5, u5, l
+        mul     l, a3, b3
+        adcs    u6, u6, l
+        mul     l, a3, b4
+        adcs    u7, u7, l
+        mul     l, a3, b5
+        adcs    u8, u8, l
+        cset    u9, cs
 
-                umulh   l, a3, b0
-                adds    u4, u4, l
-                umulh   l, a3, b1
-                adcs    u5, u5, l
-                umulh   l, a3, b2
-                adcs    u6, u6, l
-                umulh   l, a3, b3
-                adcs    u7, u7, l
-                umulh   l, a3, b4
-                adcs    u8, u8, l
-                umulh   l, a3, b5
-                adc     u9, u9, l
+        umulh   l, a3, b0
+        adds    u4, u4, l
+        umulh   l, a3, b1
+        adcs    u5, u5, l
+        umulh   l, a3, b2
+        adcs    u6, u6, l
+        umulh   l, a3, b3
+        adcs    u7, u7, l
+        umulh   l, a3, b4
+        adcs    u8, u8, l
+        umulh   l, a3, b5
+        adc     u9, u9, l
 
 // Row 4 = [u10;...;u0] = [a4;a3;a2;a1;a0] * [b5;...;b0]
 
-                ldp     a4, a5, [x, #32]
+        ldp     a4, a5, [x, #32]
 
-                mul     l, a4, b0
-                adds    u4, u4, l
-                mul     l, a4, b1
-                adcs    u5, u5, l
-                mul     l, a4, b2
-                adcs    u6, u6, l
-                mul     l, a4, b3
-                adcs    u7, u7, l
-                mul     l, a4, b4
-                adcs    u8, u8, l
-                mul     l, a4, b5
-                adcs    u9, u9, l
-                cset    u10, cs
+        mul     l, a4, b0
+        adds    u4, u4, l
+        mul     l, a4, b1
+        adcs    u5, u5, l
+        mul     l, a4, b2
+        adcs    u6, u6, l
+        mul     l, a4, b3
+        adcs    u7, u7, l
+        mul     l, a4, b4
+        adcs    u8, u8, l
+        mul     l, a4, b5
+        adcs    u9, u9, l
+        cset    u10, cs
 
-                umulh   l, a4, b0
-                adds    u5, u5, l
-                umulh   l, a4, b1
-                adcs    u6, u6, l
-                umulh   l, a4, b2
-                adcs    u7, u7, l
-                umulh   l, a4, b3
-                adcs    u8, u8, l
-                umulh   l, a4, b4
-                adcs    u9, u9, l
-                umulh   l, a4, b5
-                adc     u10, u10, l
+        umulh   l, a4, b0
+        adds    u5, u5, l
+        umulh   l, a4, b1
+        adcs    u6, u6, l
+        umulh   l, a4, b2
+        adcs    u7, u7, l
+        umulh   l, a4, b3
+        adcs    u8, u8, l
+        umulh   l, a4, b4
+        adcs    u9, u9, l
+        umulh   l, a4, b5
+        adc     u10, u10, l
 
 // Row 5 = [u11;...;u0] = [a5;a4;a3;a2;a1;a0] * [b5;...;b0]
 
-                mul     l, a5, b0
-                adds    u5, u5, l
-                mul     l, a5, b1
-                adcs    u6, u6, l
-                mul     l, a5, b2
-                adcs    u7, u7, l
-                mul     l, a5, b3
-                adcs    u8, u8, l
-                mul     l, a5, b4
-                adcs    u9, u9, l
-                mul     l, a5, b5
-                adcs    u10, u10, l
-                cset    u11, cs
+        mul     l, a5, b0
+        adds    u5, u5, l
+        mul     l, a5, b1
+        adcs    u6, u6, l
+        mul     l, a5, b2
+        adcs    u7, u7, l
+        mul     l, a5, b3
+        adcs    u8, u8, l
+        mul     l, a5, b4
+        adcs    u9, u9, l
+        mul     l, a5, b5
+        adcs    u10, u10, l
+        cset    u11, cs
 
-                umulh   l, a5, b0
-                adds    u6, u6, l
-                umulh   l, a5, b1
-                adcs    u7, u7, l
-                umulh   l, a5, b2
-                adcs    u8, u8, l
-                umulh   l, a5, b3
-                adcs    u9, u9, l
-                umulh   l, a5, b4
-                adcs    u10, u10, l
-                umulh   l, a5, b5
-                adc     u11, u11, l
+        umulh   l, a5, b0
+        adds    u6, u6, l
+        umulh   l, a5, b1
+        adcs    u7, u7, l
+        umulh   l, a5, b2
+        adcs    u8, u8, l
+        umulh   l, a5, b3
+        adcs    u9, u9, l
+        umulh   l, a5, b4
+        adcs    u10, u10, l
+        umulh   l, a5, b5
+        adc     u11, u11, l
 
 // Montgomery rotate the low half
 
-                montreds(u0,u5,u4,u3,u2,u1,u0, b0,b1,b2)
-                montreds(u1,u0,u5,u4,u3,u2,u1, b0,b1,b2)
-                montreds(u2,u1,u0,u5,u4,u3,u2, b0,b1,b2)
-                montreds(u3,u2,u1,u0,u5,u4,u3, b0,b1,b2)
-                montreds(u4,u3,u2,u1,u0,u5,u4, b0,b1,b2)
-                montreds(u5,u4,u3,u2,u1,u0,u5, b0,b1,b2)
+        montreds(u0,u5,u4,u3,u2,u1,u0, b0,b1,b2)
+        montreds(u1,u0,u5,u4,u3,u2,u1, b0,b1,b2)
+        montreds(u2,u1,u0,u5,u4,u3,u2, b0,b1,b2)
+        montreds(u3,u2,u1,u0,u5,u4,u3, b0,b1,b2)
+        montreds(u4,u3,u2,u1,u0,u5,u4, b0,b1,b2)
+        montreds(u5,u4,u3,u2,u1,u0,u5, b0,b1,b2)
 
 // Add up the high and low parts as [h; u5;u4;u3;u2;u1;u0] = z
 
-                adds    u0, u0, u6
-                adcs    u1, u1, u7
-                adcs    u2, u2, u8
-                adcs    u3, u3, u9
-                adcs    u4, u4, u10
-                adcs    u5, u5, u11
-                adc     h, xzr, xzr
+        adds    u0, u0, u6
+        adcs    u1, u1, u7
+        adcs    u2, u2, u8
+        adcs    u3, u3, u9
+        adcs    u4, u4, u10
+        adcs    u5, u5, u11
+        adc     h, xzr, xzr
 
 // Now add [h; u11;u10;u9;u8;u7;u6] = z + (2^384 - p_384)
 
-                mov     l, #0xffffffff00000001
-                adds    u6, u0, l
-                mov     l, #0x00000000ffffffff
-                adcs    u7, u1, l
-                mov     l, #0x0000000000000001
-                adcs    u8, u2, l
-                adcs    u9, u3, xzr
-                adcs    u10, u4, xzr
-                adcs    u11, u5, xzr
-                adcs    h, h, xzr
+        mov     l, #0xffffffff00000001
+        adds    u6, u0, l
+        mov     l, #0x00000000ffffffff
+        adcs    u7, u1, l
+        mov     l, #0x0000000000000001
+        adcs    u8, u2, l
+        adcs    u9, u3, xzr
+        adcs    u10, u4, xzr
+        adcs    u11, u5, xzr
+        adcs    h, h, xzr
 
 // Now z >= p_384 iff h is nonzero, so select accordingly
 
-                csel    u0, u0, u6, eq
-                csel    u1, u1, u7, eq
-                csel    u2, u2, u8, eq
-                csel    u3, u3, u9, eq
-                csel    u4, u4, u10, eq
-                csel    u5, u5, u11, eq
+        csel    u0, u0, u6, eq
+        csel    u1, u1, u7, eq
+        csel    u2, u2, u8, eq
+        csel    u3, u3, u9, eq
+        csel    u4, u4, u10, eq
+        csel    u5, u5, u11, eq
 
 // Store back final result
 
-                stp     u0, u1, [z]
-                stp     u2, u3, [z, #16]
-                stp     u4, u5, [z, #32]
+        stp     u0, u1, [z]
+        stp     u2, u3, [z, #16]
+        stp     u4, u5, [z, #32]
 
 // Restore registers
 
-                ldp     x21, x22, [sp], #16
-                ldp     x19, x20, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
@@ -26,12 +26,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p384_alt
-        .private_extern bignum_montmul_p384_alt
+        S2N_ASM_HIDDEN(bignum_montmul_p384_alt)
 
         .globl _bignum_montmul_p384_alt
-        .private_extern _bignum_montmul_p384_alt
+        S2N_ASM_HIDDEN(_bignum_montmul_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
@@ -27,8 +27,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montmul_p384_alt
-        .globl  _bignum_montmul_p384_alt
+        .globl bignum_montmul_p384_alt
+        .private_extern bignum_montmul_p384_alt
+
+        .globl _bignum_montmul_p384_alt
+        .private_extern _bignum_montmul_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
@@ -25,12 +25,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p384
-        .private_extern bignum_montsqr_p384
+        S2N_ASM_HIDDEN(bignum_montsqr_p384)
 
         .globl _bignum_montsqr_p384
-        .private_extern _bignum_montsqr_p384
+        S2N_ASM_HIDDEN(_bignum_montsqr_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
@@ -26,8 +26,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montsqr_p384
-        .globl  _bignum_montsqr_p384
+        .globl bignum_montsqr_p384
+        .private_extern bignum_montsqr_p384
+
+        .globl _bignum_montsqr_p384
+        .private_extern _bignum_montsqr_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
@@ -25,14 +25,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_montsqr_p384
-        S2N_ASM_HIDDEN(bignum_montsqr_p384)
-
-        .globl _bignum_montsqr_p384
-        S2N_ASM_HIDDEN(_bignum_montsqr_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p384)
         .text
         .balign 4
 
@@ -67,29 +63,29 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Recycle d0 (which we know gets implicitly cancelled) to store it     */  \
-                lsl     t1, d0, #32;                                        \
-                add     d0, t1, d0;                                         \
+        lsl     t1, d0, #32;                                        \
+        add     d0, t1, d0;                                         \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
 /* bits since by design it will cancel anyway; we only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
-                lsr     t1, d0, #32;                                        \
-                subs    t1, t1, d0;                                         \
-                sbc     t2, d0, xzr;                                        \
+        lsr     t1, d0, #32;                                        \
+        subs    t1, t1, d0;                                         \
+        sbc     t2, d0, xzr;                                        \
 /* Now select in t1 the field to subtract from d1                       */  \
-                extr    t1, t2, t1, #32;                                    \
+        extr    t1, t2, t1, #32;                                    \
 /* And now get the terms to subtract from d2 and d3                     */  \
-                lsr     t2, t2, #32;                                        \
-                adds    t2, t2, d0;                                         \
-                adc     t3, xzr, xzr;                                       \
+        lsr     t2, t2, #32;                                        \
+        adds    t2, t2, d0;                                         \
+        adc     t3, xzr, xzr;                                       \
 /* Do the subtraction of that portion                                   */  \
-                subs    d1, d1, t1;                                         \
-                sbcs    d2, d2, t2;                                         \
-                sbcs    d3, d3, t3;                                         \
-                sbcs    d4, d4, xzr;                                        \
-                sbcs    d5, d5, xzr;                                        \
+        subs    d1, d1, t1;                                         \
+        sbcs    d2, d2, t2;                                         \
+        sbcs    d3, d3, t3;                                         \
+        sbcs    d4, d4, xzr;                                        \
+        sbcs    d5, d5, xzr;                                        \
 /* Now effectively add 2^384 * w by taking d0 as the input for last sbc */  \
-                sbc     d6, d0, xzr
+        sbc     d6, d0, xzr
 
 #define a0 x2
 #define a1 x3
@@ -109,60 +105,59 @@
 #define d3 x16
 #define d4 x17
 
-bignum_montsqr_p384:
-_bignum_montsqr_p384:
+S2N_BN_SYMBOL(bignum_montsqr_p384):
 
 // Load in all words of the input
 
-                ldp     a0, a1, [x1]
-                ldp     a2, a3, [x1, #16]
-                ldp     a4, a5, [x1, #32]
+        ldp     a0, a1, [x1]
+        ldp     a2, a3, [x1, #16]
+        ldp     a4, a5, [x1, #32]
 
 // Square the low half getting a result in [c5;c4;c3;c2;c1;c0]
 
-                mul     d1, a0, a1
-                mul     d2, a0, a2
-                mul     d3, a1, a2
-                mul     c0, a0, a0
-                mul     c2, a1, a1
-                mul     c4, a2, a2
+        mul     d1, a0, a1
+        mul     d2, a0, a2
+        mul     d3, a1, a2
+        mul     c0, a0, a0
+        mul     c2, a1, a1
+        mul     c4, a2, a2
 
-                umulh   d4, a0, a1
-                adds    d2, d2, d4
-                umulh   d4, a0, a2
-                adcs    d3, d3, d4
-                umulh   d4, a1, a2
-                adcs    d4, d4, xzr
+        umulh   d4, a0, a1
+        adds    d2, d2, d4
+        umulh   d4, a0, a2
+        adcs    d3, d3, d4
+        umulh   d4, a1, a2
+        adcs    d4, d4, xzr
 
-                umulh   c1, a0, a0
-                umulh   c3, a1, a1
-                umulh   c5, a2, a2
+        umulh   c1, a0, a0
+        umulh   c3, a1, a1
+        umulh   c5, a2, a2
 
-                adds    d1, d1, d1
-                adcs    d2, d2, d2
-                adcs    d3, d3, d3
-                adcs    d4, d4, d4
-                adc     c5, c5, xzr
+        adds    d1, d1, d1
+        adcs    d2, d2, d2
+        adcs    d3, d3, d3
+        adcs    d4, d4, d4
+        adc     c5, c5, xzr
 
-                adds    c1, c1, d1
-                adcs    c2, c2, d2
-                adcs    c3, c3, d3
-                adcs    c4, c4, d4
-                adc     c5, c5, xzr
+        adds    c1, c1, d1
+        adcs    c2, c2, d2
+        adcs    c3, c3, d3
+        adcs    c4, c4, d4
+        adc     c5, c5, xzr
 
 // Perform three "short" Montgomery steps on the low square
 // This shifts it to an offset compatible with middle product
 // Stash the result temporarily in the output buffer (to avoid more registers)
 
-                montreds(c0,c5,c4,c3,c2,c1,c0, d1,d2,d3)
+        montreds(c0,c5,c4,c3,c2,c1,c0, d1,d2,d3)
 
-                montreds(c1,c0,c5,c4,c3,c2,c1, d1,d2,d3)
+        montreds(c1,c0,c5,c4,c3,c2,c1, d1,d2,d3)
 
-                montreds(c2,c1,c0,c5,c4,c3,c2, d1,d2,d3)
+        montreds(c2,c1,c0,c5,c4,c3,c2, d1,d2,d3)
 
-                stp     c3, c4, [x0]
-                stp     c5, c0, [x0, #16]
-                stp     c1, c2, [x0, #32]
+        stp     c3, c4, [x0]
+        stp     c5, c0, [x0, #16]
+        stp     c1, c2, [x0, #32]
 
 // Compute product of the cross-term with ADK 3x3->6 multiplier
 
@@ -191,81 +186,81 @@ _bignum_montsqr_p384:
 #define l  h0
 #define t  h1
 
-                mul     s0, a0, a3
-                mul     l1, a1, a4
-                mul     l2, a2, a5
-                umulh   h0, a0, a3
-                umulh   h1, a1, a4
-                umulh   h2, a2, a5
+        mul     s0, a0, a3
+        mul     l1, a1, a4
+        mul     l2, a2, a5
+        umulh   h0, a0, a3
+        umulh   h1, a1, a4
+        umulh   h2, a2, a5
 
-                adds    h0, h0, l1
-                adcs    h1, h1, l2
-                adc     h2, h2, xzr
+        adds    h0, h0, l1
+        adcs    h1, h1, l2
+        adc     h2, h2, xzr
 
-                adds    s1, h0, s0
-                adcs    s2, h1, h0
-                adcs    s3, h2, h1
-                adc     s4, h2, xzr
+        adds    s1, h0, s0
+        adcs    s2, h1, h0
+        adcs    s3, h2, h1
+        adc     s4, h2, xzr
 
-                adds    s2, s2, s0
-                adcs    s3, s3, h0
-                adcs    s4, s4, h1
-                adc     s5, h2, xzr
+        adds    s2, s2, s0
+        adcs    s3, s3, h0
+        adcs    s4, s4, h1
+        adc     s5, h2, xzr
 
-                muldiffn(c,h,l, t, a0,a1, a4,a3)
-                adds    xzr, c, #1
-                adcs    s1, s1, l
-                adcs    s2, s2, h
-                adcs    s3, s3, c
-                adcs    s4, s4, c
-                adc     s5, s5, c
+        muldiffn(c,h,l, t, a0,a1, a4,a3)
+        adds    xzr, c, #1
+        adcs    s1, s1, l
+        adcs    s2, s2, h
+        adcs    s3, s3, c
+        adcs    s4, s4, c
+        adc     s5, s5, c
 
-                muldiffn(c,h,l, t, a0,a2, a5,a3)
-                adds    xzr, c, #1
-                adcs    s2, s2, l
-                adcs    s3, s3, h
-                adcs    s4, s4, c
-                adc     s5, s5, c
+        muldiffn(c,h,l, t, a0,a2, a5,a3)
+        adds    xzr, c, #1
+        adcs    s2, s2, l
+        adcs    s3, s3, h
+        adcs    s4, s4, c
+        adc     s5, s5, c
 
-                muldiffn(c,h,l, t, a1,a2, a5,a4)
-                adds    xzr, c, #1
-                adcs    s3, s3, l
-                adcs    s4, s4, h
-                adc     s5, s5, c
+        muldiffn(c,h,l, t, a1,a2, a5,a4)
+        adds    xzr, c, #1
+        adcs    s3, s3, l
+        adcs    s4, s4, h
+        adc     s5, s5, c
 
 // Double it and add the stashed Montgomerified low square
 
-                adds    s0, s0, s0
-                adcs    s1, s1, s1
-                adcs    s2, s2, s2
-                adcs    s3, s3, s3
-                adcs    s4, s4, s4
-                adcs    s5, s5, s5
-                adc     s6, xzr, xzr
+        adds    s0, s0, s0
+        adcs    s1, s1, s1
+        adcs    s2, s2, s2
+        adcs    s3, s3, s3
+        adcs    s4, s4, s4
+        adcs    s5, s5, s5
+        adc     s6, xzr, xzr
 
-                ldp     a0, a1, [x0]
-                adds    s0, s0, a0
-                adcs    s1, s1, a1
-                ldp     a0, a1, [x0, #16]
-                adcs    s2, s2, a0
-                adcs    s3, s3, a1
-                ldp     a0, a1, [x0, #32]
-                adcs    s4, s4, a0
-                adcs    s5, s5, a1
-                adc     s6, s6, xzr
+        ldp     a0, a1, [x0]
+        adds    s0, s0, a0
+        adcs    s1, s1, a1
+        ldp     a0, a1, [x0, #16]
+        adcs    s2, s2, a0
+        adcs    s3, s3, a1
+        ldp     a0, a1, [x0, #32]
+        adcs    s4, s4, a0
+        adcs    s5, s5, a1
+        adc     s6, s6, xzr
 
 // Montgomery-reduce the combined low and middle term another thrice
 
-                montreds(s0,s5,s4,s3,s2,s1,s0, a0,a1,a2)
+        montreds(s0,s5,s4,s3,s2,s1,s0, a0,a1,a2)
 
-                montreds(s1,s0,s5,s4,s3,s2,s1, a0,a1,a2)
+        montreds(s1,s0,s5,s4,s3,s2,s1, a0,a1,a2)
 
-                montreds(s2,s1,s0,s5,s4,s3,s2, a0,a1,a2)
+        montreds(s2,s1,s0,s5,s4,s3,s2, a0,a1,a2)
 
-                adds    s6, s6, s0
-                adcs    s0, s1, xzr
-                adcs    s1, s2, xzr
-                adcs    s2, xzr, xzr
+        adds    s6, s6, s0
+        adcs    s0, s1, xzr
+        adcs    s1, s2, xzr
+        adcs    s2, xzr, xzr
 
 // Our sum so far is in [s2;s1;s0;s6;s5;s4;s3]
 // Choose more intuitive names
@@ -293,48 +288,48 @@ _bignum_montsqr_p384:
 
 // Add in all the pure squares 33 + 44 + 55
 
-                mul     t1, a3, a3
-                adds    r0, r0, t1
-                mul     t2, a4, a4
-                mul     t3, a5, a5
-                umulh   t1, a3, a3
-                adcs    r1, r1, t1
-                umulh   t1, a4, a4
-                adcs    r2, r2, t2
-                adcs    r3, r3, t1
-                umulh   t1, a5, a5
-                adcs    r4, r4, t3
-                adcs    r5, r5, t1
-                adc     r6, r6, xzr
+        mul     t1, a3, a3
+        adds    r0, r0, t1
+        mul     t2, a4, a4
+        mul     t3, a5, a5
+        umulh   t1, a3, a3
+        adcs    r1, r1, t1
+        umulh   t1, a4, a4
+        adcs    r2, r2, t2
+        adcs    r3, r3, t1
+        umulh   t1, a5, a5
+        adcs    r4, r4, t3
+        adcs    r5, r5, t1
+        adc     r6, r6, xzr
 
 // Now compose the 34 + 35 + 45 terms, which need doubling
 
-                mul     t1, a3, a4
-                mul     t2, a3, a5
-                mul     t3, a4, a5
-                umulh   t4, a3, a4
-                adds    t2, t2, t4
-                umulh   t4, a3, a5
-                adcs    t3, t3, t4
-                umulh   t4, a4, a5
-                adc     t4, t4, xzr
+        mul     t1, a3, a4
+        mul     t2, a3, a5
+        mul     t3, a4, a5
+        umulh   t4, a3, a4
+        adds    t2, t2, t4
+        umulh   t4, a3, a5
+        adcs    t3, t3, t4
+        umulh   t4, a4, a5
+        adc     t4, t4, xzr
 
 // Double and add. Recycle one of the no-longer-needed inputs as a temp
 
 #define t5 x5
 
-                adds    t1, t1, t1
-                adcs    t2, t2, t2
-                adcs    t3, t3, t3
-                adcs    t4, t4, t4
-                adc     t5, xzr, xzr
+        adds    t1, t1, t1
+        adcs    t2, t2, t2
+        adcs    t3, t3, t3
+        adcs    t4, t4, t4
+        adc     t5, xzr, xzr
 
-                adds    r1, r1, t1
-                adcs    r2, r2, t2
-                adcs    r3, r3, t3
-                adcs    r4, r4, t4
-                adcs    r5, r5, t5
-                adc     r6, r6, xzr
+        adds    r1, r1, t1
+        adcs    r2, r2, t2
+        adcs    r3, r3, t3
+        adcs    r4, r4, t4
+        adcs    r5, r5, t5
+        adc     r6, r6, xzr
 
 // We know, writing B = 2^{6*64} that the full implicit result is
 // B^2 c <= z + (B - 1) * p < B * p + (B - 1) * p < 2 * B * p,
@@ -343,48 +338,48 @@ _bignum_montsqr_p384:
 // comparison to catch cases where the residue is >= p.
 // First set [0;0;0;t3;t2;t1] = 2^384 - p_384
 
-                mov     t1, #0xffffffff00000001
-                mov     t2, #0x00000000ffffffff
-                mov     t3, #0x0000000000000001
+        mov     t1, #0xffffffff00000001
+        mov     t2, #0x00000000ffffffff
+        mov     t3, #0x0000000000000001
 
 // Let dd = [] be the 6-word intermediate result.
 // Set CF if the addition dd + (2^384 - p_384) >= 2^384, hence iff dd >= p_384.
 
-                adds    xzr, r0, t1
-                adcs    xzr, r1, t2
-                adcs    xzr, r2, t3
-                adcs    xzr, r3, xzr
-                adcs    xzr, r4, xzr
-                adcs    xzr, r5, xzr
+        adds    xzr, r0, t1
+        adcs    xzr, r1, t2
+        adcs    xzr, r2, t3
+        adcs    xzr, r3, xzr
+        adcs    xzr, r4, xzr
+        adcs    xzr, r5, xzr
 
 // Now just add this new carry into the existing r6. It's easy to see they
 // can't both be 1 by our range assumptions, so this gives us a {0,1} flag
 
-                adc     r6, r6, xzr
+        adc     r6, r6, xzr
 
 // Now convert it into a bitmask
 
-                sub     r6, xzr, r6
+        sub     r6, xzr, r6
 
 // Masked addition of 2^384 - p_384, hence subtraction of p_384
 
-                and     t1, t1, r6
-                adds    r0, r0, t1
-                and     t2, t2, r6
-                adcs    r1, r1, t2
-                and     t3, t3, r6
-                adcs    r2, r2, t3
-                adcs    r3, r3, xzr
-                adcs    r4, r4, xzr
-                adc     r5, r5, xzr
+        and     t1, t1, r6
+        adds    r0, r0, t1
+        and     t2, t2, r6
+        adcs    r1, r1, t2
+        and     t3, t3, r6
+        adcs    r2, r2, t3
+        adcs    r3, r3, xzr
+        adcs    r4, r4, xzr
+        adc     r5, r5, xzr
 
 // Store it back
 
-                stp     r0, r1, [x0]
-                stp     r2, r3, [x0, #16]
-                stp     r4, r5, [x0, #32]
+        stp     r0, r1, [x0]
+        stp     r2, r3, [x0, #16]
+        stp     r4, r5, [x0, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
@@ -25,12 +25,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p384_alt
-        .private_extern bignum_montsqr_p384_alt
+        S2N_ASM_HIDDEN(bignum_montsqr_p384_alt)
 
         .globl _bignum_montsqr_p384_alt
-        .private_extern _bignum_montsqr_p384_alt
+        S2N_ASM_HIDDEN(_bignum_montsqr_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
@@ -25,14 +25,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_montsqr_p384_alt
-        S2N_ASM_HIDDEN(bignum_montsqr_p384_alt)
-
-        .globl _bignum_montsqr_p384_alt
-        S2N_ASM_HIDDEN(_bignum_montsqr_p384_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p384_alt)
         .text
         .balign 4
 
@@ -49,25 +45,25 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Store it in d6 to make the 2^384 * w contribution already            */  \
-                lsl     t1, d0, #32;                                        \
-                add     d6, t1, d0;                                         \
+        lsl     t1, d0, #32;                                        \
+        add     d6, t1, d0;                                         \
 /* Now let [t3;t2;t1;-] = (2^384 - p_384) * w                    */         \
 /* We know the lowest word will cancel d0 so we don't need it    */         \
-                mov     t1, #0xffffffff00000001;                            \
-                umulh   t1, t1, d6;                                         \
-                mov     t2, #0x00000000ffffffff;                            \
-                mul     t3, t2, d6;                                         \
-                umulh   t2, t2, d6;                                         \
-                adds    t1, t1, t3;                                         \
-                adcs    t2, t2, d6;                                         \
-                adc     t3, xzr, xzr;                                       \
+        mov     t1, #0xffffffff00000001;                            \
+        umulh   t1, t1, d6;                                         \
+        mov     t2, #0x00000000ffffffff;                            \
+        mul     t3, t2, d6;                                         \
+        umulh   t2, t2, d6;                                         \
+        adds    t1, t1, t3;                                         \
+        adcs    t2, t2, d6;                                         \
+        adc     t3, xzr, xzr;                                       \
 /* Now add it, by subtracting from 2^384 * w + x */                         \
-                subs    d1, d1, t1;                                         \
-                sbcs    d2, d2, t2;                                         \
-                sbcs    d3, d3, t3;                                         \
-                sbcs    d4, d4, xzr;                                        \
-                sbcs    d5, d5, xzr;                                        \
-                sbc     d6, d6, xzr
+        subs    d1, d1, t1;                                         \
+        sbcs    d2, d2, t2;                                         \
+        sbcs    d3, d3, t3;                                         \
+        sbcs    d4, d4, xzr;                                        \
+        sbcs    d5, d5, xzr;                                        \
+        sbc     d6, d6, xzr
 
 #define z x0
 #define x x1
@@ -95,190 +91,189 @@
 #define u11 x20
 #define h x6 // same as a4
 
-bignum_montsqr_p384_alt:
-_bignum_montsqr_p384_alt:
+S2N_BN_SYMBOL(bignum_montsqr_p384_alt):
 
 // It's convenient to have two more registers to play with
 
-                stp     x19, x20, [sp, #-16]!
+        stp     x19, x20, [sp, #-16]!
 
 // Load all the elements as [a5;a4;a3;a2;a1;a0], set up an initial
 // window [u8;u7; u6;u5; u4;u3; u2;u1] = [34;05;03;01], and then
 // chain in the addition of 02 + 12 + 13 + 14 + 15 to that window
 // (no carry-out possible since we add it to the top of a product).
 
-                ldp     a0, a1, [x]
+        ldp     a0, a1, [x]
 
-                mul     u1, a0, a1
-                umulh   u2, a0, a1
+        mul     u1, a0, a1
+        umulh   u2, a0, a1
 
-                ldp     a2, a3, [x, #16]
+        ldp     a2, a3, [x, #16]
 
-                mul     l, a0, a2
-                adds    u2, u2, l
+        mul     l, a0, a2
+        adds    u2, u2, l
 
-                mul     u3, a0, a3
-                mul     l, a1, a2
-                adcs    u3, u3, l
+        mul     u3, a0, a3
+        mul     l, a1, a2
+        adcs    u3, u3, l
 
-                umulh   u4, a0, a3
-                mul     l, a1, a3
-                adcs    u4, u4, l
+        umulh   u4, a0, a3
+        mul     l, a1, a3
+        adcs    u4, u4, l
 
-                ldp     a4, a5, [x, #32]
+        ldp     a4, a5, [x, #32]
 
-                mul     u5, a0, a5
-                mul     l, a1, a4
-                adcs    u5, u5, l
+        mul     u5, a0, a5
+        mul     l, a1, a4
+        adcs    u5, u5, l
 
-                umulh   u6, a0, a5
-                mul     l, a1, a5
-                adcs    u6, u6, l
+        umulh   u6, a0, a5
+        mul     l, a1, a5
+        adcs    u6, u6, l
 
-                mul     u7, a3, a4
-                adcs    u7, u7, xzr
+        mul     u7, a3, a4
+        adcs    u7, u7, xzr
 
-                umulh   u8, a3, a4
-                adc     u8, u8, xzr
+        umulh   u8, a3, a4
+        adc     u8, u8, xzr
 
-                umulh   l, a0, a2
-                adds    u3, u3, l
-                umulh   l, a1, a2
-                adcs    u4, u4, l
-                umulh   l, a1, a3
-                adcs    u5, u5, l
-                umulh   l, a1, a4
-                adcs    u6, u6, l
-                umulh   l, a1, a5
-                adcs    u7, u7, l
-                adc     u8, u8, xzr
+        umulh   l, a0, a2
+        adds    u3, u3, l
+        umulh   l, a1, a2
+        adcs    u4, u4, l
+        umulh   l, a1, a3
+        adcs    u5, u5, l
+        umulh   l, a1, a4
+        adcs    u6, u6, l
+        umulh   l, a1, a5
+        adcs    u7, u7, l
+        adc     u8, u8, xzr
 
 // Now chain in the 04 + 23 + 24 + 25 + 35 + 45 terms
 
-                mul     l, a0, a4
-                adds    u4, u4, l
-                mul     l, a2, a3
-                adcs    u5, u5, l
-                mul     l, a2, a4
-                adcs    u6, u6, l
-                mul     l, a2, a5
-                adcs    u7, u7, l
-                mul     l, a3, a5
-                adcs    u8, u8, l
-                mul     u9, a4, a5
-                adcs    u9, u9, xzr
-                umulh   u10, a4, a5
-                adc     u10, u10, xzr
+        mul     l, a0, a4
+        adds    u4, u4, l
+        mul     l, a2, a3
+        adcs    u5, u5, l
+        mul     l, a2, a4
+        adcs    u6, u6, l
+        mul     l, a2, a5
+        adcs    u7, u7, l
+        mul     l, a3, a5
+        adcs    u8, u8, l
+        mul     u9, a4, a5
+        adcs    u9, u9, xzr
+        umulh   u10, a4, a5
+        adc     u10, u10, xzr
 
-                umulh   l, a0, a4
-                adds    u5, u5, l
-                umulh   l, a2, a3
-                adcs    u6, u6, l
-                umulh   l, a2, a4
-                adcs    u7, u7, l
-                umulh   l, a2, a5
-                adcs    u8, u8, l
-                umulh   l, a3, a5
-                adcs    u9, u9, l
-                adc     u10, u10, xzr
+        umulh   l, a0, a4
+        adds    u5, u5, l
+        umulh   l, a2, a3
+        adcs    u6, u6, l
+        umulh   l, a2, a4
+        adcs    u7, u7, l
+        umulh   l, a2, a5
+        adcs    u8, u8, l
+        umulh   l, a3, a5
+        adcs    u9, u9, l
+        adc     u10, u10, xzr
 
 // Double that, with u11 holding the top carry
 
-                adds    u1, u1, u1
-                adcs    u2, u2, u2
-                adcs    u3, u3, u3
-                adcs    u4, u4, u4
-                adcs    u5, u5, u5
-                adcs    u6, u6, u6
-                adcs    u7, u7, u7
-                adcs    u8, u8, u8
-                adcs    u9, u9, u9
-                adcs    u10, u10, u10
-                cset    u11, cs
+        adds    u1, u1, u1
+        adcs    u2, u2, u2
+        adcs    u3, u3, u3
+        adcs    u4, u4, u4
+        adcs    u5, u5, u5
+        adcs    u6, u6, u6
+        adcs    u7, u7, u7
+        adcs    u8, u8, u8
+        adcs    u9, u9, u9
+        adcs    u10, u10, u10
+        cset    u11, cs
 
 // Add the homogeneous terms 00 + 11 + 22 + 33 + 44 + 55
 
-                umulh   l, a0, a0
-                mul     u0, a0, a0
-                adds    u1, u1, l
+        umulh   l, a0, a0
+        mul     u0, a0, a0
+        adds    u1, u1, l
 
-                mul     l, a1, a1
-                adcs    u2, u2, l
-                umulh   l, a1, a1
-                adcs    u3, u3, l
+        mul     l, a1, a1
+        adcs    u2, u2, l
+        umulh   l, a1, a1
+        adcs    u3, u3, l
 
-                mul     l, a2, a2
-                adcs    u4, u4, l
-                umulh   l, a2, a2
-                adcs    u5, u5, l
+        mul     l, a2, a2
+        adcs    u4, u4, l
+        umulh   l, a2, a2
+        adcs    u5, u5, l
 
-                mul     l, a3, a3
-                adcs    u6, u6, l
-                umulh   l, a3, a3
-                adcs    u7, u7, l
+        mul     l, a3, a3
+        adcs    u6, u6, l
+        umulh   l, a3, a3
+        adcs    u7, u7, l
 
-                mul     l, a4, a4
-                adcs    u8, u8, l
-                umulh   l, a4, a4
-                adcs    u9, u9, l
+        mul     l, a4, a4
+        adcs    u8, u8, l
+        umulh   l, a4, a4
+        adcs    u9, u9, l
 
-                mul     l, a5, a5
-                adcs    u10, u10, l
-                umulh   l, a5, a5
-                adc     u11, u11, l
+        mul     l, a5, a5
+        adcs    u10, u10, l
+        umulh   l, a5, a5
+        adc     u11, u11, l
 
 // Montgomery rotate the low half
 
-                montreds(u0,u5,u4,u3,u2,u1,u0, a1,a2,a3)
-                montreds(u1,u0,u5,u4,u3,u2,u1, a1,a2,a3)
-                montreds(u2,u1,u0,u5,u4,u3,u2, a1,a2,a3)
-                montreds(u3,u2,u1,u0,u5,u4,u3, a1,a2,a3)
-                montreds(u4,u3,u2,u1,u0,u5,u4, a1,a2,a3)
-                montreds(u5,u4,u3,u2,u1,u0,u5, a1,a2,a3)
+        montreds(u0,u5,u4,u3,u2,u1,u0, a1,a2,a3)
+        montreds(u1,u0,u5,u4,u3,u2,u1, a1,a2,a3)
+        montreds(u2,u1,u0,u5,u4,u3,u2, a1,a2,a3)
+        montreds(u3,u2,u1,u0,u5,u4,u3, a1,a2,a3)
+        montreds(u4,u3,u2,u1,u0,u5,u4, a1,a2,a3)
+        montreds(u5,u4,u3,u2,u1,u0,u5, a1,a2,a3)
 
 // Add up the high and low parts as [h; u5;u4;u3;u2;u1;u0] = z
 
-                adds    u0, u0, u6
-                adcs    u1, u1, u7
-                adcs    u2, u2, u8
-                adcs    u3, u3, u9
-                adcs    u4, u4, u10
-                adcs    u5, u5, u11
-                adc     h, xzr, xzr
+        adds    u0, u0, u6
+        adcs    u1, u1, u7
+        adcs    u2, u2, u8
+        adcs    u3, u3, u9
+        adcs    u4, u4, u10
+        adcs    u5, u5, u11
+        adc     h, xzr, xzr
 
 // Now add [h; u11;u10;u9;u8;u7;u6] = z + (2^384 - p_384)
 
-                mov     l, #0xffffffff00000001
-                adds    u6, u0, l
-                mov     l, #0x00000000ffffffff
-                adcs    u7, u1, l
-                mov     l, #0x0000000000000001
-                adcs    u8, u2, l
-                adcs    u9, u3, xzr
-                adcs    u10, u4, xzr
-                adcs    u11, u5, xzr
-                adcs    h, h, xzr
+        mov     l, #0xffffffff00000001
+        adds    u6, u0, l
+        mov     l, #0x00000000ffffffff
+        adcs    u7, u1, l
+        mov     l, #0x0000000000000001
+        adcs    u8, u2, l
+        adcs    u9, u3, xzr
+        adcs    u10, u4, xzr
+        adcs    u11, u5, xzr
+        adcs    h, h, xzr
 
 // Now z >= p_384 iff h is nonzero, so select accordingly
 
-                csel    u0, u0, u6, eq
-                csel    u1, u1, u7, eq
-                csel    u2, u2, u8, eq
-                csel    u3, u3, u9, eq
-                csel    u4, u4, u10, eq
-                csel    u5, u5, u11, eq
+        csel    u0, u0, u6, eq
+        csel    u1, u1, u7, eq
+        csel    u2, u2, u8, eq
+        csel    u3, u3, u9, eq
+        csel    u4, u4, u10, eq
+        csel    u5, u5, u11, eq
 
 // Store back final result
 
-                stp     u0, u1, [z]
-                stp     u2, u3, [z, #16]
-                stp     u4, u5, [z, #32]
+        stp     u0, u1, [z]
+        stp     u2, u3, [z, #16]
+        stp     u4, u5, [z, #32]
 
 // Restore registers
 
-                ldp     x19, x20, [sp], #16
+        ldp     x19, x20, [sp], #16
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
@@ -26,8 +26,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montsqr_p384_alt
-        .globl  _bignum_montsqr_p384_alt
+        .globl bignum_montsqr_p384_alt
+        .private_extern bignum_montsqr_p384_alt
+
+        .globl _bignum_montsqr_p384_alt
+        .private_extern _bignum_montsqr_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
@@ -25,14 +25,10 @@
 //
 // Standard ARM ABI: X0 = p, X1 = z, X2 = x, X3 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_mux_6
-        S2N_ASM_HIDDEN(bignum_mux_6)
-
-        .globl _bignum_mux_6
-        S2N_ASM_HIDDEN(_bignum_mux_6)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mux_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mux_6)
         .text
         .balign 4
 
@@ -43,42 +39,41 @@
 #define a x4
 
 
-bignum_mux_6:
-_bignum_mux_6:
+S2N_BN_SYMBOL(bignum_mux_6):
 
-                cmp     p, #0                    // Set condition codes p = 0
+cmp     p, #0                    // Set condition codes p = 0
 
-                ldr     a, [x]
-                ldr     p, [y]
-                csel    a, a, p, ne
-                str     a, [z]
+        ldr     a, [x]
+        ldr     p, [y]
+        csel    a, a, p, ne
+        str     a, [z]
 
-                ldr     a, [x, #8]
-                ldr     p, [y, #8]
-                csel    a, a, p, ne
-                str     a, [z, #8]
+        ldr     a, [x, #8]
+        ldr     p, [y, #8]
+        csel    a, a, p, ne
+        str     a, [z, #8]
 
-                ldr     a, [x, #16]
-                ldr     p, [y, #16]
-                csel    a, a, p, ne
-                str     a, [z, #16]
+        ldr     a, [x, #16]
+        ldr     p, [y, #16]
+        csel    a, a, p, ne
+        str     a, [z, #16]
 
-                ldr     a, [x, #24]
-                ldr     p, [y, #24]
-                csel    a, a, p, ne
-                str     a, [z, #24]
+        ldr     a, [x, #24]
+        ldr     p, [y, #24]
+        csel    a, a, p, ne
+        str     a, [z, #24]
 
-                ldr     a, [x, #32]
-                ldr     p, [y, #32]
-                csel    a, a, p, ne
-                str     a, [z, #32]
+        ldr     a, [x, #32]
+        ldr     p, [y, #32]
+        csel    a, a, p, ne
+        str     a, [z, #32]
 
-                ldr     a, [x, #40]
-                ldr     p, [y, #40]
-                csel    a, a, p, ne
-                str     a, [z, #40]
+        ldr     a, [x, #40]
+        ldr     p, [y, #40]
+        csel    a, a, p, ne
+        str     a, [z, #40]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
@@ -26,8 +26,12 @@
 // Standard ARM ABI: X0 = p, X1 = z, X2 = x, X3 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mux_6
-        .globl  _bignum_mux_6
+        .globl bignum_mux_6
+        .private_extern bignum_mux_6
+
+        .globl _bignum_mux_6
+        .private_extern _bignum_mux_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
@@ -25,12 +25,13 @@
 //
 // Standard ARM ABI: X0 = p, X1 = z, X2 = x, X3 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mux_6
-        .private_extern bignum_mux_6
+        S2N_ASM_HIDDEN(bignum_mux_6)
 
         .globl _bignum_mux_6
-        .private_extern _bignum_mux_6
+        S2N_ASM_HIDDEN(_bignum_mux_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
@@ -21,14 +21,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_neg_p384
-        S2N_ASM_HIDDEN(bignum_neg_p384)
-
-        .globl _bignum_neg_p384
-        S2N_ASM_HIDDEN(_bignum_neg_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p384)
         .text
         .balign 4
 
@@ -46,54 +42,53 @@
 #define d5 x9
 
 
-bignum_neg_p384:
-_bignum_neg_p384:
+S2N_BN_SYMBOL(bignum_neg_p384):
 
 // Load the 6 digits of x
 
-                ldp     d0, d1, [x]
-                ldp     d2, d3, [x, #16]
-                ldp     d4, d5, [x, #32]
+        ldp     d0, d1, [x]
+        ldp     d2, d3, [x, #16]
+        ldp     d4, d5, [x, #32]
 
 // Set a bitmask p for the input being nonzero, so that we avoid doing
 // -0 = p_384 and hence maintain strict modular reduction
 
-                orr     p, d0, d1
-                orr     t, d2, d3
-                orr     p, p, t
-                orr     t, d4, d5
-                orr     p, p, t
-                cmp     p, #0
-                csetm   p, ne
+        orr     p, d0, d1
+        orr     t, d2, d3
+        orr     p, p, t
+        orr     t, d4, d5
+        orr     p, p, t
+        cmp     p, #0
+        csetm   p, ne
 
 // Load and mask the complicated lower three words of
 // p_384 = [-1;-1;-1;n2;n1;n0] and subtract, using mask itself for upper digits
 
-                mov     t, #0x00000000ffffffff
-                and     t, t, p
-                subs    d0, t, d0
+        mov     t, #0x00000000ffffffff
+        and     t, t, p
+        subs    d0, t, d0
 
-                mov     t, #0xffffffff00000000
-                and     t, t, p
-                sbcs    d1, t, d1
+        mov     t, #0xffffffff00000000
+        and     t, t, p
+        sbcs    d1, t, d1
 
-                mov     t, #0xfffffffffffffffe
-                and     t, t, p
-                sbcs    d2, t, d2
+        mov     t, #0xfffffffffffffffe
+        and     t, t, p
+        sbcs    d2, t, d2
 
-                sbcs    d3, p, d3
-                sbcs    d4, p, d4
-                sbc     d5, p, d5
+        sbcs    d3, p, d3
+        sbcs    d4, p, d4
+        sbc     d5, p, d5
 
 // Write back the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
 
 // Return
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
@@ -22,8 +22,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_neg_p384
-        .globl  _bignum_neg_p384
+        .globl bignum_neg_p384
+        .private_extern bignum_neg_p384
+
+        .globl _bignum_neg_p384
+        .private_extern _bignum_neg_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
@@ -21,12 +21,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_neg_p384
-        .private_extern bignum_neg_p384
+        S2N_ASM_HIDDEN(bignum_neg_p384)
 
         .globl _bignum_neg_p384
-        .private_extern _bignum_neg_p384
+        S2N_ASM_HIDDEN(_bignum_neg_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
@@ -21,14 +21,10 @@
 //
 // Standard ARM ABI: X0 = x, returns X0
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_nonzero_6
-        S2N_ASM_HIDDEN(bignum_nonzero_6)
-
-        .globl _bignum_nonzero_6
-        S2N_ASM_HIDDEN(_bignum_nonzero_6)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_nonzero_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_nonzero_6)
         .text
         .balign 4
 
@@ -38,26 +34,25 @@
 #define c x3
 
 
-bignum_nonzero_6:
-_bignum_nonzero_6:
+S2N_BN_SYMBOL(bignum_nonzero_6):
 
 // Generate a = an OR of all the words in the bignum
 
-                ldp     a, d, [x]
-                orr     a, a, d
-                ldp     c, d, [x, #16]
-                orr     c, c, d
-                orr     a, a, c
-                ldp     c, d, [x, #32]
-                orr     c, c, d
-                orr     a, a, c
+        ldp     a, d, [x]
+        orr     a, a, d
+        ldp     c, d, [x, #16]
+        orr     c, c, d
+        orr     a, a, c
+        ldp     c, d, [x, #32]
+        orr     c, c, d
+        orr     a, a, c
 
 // Set a standard C condition based on whether a is nonzero
 
-                cmp     a, xzr
-                cset    x0, ne
+        cmp     a, xzr
+        cset    x0, ne
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
@@ -21,12 +21,13 @@
 //
 // Standard ARM ABI: X0 = x, returns X0
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_nonzero_6
-        .private_extern bignum_nonzero_6
+        S2N_ASM_HIDDEN(bignum_nonzero_6)
 
         .globl _bignum_nonzero_6
-        .private_extern _bignum_nonzero_6
+        S2N_ASM_HIDDEN(_bignum_nonzero_6)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
@@ -22,8 +22,12 @@
 // Standard ARM ABI: X0 = x, returns X0
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_nonzero_6
-        .globl  _bignum_nonzero_6
+        .globl bignum_nonzero_6
+        .private_extern bignum_nonzero_6
+
+        .globl _bignum_nonzero_6
+        .private_extern _bignum_nonzero_6
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
@@ -24,8 +24,12 @@
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_optneg_p384
-        .globl  _bignum_optneg_p384
+        .globl bignum_optneg_p384
+        .private_extern bignum_optneg_p384
+
+        .globl _bignum_optneg_p384
+        .private_extern _bignum_optneg_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
@@ -23,12 +23,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_optneg_p384
-        .private_extern bignum_optneg_p384
+        S2N_ASM_HIDDEN(bignum_optneg_p384)
 
         .globl _bignum_optneg_p384
-        .private_extern _bignum_optneg_p384
+        S2N_ASM_HIDDEN(_bignum_optneg_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
@@ -23,14 +23,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_optneg_p384
-        S2N_ASM_HIDDEN(bignum_optneg_p384)
-
-        .globl _bignum_optneg_p384
-        S2N_ASM_HIDDEN(_bignum_optneg_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p384)
         .text
         .balign 4
 
@@ -52,62 +48,61 @@
 #define n5 x14
 
 
-bignum_optneg_p384:
-_bignum_optneg_p384:
+S2N_BN_SYMBOL(bignum_optneg_p384):
 
 // Load the 6 digits of x
 
-                ldp     d0, d1, [x]
-                ldp     d2, d3, [x, #16]
-                ldp     d4, d5, [x, #32]
+        ldp     d0, d1, [x]
+        ldp     d2, d3, [x, #16]
+        ldp     d4, d5, [x, #32]
 
 // Adjust p by zeroing it if the input is zero (to avoid giving -0 = p, which
 // is not strictly reduced even though it's correct modulo p)
 
-                orr     n0, d0, d1
-                orr     n1, d2, d3
-                orr     n2, d4, d5
-                orr     n3, n0, n1
-                orr     n4, n2, n3
-                cmp     n4, #0
-                csel    p, xzr, p, eq
+        orr     n0, d0, d1
+        orr     n1, d2, d3
+        orr     n2, d4, d5
+        orr     n3, n0, n1
+        orr     n4, n2, n3
+        cmp     n4, #0
+        csel    p, xzr, p, eq
 
 // Load the complicated lower three words of p_384 = [-1;-1;-1;n2;n1;n0] and -1
 
-                mov     n0, #0x00000000ffffffff
-                mov     n1, #0xffffffff00000000
-                mov     n2, #0xfffffffffffffffe
-                mov     n5, #0xffffffffffffffff
+        mov     n0, #0x00000000ffffffff
+        mov     n1, #0xffffffff00000000
+        mov     n2, #0xfffffffffffffffe
+        mov     n5, #0xffffffffffffffff
 
 // Do the subtraction, which by hypothesis does not underflow
 
-                subs    n0, n0, d0
-                sbcs    n1, n1, d1
-                sbcs    n2, n2, d2
-                sbcs    n3, n5, d3
-                sbcs    n4, n5, d4
-                sbcs    n5, n5, d5
+        subs    n0, n0, d0
+        sbcs    n1, n1, d1
+        sbcs    n2, n2, d2
+        sbcs    n3, n5, d3
+        sbcs    n4, n5, d4
+        sbcs    n5, n5, d5
 
 // Set condition code if original x is nonzero and p was nonzero
 
-                cmp     p, #0
+        cmp     p, #0
 
 // Hence multiplex and write back
 
-                csel    n0, n0, d0, ne
-                csel    n1, n1, d1, ne
-                csel    n2, n2, d2, ne
-                csel    n3, n3, d3, ne
-                csel    n4, n4, d4, ne
-                csel    n5, n5, d5, ne
+        csel    n0, n0, d0, ne
+        csel    n1, n1, d1, ne
+        csel    n2, n2, d2, ne
+        csel    n3, n3, d3, ne
+        csel    n4, n4, d4, ne
+        csel    n5, n5, d5, ne
 
-                stp     n0, n1, [z]
-                stp     n2, n3, [z, #16]
-                stp     n4, n5, [z, #32]
+        stp     n0, n1, [z]
+        stp     n2, n3, [z, #16]
+        stp     n4, n5, [z, #32]
 
 // Return
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_sub_p384
-        .globl  _bignum_sub_p384
+        .globl bignum_sub_p384
+        .private_extern bignum_sub_p384
+
+        .globl _bignum_sub_p384
+        .private_extern _bignum_sub_p384
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_sub_p384
-        S2N_ASM_HIDDEN(bignum_sub_p384)
-
-        .globl _bignum_sub_p384
-        S2N_ASM_HIDDEN(_bignum_sub_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p384)
         .text
         .balign 4
 
@@ -47,50 +43,49 @@
 #define d5 x10
 
 
-bignum_sub_p384:
-_bignum_sub_p384:
+S2N_BN_SYMBOL(bignum_sub_p384):
 
 // First just subtract the numbers as [d5; d4; d3; d2; d1; d0]
 // Set a mask based on (inverted) carry indicating x < y = correction is needed
 
-                ldp     d0, d1, [x]
-                ldp     l, c, [y]
-                subs    d0, d0, l
-                sbcs    d1, d1, c
-                ldp     d2, d3, [x, #16]
-                ldp     l, c, [y, #16]
-                sbcs    d2, d2, l
-                sbcs    d3, d3, c
-                ldp     d4, d5, [x, #32]
-                ldp     l, c, [y, #32]
-                sbcs    d4, d4, l
-                sbcs    d5, d5, c
+        ldp     d0, d1, [x]
+        ldp     l, c, [y]
+        subs    d0, d0, l
+        sbcs    d1, d1, c
+        ldp     d2, d3, [x, #16]
+        ldp     l, c, [y, #16]
+        sbcs    d2, d2, l
+        sbcs    d3, d3, c
+        ldp     d4, d5, [x, #32]
+        ldp     l, c, [y, #32]
+        sbcs    d4, d4, l
+        sbcs    d5, d5, c
 
 // Create a mask for the condition x < y, when we need to correct
 
-                csetm   c, cc
+        csetm   c, cc
 
 // Now correct by adding masked p_384
 
-                mov     l, #0x00000000ffffffff
-                and     l, l, c
-                adds    d0, d0, l
-                eor     l, l, c
-                adcs    d1, d1, l
-                mov     l, #0xfffffffffffffffe
-                and     l, l, c
-                adcs    d2, d2, l
-                adcs    d3, d3, c
-                adcs    d4, d4, c
-                adc     d5, d5, c
+        mov     l, #0x00000000ffffffff
+        and     l, l, c
+        adds    d0, d0, l
+        eor     l, l, c
+        adcs    d1, d1, l
+        mov     l, #0xfffffffffffffffe
+        and     l, l, c
+        adcs    d2, d2, l
+        adcs    d3, d3, c
+        adcs    d4, d4, c
+        adc     d5, d5, c
 
 // Store the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sub_p384
-        .private_extern bignum_sub_p384
+        S2N_ASM_HIDDEN(bignum_sub_p384)
 
         .globl _bignum_sub_p384
-        .private_extern _bignum_sub_p384
+        S2N_ASM_HIDDEN(_bignum_sub_p384)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
@@ -23,10 +23,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_tomont_p384
-        .globl  _bignum_tomont_p384
-        .globl  bignum_tomont_p384_alt
-        .globl  _bignum_tomont_p384_alt
+        .globl bignum_tomont_p384
+        .private_extern bignum_tomont_p384
+
+        .globl _bignum_tomont_p384
+        .private_extern _bignum_tomont_p384
+
+        .globl bignum_tomont_p384_alt
+        .private_extern bignum_tomont_p384_alt
+
+        .globl _bignum_tomont_p384_alt
+        .private_extern _bignum_tomont_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
@@ -22,20 +22,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_tomont_p384
-        S2N_ASM_HIDDEN(bignum_tomont_p384)
-
-        .globl _bignum_tomont_p384
-        S2N_ASM_HIDDEN(_bignum_tomont_p384)
-
-        .globl bignum_tomont_p384_alt
-        S2N_ASM_HIDDEN(bignum_tomont_p384_alt)
-
-        .globl _bignum_tomont_p384_alt
-        S2N_ASM_HIDDEN(_bignum_tomont_p384_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p384_alt)
         .text
         .balign 4
 
@@ -47,44 +39,43 @@
 
 #define modstep_p384(d6,d5,d4,d3,d2,d1,d0, t1,t2,t3)                        \
 /* Initial quotient approximation q = min (h + 1) (2^64 - 1) */             \
-                adds    d6, d6, #1;                                         \
-                csetm   t3, cs;                                             \
-                add     d6, d6, t3;                                         \
-                orn     t3, xzr, t3;                                        \
-                sub     t2, d6, #1;                                         \
-                sub     t1, xzr, d6;                                        \
+        adds    d6, d6, #1;                                         \
+        csetm   t3, cs;                                             \
+        add     d6, d6, t3;                                         \
+        orn     t3, xzr, t3;                                        \
+        sub     t2, d6, #1;                                         \
+        sub     t1, xzr, d6;                                        \
 /* Correction term [d6;t2;t1;d0] = q * (2^384 - p_384) */                   \
-                lsl     d0, t1, #32;                                        \
-                extr    t1, t2, t1, #32;                                    \
-                lsr     t2, t2, #32;                                        \
-                adds    d0, d0, d6;                                         \
-                adcs    t1, t1, xzr;                                        \
-                adcs    t2, t2, d6;                                         \
-                adc     d6, xzr, xzr;                                       \
+        lsl     d0, t1, #32;                                        \
+        extr    t1, t2, t1, #32;                                    \
+        lsr     t2, t2, #32;                                        \
+        adds    d0, d0, d6;                                         \
+        adcs    t1, t1, xzr;                                        \
+        adcs    t2, t2, d6;                                         \
+        adc     d6, xzr, xzr;                                       \
 /* Addition to the initial value */                                         \
-                adds    d1, d1, t1;                                         \
-                adcs    d2, d2, t2;                                         \
-                adcs    d3, d3, d6;                                         \
-                adcs    d4, d4, xzr;                                        \
-                adcs    d5, d5, xzr;                                        \
-                adc     t3, t3, xzr;                                        \
+        adds    d1, d1, t1;                                         \
+        adcs    d2, d2, t2;                                         \
+        adcs    d3, d3, d6;                                         \
+        adcs    d4, d4, xzr;                                        \
+        adcs    d5, d5, xzr;                                        \
+        adc     t3, t3, xzr;                                        \
 /* Use net top of the 7-word answer in t3 for masked correction */          \
-                mov     t1, #0x00000000ffffffff;                            \
-                and     t1, t1, t3;                                         \
-                adds    d0, d0, t1;                                         \
-                eor     t1, t1, t3;                                         \
-                adcs    d1, d1, t1;                                         \
-                mov     t1, #0xfffffffffffffffe;                            \
-                and     t1, t1, t3;                                         \
-                adcs    d2, d2, t1;                                         \
-                adcs    d3, d3, t3;                                         \
-                adcs    d4, d4, t3;                                         \
-                adc     d5, d5, t3
+        mov     t1, #0x00000000ffffffff;                            \
+        and     t1, t1, t3;                                         \
+        adds    d0, d0, t1;                                         \
+        eor     t1, t1, t3;                                         \
+        adcs    d1, d1, t1;                                         \
+        mov     t1, #0xfffffffffffffffe;                            \
+        and     t1, t1, t3;                                         \
+        adcs    d2, d2, t1;                                         \
+        adcs    d3, d3, t3;                                         \
+        adcs    d4, d4, t3;                                         \
+        adc     d5, d5, t3
 
-bignum_tomont_p384:
-_bignum_tomont_p384:
-bignum_tomont_p384_alt:
-_bignum_tomont_p384_alt:
+S2N_BN_SYMBOL(bignum_tomont_p384):
+
+S2N_BN_SYMBOL(bignum_tomont_p384_alt):
 
 #define d0 x2
 #define d1 x3
@@ -107,46 +98,46 @@ _bignum_tomont_p384_alt:
 
 // Load the inputs
 
-                ldp     d0, d1, [x1]
-                ldp     d2, d3, [x1, #16]
-                ldp     d4, d5, [x1, #32]
+        ldp     d0, d1, [x1]
+        ldp     d2, d3, [x1, #16]
+        ldp     d4, d5, [x1, #32]
 
 // Do an initial reduction to make sure this is < p_384, using just
 // a copy of the bignum_mod_p384 code. This is needed to set up the
 // invariant "input < p_384" for the main modular reduction steps.
 
-                mov     n0, #0x00000000ffffffff
-                mov     n1, #0xffffffff00000000
-                mov     n2, #0xfffffffffffffffe
-                subs    n0, d0, n0
-                sbcs    n1, d1, n1
-                sbcs    n2, d2, n2
-                adcs    n3, d3, xzr
-                adcs    n4, d4, xzr
-                adcs    n5, d5, xzr
-                csel    d0, d0, n0, cc
-                csel    d1, d1, n1, cc
-                csel    d2, d2, n2, cc
-                csel    d3, d3, n3, cc
-                csel    d4, d4, n4, cc
-                csel    d5, d5, n5, cc
+        mov     n0, #0x00000000ffffffff
+        mov     n1, #0xffffffff00000000
+        mov     n2, #0xfffffffffffffffe
+        subs    n0, d0, n0
+        sbcs    n1, d1, n1
+        sbcs    n2, d2, n2
+        adcs    n3, d3, xzr
+        adcs    n4, d4, xzr
+        adcs    n5, d5, xzr
+        csel    d0, d0, n0, cc
+        csel    d1, d1, n1, cc
+        csel    d2, d2, n2, cc
+        csel    d3, d3, n3, cc
+        csel    d4, d4, n4, cc
+        csel    d5, d5, n5, cc
 
 // Successively multiply by 2^64 and reduce
 
-                modstep_p384(d5,d4,d3,d2,d1,d0,d6, t1,t2,t3)
-                modstep_p384(d4,d3,d2,d1,d0,d6,d5, t1,t2,t3)
-                modstep_p384(d3,d2,d1,d0,d6,d5,d4, t1,t2,t3)
-                modstep_p384(d2,d1,d0,d6,d5,d4,d3, t1,t2,t3)
-                modstep_p384(d1,d0,d6,d5,d4,d3,d2, t1,t2,t3)
-                modstep_p384(d0,d6,d5,d4,d3,d2,d1, t1,t2,t3)
+        modstep_p384(d5,d4,d3,d2,d1,d0,d6, t1,t2,t3)
+        modstep_p384(d4,d3,d2,d1,d0,d6,d5, t1,t2,t3)
+        modstep_p384(d3,d2,d1,d0,d6,d5,d4, t1,t2,t3)
+        modstep_p384(d2,d1,d0,d6,d5,d4,d3, t1,t2,t3)
+        modstep_p384(d1,d0,d6,d5,d4,d3,d2, t1,t2,t3)
+        modstep_p384(d0,d6,d5,d4,d3,d2,d1, t1,t2,t3)
 
 // Store the result and return
 
-                stp     d1, d2, [x0]
-                stp     d3, d4, [x0, #16]
-                stp     d5, d6, [x0, #32]
+        stp     d1, d2, [x0]
+        stp     d3, d4, [x0, #16]
+        stp     d5, d6, [x0, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
@@ -22,18 +22,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tomont_p384
-        .private_extern bignum_tomont_p384
+        S2N_ASM_HIDDEN(bignum_tomont_p384)
 
         .globl _bignum_tomont_p384
-        .private_extern _bignum_tomont_p384
+        S2N_ASM_HIDDEN(_bignum_tomont_p384)
 
         .globl bignum_tomont_p384_alt
-        .private_extern bignum_tomont_p384_alt
+        S2N_ASM_HIDDEN(bignum_tomont_p384_alt)
 
         .globl _bignum_tomont_p384_alt
-        .private_extern _bignum_tomont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_tomont_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
@@ -25,20 +25,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_triple_p384
-        S2N_ASM_HIDDEN(bignum_triple_p384)
-
-        .globl _bignum_triple_p384
-        S2N_ASM_HIDDEN(_bignum_triple_p384)
-
-        .globl bignum_triple_p384_alt
-        S2N_ASM_HIDDEN(bignum_triple_p384_alt)
-
-        .globl _bignum_triple_p384_alt
-        S2N_ASM_HIDDEN(_bignum_triple_p384_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p384_alt)
         .text
         .balign 4
 
@@ -73,78 +65,77 @@
 #define t1 x10
 
 
-bignum_triple_p384:
-_bignum_triple_p384:
-bignum_triple_p384_alt:
-_bignum_triple_p384_alt:
+S2N_BN_SYMBOL(bignum_triple_p384):
+
+S2N_BN_SYMBOL(bignum_triple_p384_alt):
 
 // Load the inputs
 
-                ldp     a0, a1, [x]
-                ldp     a2, a3, [x, #16]
-                ldp     a4, a5, [x, #32]
+        ldp     a0, a1, [x]
+        ldp     a2, a3, [x, #16]
+        ldp     a4, a5, [x, #32]
 
 // First do the multiplication by 3, getting z = [h; d5; ...; d0]
 
-                lsl     d0, a0, #1
-                adds    d0, d0, a0
-                extr    d1, a1, a0, #63
-                adcs    d1, d1, a1
-                extr    d2, a2, a1, #63
-                adcs    d2, d2, a2
-                extr    d3, a3, a2, #63
-                adcs    d3, d3, a3
-                extr    d4, a4, a3, #63
-                adcs    d4, d4, a4
-                extr    d5, a5, a4, #63
-                adcs    d5, d5, a5
-                lsr     h, a5, #63
-                adc     h, h, xzr
+        lsl     d0, a0, #1
+        adds    d0, d0, a0
+        extr    d1, a1, a0, #63
+        adcs    d1, d1, a1
+        extr    d2, a2, a1, #63
+        adcs    d2, d2, a2
+        extr    d3, a3, a2, #63
+        adcs    d3, d3, a3
+        extr    d4, a4, a3, #63
+        adcs    d4, d4, a4
+        extr    d5, a5, a4, #63
+        adcs    d5, d5, a5
+        lsr     h, a5, #63
+        adc     h, h, xzr
 
 // For this limited range a simple quotient estimate of q = h + 1 works, where
 // h = floor(z / 2^384). Then -p_384 <= z - q * p_384 < p_384, so we just need
 // to subtract q * p_384 and then if that's negative, add back p_384.
 
-                add     q, h, #1
+        add     q, h, #1
 
 // Initial subtraction of z - q * p_384, with bitmask c for the carry
 // Actually done as an addition of (z - 2^384 * h) + q * (2^384 - p_384)
 // which, because q = h + 1, is exactly 2^384 + (z - q * p_384), and
 // therefore CF <=> 2^384 + (z - q * p_384) >= 2^384 <=> z >= q * p_384.
 
-                lsl     t1, q, #32
-                subs    t0, q, t1
-                sbc     t1, t1, xzr
+        lsl     t1, q, #32
+        subs    t0, q, t1
+        sbc     t1, t1, xzr
 
-                adds    d0, d0, t0
-                adcs    d1, d1, t1
-                adcs    d2, d2, q
-                adcs    d3, d3, xzr
-                adcs    d4, d4, xzr
-                adcs    d5, d5, xzr
-                csetm   c, cc
+        adds    d0, d0, t0
+        adcs    d1, d1, t1
+        adcs    d2, d2, q
+        adcs    d3, d3, xzr
+        adcs    d4, d4, xzr
+        adcs    d5, d5, xzr
+        csetm   c, cc
 
 // Use the bitmask c for final masked addition of p_384.
 
-                mov     t0, #0x00000000ffffffff
-                and     t0, t0, c
-                adds    d0, d0, t0
-                eor     t0, t0, c
-                adcs    d1, d1, t0
-                mov     t0, #0xfffffffffffffffe
-                and     t0, t0, c
-                adcs    d2, d2, t0
-                adcs    d3, d3, c
-                adcs    d4, d4, c
-                adc     d5, d5, c
+        mov     t0, #0x00000000ffffffff
+        and     t0, t0, c
+        adds    d0, d0, t0
+        eor     t0, t0, c
+        adcs    d1, d1, t0
+        mov     t0, #0xfffffffffffffffe
+        and     t0, t0, c
+        adcs    d2, d2, t0
+        adcs    d3, d3, c
+        adcs    d4, d4, c
+        adc     d5, d5, c
 
 // Store the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
@@ -26,10 +26,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_triple_p384
-        .globl  _bignum_triple_p384
-        .globl  bignum_triple_p384_alt
-        .globl  _bignum_triple_p384_alt
+        .globl bignum_triple_p384
+        .private_extern bignum_triple_p384
+
+        .globl _bignum_triple_p384
+        .private_extern _bignum_triple_p384
+
+        .globl bignum_triple_p384_alt
+        .private_extern bignum_triple_p384_alt
+
+        .globl _bignum_triple_p384_alt
+        .private_extern _bignum_triple_p384_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
@@ -25,18 +25,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p384
-        .private_extern bignum_triple_p384
+        S2N_ASM_HIDDEN(bignum_triple_p384)
 
         .globl _bignum_triple_p384
-        .private_extern _bignum_triple_p384
+        S2N_ASM_HIDDEN(_bignum_triple_p384)
 
         .globl bignum_triple_p384_alt
-        .private_extern bignum_triple_p384_alt
+        S2N_ASM_HIDDEN(bignum_triple_p384_alt)
 
         .globl _bignum_triple_p384_alt
-        .private_extern _bignum_triple_p384_alt
+        S2N_ASM_HIDDEN(_bignum_triple_p384_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_add_p521
-        S2N_ASM_HIDDEN(bignum_add_p521)
-
-        .globl _bignum_add_p521
-        S2N_ASM_HIDDEN(_bignum_add_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p521)
         .text
         .balign 4
 
@@ -49,62 +45,61 @@
 #define d8 x13
 
 
-bignum_add_p521:
-_bignum_add_p521:
+S2N_BN_SYMBOL(bignum_add_p521):
 
 // Force carry-in to get s = [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x + y + 1.
 // We ignore the carry-out, assuming inputs are reduced so there is none.
 
-                subs    xzr, xzr, xzr
-                ldp     d0, d1, [x]
-                ldp     l, h, [y]
-                adcs    d0, d0, l
-                adcs    d1, d1, h
-                ldp     d2, d3, [x, #16]
-                ldp     l, h, [y, #16]
-                adcs    d2, d2, l
-                adcs    d3, d3, h
-                ldp     d4, d5, [x, #32]
-                ldp     l, h, [y, #32]
-                adcs    d4, d4, l
-                adcs    d5, d5, h
-                ldp     d6, d7, [x, #48]
-                ldp     l, h, [y, #48]
-                adcs    d6, d6, l
-                adcs    d7, d7, h
-                ldr     d8, [x, #64]
-                ldr     l, [y, #64]
-                adc     d8, d8, l
+        subs    xzr, xzr, xzr
+        ldp     d0, d1, [x]
+        ldp     l, h, [y]
+        adcs    d0, d0, l
+        adcs    d1, d1, h
+        ldp     d2, d3, [x, #16]
+        ldp     l, h, [y, #16]
+        adcs    d2, d2, l
+        adcs    d3, d3, h
+        ldp     d4, d5, [x, #32]
+        ldp     l, h, [y, #32]
+        adcs    d4, d4, l
+        adcs    d5, d5, h
+        ldp     d6, d7, [x, #48]
+        ldp     l, h, [y, #48]
+        adcs    d6, d6, l
+        adcs    d7, d7, h
+        ldr     d8, [x, #64]
+        ldr     l, [y, #64]
+        adc     d8, d8, l
 
 // Now x + y >= p_521 <=> s = x + y + 1 >= 2^521
 // Set CF <=> s = x + y + 1 >= 2^521 and make it a mask in l as well
 
-                subs    l, d8, #512
-                csetm   l, cs
+        subs    l, d8, #512
+        csetm   l, cs
 
 // Now if CF is set (and l is all 1s), we want (x + y) - p_521 = s - 2^521
 // while otherwise we want x + y = s - 1 (from existing CF, which is nice)
 
-                sbcs    d0, d0, xzr
-                and     l, l, #512
-                sbcs    d1, d1, xzr
-                sbcs    d2, d2, xzr
-                sbcs    d3, d3, xzr
-                sbcs    d4, d4, xzr
-                sbcs    d5, d5, xzr
-                sbcs    d6, d6, xzr
-                sbcs    d7, d7, xzr
-                sbc     d8, d8, l
+        sbcs    d0, d0, xzr
+        and     l, l, #512
+        sbcs    d1, d1, xzr
+        sbcs    d2, d2, xzr
+        sbcs    d3, d3, xzr
+        sbcs    d4, d4, xzr
+        sbcs    d5, d5, xzr
+        sbcs    d6, d6, xzr
+        sbcs    d7, d7, xzr
+        sbc     d8, d8, l
 
 // Store the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_add_p521
-        .private_extern bignum_add_p521
+        S2N_ASM_HIDDEN(bignum_add_p521)
 
         .globl _bignum_add_p521
-        .private_extern _bignum_add_p521
+        S2N_ASM_HIDDEN(_bignum_add_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_add_p521
-        .globl  _bignum_add_p521
+        .globl bignum_add_p521
+        .private_extern bignum_add_p521
+
+        .globl _bignum_add_p521
+        .private_extern _bignum_add_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
@@ -23,20 +23,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_cmul_p521
-        S2N_ASM_HIDDEN(bignum_cmul_p521)
-
-        .globl _bignum_cmul_p521
-        S2N_ASM_HIDDEN(_bignum_cmul_p521)
-
-        .globl bignum_cmul_p521_alt
-        S2N_ASM_HIDDEN(bignum_cmul_p521_alt)
-
-        .globl _bignum_cmul_p521_alt
-        S2N_ASM_HIDDEN(_bignum_cmul_p521_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p521_alt)
         .text
         .balign 4
 
@@ -72,97 +64,96 @@
 #define a8 x14
 #define dd x15
 
-bignum_cmul_p521:
-_bignum_cmul_p521:
-bignum_cmul_p521_alt:
-_bignum_cmul_p521_alt:
+S2N_BN_SYMBOL(bignum_cmul_p521):
+
+S2N_BN_SYMBOL(bignum_cmul_p521_alt):
 
 // First do the multiply, getting [d9; ...; d0], and as this is done
 // accumulate an AND "dd" of digits d7,...,d1 for later use
 
-                ldp     a0, a1, [x]
-                mul     d0, c, a0
-                mul     d1, c, a1
-                umulh   a0, c, a0
-                adds    d1, d1, a0
-                umulh   a1, c, a1
+        ldp     a0, a1, [x]
+        mul     d0, c, a0
+        mul     d1, c, a1
+        umulh   a0, c, a0
+        adds    d1, d1, a0
+        umulh   a1, c, a1
 
-                ldp     a2, a3, [x, #16]
-                mul     d2, c, a2
-                mul     d3, c, a3
-                umulh   a2, c, a2
-                adcs    d2, d2, a1
-                and     dd, d1, d2
-                umulh   a3, c, a3
-                adcs    d3, d3, a2
-                and     dd, dd, d3
+        ldp     a2, a3, [x, #16]
+        mul     d2, c, a2
+        mul     d3, c, a3
+        umulh   a2, c, a2
+        adcs    d2, d2, a1
+        and     dd, d1, d2
+        umulh   a3, c, a3
+        adcs    d3, d3, a2
+        and     dd, dd, d3
 
-                ldp     a4, a5, [x, #32]
-                mul     d4, c, a4
-                mul     d5, c, a5
-                umulh   a4, c, a4
-                adcs    d4, d4, a3
-                and     dd, dd, d4
-                umulh   a5, c, a5
-                adcs    d5, d5, a4
-                and     dd, dd, d5
+        ldp     a4, a5, [x, #32]
+        mul     d4, c, a4
+        mul     d5, c, a5
+        umulh   a4, c, a4
+        adcs    d4, d4, a3
+        and     dd, dd, d4
+        umulh   a5, c, a5
+        adcs    d5, d5, a4
+        and     dd, dd, d5
 
-                ldp     a6, a7, [x, #48]
-                mul     d6, c, a6
-                mul     d7, c, a7
-                umulh   a6, c, a6
-                adcs    d6, d6, a5
-                and     dd, dd, d6
-                umulh   a7, c, a7
-                adcs    d7, d7, a6
-                and     dd, dd, d7
+        ldp     a6, a7, [x, #48]
+        mul     d6, c, a6
+        mul     d7, c, a7
+        umulh   a6, c, a6
+        adcs    d6, d6, a5
+        and     dd, dd, d6
+        umulh   a7, c, a7
+        adcs    d7, d7, a6
+        and     dd, dd, d7
 
-                ldr     a8, [x, #64]
-                mul     d8, c, a8
-                adcs    d8, d8, a7
-                umulh   a8, c, a8
-                adc     d9, xzr, a8
+        ldr     a8, [x, #64]
+        mul     d8, c, a8
+        adcs    d8, d8, a7
+        umulh   a8, c, a8
+        adc     d9, xzr, a8
 
 // Extract the high part h and mask off the low part l = [d8;d7;...;d0]
 // but stuff d8 with 1 bits at the left to ease a comparison below
 
-                extr    h, d9, d8, #9
-                orr     d8, d8, #~0x1FF
+        extr    h, d9, d8, #9
+        orr     d8, d8, #~0x1FF
 
 // Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
 // happen if digits d7,...d1 are all 1s, we use the AND of them "dd" to
 // condense the carry chain, and since we stuffed 1 bits into d8 we get
 // the result in CF without an additional comparison.
 
-                subs    xzr, xzr, xzr
-                adcs    xzr, d0, h
-                adcs    xzr, dd, xzr
-                adcs    xzr, d8, xzr
+        subs    xzr, xzr, xzr
+        adcs    xzr, d0, h
+        adcs    xzr, dd, xzr
+        adcs    xzr, d8, xzr
 
 // Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
 // while otherwise we want just h + l. So mask h + l + CF to 521 bits.
 // This masking also gets rid of the stuffing with 1s we did above.
 
-                adcs    d0, d0, h
-                adcs    d1, d1, xzr
-                adcs    d2, d2, xzr
-                adcs    d3, d3, xzr
-                adcs    d4, d4, xzr
-                adcs    d5, d5, xzr
-                adcs    d6, d6, xzr
-                adcs    d7, d7, xzr
-                adc     d8, d8, xzr
-                and     d8, d8, #0x1FF
+        adcs    d0, d0, h
+        adcs    d1, d1, xzr
+        adcs    d2, d2, xzr
+        adcs    d3, d3, xzr
+        adcs    d4, d4, xzr
+        adcs    d5, d5, xzr
+        adcs    d6, d6, xzr
+        adcs    d7, d7, xzr
+        adc     d8, d8, xzr
+        and     d8, d8, #0x1FF
 
 // Store the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
@@ -24,10 +24,18 @@
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_cmul_p521
-        .globl  _bignum_cmul_p521
-        .globl  bignum_cmul_p521_alt
-        .globl  _bignum_cmul_p521_alt
+        .globl bignum_cmul_p521
+        .private_extern bignum_cmul_p521
+
+        .globl _bignum_cmul_p521
+        .private_extern _bignum_cmul_p521
+
+        .globl bignum_cmul_p521_alt
+        .private_extern bignum_cmul_p521_alt
+
+        .globl _bignum_cmul_p521_alt
+        .private_extern _bignum_cmul_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
@@ -23,18 +23,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p521
-        .private_extern bignum_cmul_p521
+        S2N_ASM_HIDDEN(bignum_cmul_p521)
 
         .globl _bignum_cmul_p521
-        .private_extern _bignum_cmul_p521
+        S2N_ASM_HIDDEN(_bignum_cmul_p521)
 
         .globl bignum_cmul_p521_alt
-        .private_extern bignum_cmul_p521_alt
+        S2N_ASM_HIDDEN(bignum_cmul_p521_alt)
 
         .globl _bignum_cmul_p521_alt
-        .private_extern _bignum_cmul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_cmul_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
@@ -25,14 +25,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_deamont_p521
-        S2N_ASM_HIDDEN(bignum_deamont_p521)
-
-        .globl _bignum_deamont_p521
-        S2N_ASM_HIDDEN(_bignum_deamont_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p521)
         .text
         .balign 4
 
@@ -60,72 +56,71 @@
 #define l x12
 #define u x12
 
-bignum_deamont_p521:
-_bignum_deamont_p521:
+S2N_BN_SYMBOL(bignum_deamont_p521):
 
 // Load all the inputs
 
-                ldp     d0, d1, [x]
-                ldp     d2, d3, [x, #16]
-                ldp     d4, d5, [x, #32]
-                ldp     d6, d7, [x, #48]
-                ldr     d8, [x, #64]
+        ldp     d0, d1, [x]
+        ldp     d2, d3, [x, #16]
+        ldp     d4, d5, [x, #32]
+        ldp     d6, d7, [x, #48]
+        ldr     d8, [x, #64]
 
 // Stash the lowest 55 bits at the top of c, then shift the whole 576-bit
 // input right by 9*64 - 521 = 576 - 521 = 55 bits. As this is done,
 // accumulate an AND of words d0..d6.
 
-                lsl     c, d0, #9
-                extr    d0, d1, d0, #55
-                extr    d1, d2, d1, #55
-                and     u, d0, d1
-                extr    d2, d3, d2, #55
-                and     u, u, d2
-                extr    d3, d4, d3, #55
-                and     u, u, d3
-                extr    d4, d5, d4, #55
-                and     u, u, d4
-                extr    d5, d6, d5, #55
-                and     u, u, d5
-                extr    d6, d7, d6, #55
-                and     u, u, d6
-                extr    d7, d8, d7, #55
-                lsr     d8, d8, #55
+        lsl     c, d0, #9
+        extr    d0, d1, d0, #55
+        extr    d1, d2, d1, #55
+        and     u, d0, d1
+        extr    d2, d3, d2, #55
+        and     u, u, d2
+        extr    d3, d4, d3, #55
+        and     u, u, d3
+        extr    d4, d5, d4, #55
+        and     u, u, d4
+        extr    d5, d6, d5, #55
+        and     u, u, d5
+        extr    d6, d7, d6, #55
+        and     u, u, d6
+        extr    d7, d8, d7, #55
+        lsr     d8, d8, #55
 
 // Now writing x = 2^55 * h + l (so here [d8;..d0] = h and c = 2^9 * l)
 // we want (h + 2^{521-55} * l) mod p_521 = s mod p_521. Since s < 2 * p_521
 // this is just "if s >= p_521 then s - p_521 else s". First get
 // CF <=> s >= p_521, creating the digits [h,l] to add for the l part.
 
-                adds    xzr, u, #1
-                lsl     l, c, #9
-                adcs    xzr, d7, l
-                orr     d8, d8, #~0x1FF
-                lsr     h, c, #55
-                adcs    xzr, d8, h
+        adds    xzr, u, #1
+        lsl     l, c, #9
+        adcs    xzr, d7, l
+        orr     d8, d8, #~0x1FF
+        lsr     h, c, #55
+        adcs    xzr, d8, h
 
 // Now the result = s mod p_521 = (if s >= p_521 then s - p_521 else s) =
 // (s + CF) mod 2^521. So do the addition inheriting the carry-in.
 
-                adcs    d0, d0, xzr
-                adcs    d1, d1, xzr
-                adcs    d2, d2, xzr
-                adcs    d3, d3, xzr
-                adcs    d4, d4, xzr
-                adcs    d5, d5, xzr
-                adcs    d6, d6, xzr
-                adcs    d7, d7, l
-                adc     d8, d8, h
-                and     d8, d8, #0x1FF
+        adcs    d0, d0, xzr
+        adcs    d1, d1, xzr
+        adcs    d2, d2, xzr
+        adcs    d3, d3, xzr
+        adcs    d4, d4, xzr
+        adcs    d5, d5, xzr
+        adcs    d6, d6, xzr
+        adcs    d7, d7, l
+        adc     d8, d8, h
+        and     d8, d8, #0x1FF
 
 // Store back the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
-                ret
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
@@ -25,12 +25,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_deamont_p521
-        .private_extern bignum_deamont_p521
+        S2N_ASM_HIDDEN(bignum_deamont_p521)
 
         .globl _bignum_deamont_p521
-        .private_extern _bignum_deamont_p521
+        S2N_ASM_HIDDEN(_bignum_deamont_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
@@ -26,8 +26,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_deamont_p521
-        .globl  _bignum_deamont_p521
+        .globl bignum_deamont_p521
+        .private_extern bignum_deamont_p521
+
+        .globl _bignum_deamont_p521
+        .private_extern _bignum_deamont_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
@@ -26,8 +26,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_demont_p521
-        .globl  _bignum_demont_p521
+        .globl bignum_demont_p521
+        .private_extern bignum_demont_p521
+
+        .globl _bignum_demont_p521
+        .private_extern _bignum_demont_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
@@ -25,14 +25,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_demont_p521
-        S2N_ASM_HIDDEN(bignum_demont_p521)
-
-        .globl _bignum_demont_p521
-        S2N_ASM_HIDDEN(_bignum_demont_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p521)
         .text
         .balign 4
 
@@ -54,33 +50,32 @@
 #define d8 x2
 #define c x6
 
-bignum_demont_p521:
-_bignum_demont_p521:
+S2N_BN_SYMBOL(bignum_demont_p521):
 
 // Rotate, as a 521-bit quantity, by 9*64 - 521 = 55 bits right.
 
-                ldp     d0, d1, [x]
-                lsl     c, d0, #9
-                extr    d0, d1, d0, #55
-                ldp     d2, d3, [x, #16]
-                extr    d1, d2, d1, #55
-                stp     d0, d1, [z]
-                extr    d2, d3, d2, #55
-                ldp     d4, d5, [x, #32]
-                extr    d3, d4, d3, #55
-                stp     d2, d3, [z, #16]
-                extr    d4, d5, d4, #55
-                ldp     d6, d7, [x, #48]
-                extr    d5, d6, d5, #55
-                stp     d4, d5, [z, #32]
-                extr    d6, d7, d6, #55
-                ldr     d8, [x, #64]
-                orr     d8, d8, c
-                extr    d7, d8, d7, #55
-                stp     d6, d7, [z, #48]
-                lsr     d8, d8, #55
-                str     d8, [z, #64]
-                ret
+        ldp     d0, d1, [x]
+        lsl     c, d0, #9
+        extr    d0, d1, d0, #55
+        ldp     d2, d3, [x, #16]
+        extr    d1, d2, d1, #55
+        stp     d0, d1, [z]
+        extr    d2, d3, d2, #55
+        ldp     d4, d5, [x, #32]
+        extr    d3, d4, d3, #55
+        stp     d2, d3, [z, #16]
+        extr    d4, d5, d4, #55
+        ldp     d6, d7, [x, #48]
+        extr    d5, d6, d5, #55
+        stp     d4, d5, [z, #32]
+        extr    d6, d7, d6, #55
+        ldr     d8, [x, #64]
+        orr     d8, d8, c
+        extr    d7, d8, d7, #55
+        stp     d6, d7, [z, #48]
+        lsr     d8, d8, #55
+        str     d8, [z, #64]
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
@@ -25,12 +25,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_demont_p521
-        .private_extern bignum_demont_p521
+        S2N_ASM_HIDDEN(bignum_demont_p521)
 
         .globl _bignum_demont_p521
-        .private_extern _bignum_demont_p521
+        S2N_ASM_HIDDEN(_bignum_demont_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_double_p521
-        S2N_ASM_HIDDEN(bignum_double_p521)
-
-        .globl _bignum_double_p521
-        S2N_ASM_HIDDEN(_bignum_double_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p521)
         .text
         .balign 4
 
@@ -40,44 +36,43 @@
 #define h x3
 #define l x4
 
-bignum_double_p521:
-_bignum_double_p521:
+S2N_BN_SYMBOL(bignum_double_p521):
 
 // We can decide whether 2 * x >= p_521 just by 2 * x >= 2^521, which
 // amounts to whether the top word is >= 256
 
-                ldr     c, [x, #64]
-                subs    xzr, c, #256
+        ldr     c, [x, #64]
+        subs    xzr, c, #256
 
 // Now if 2 * x >= p_521 we want 2 * x - p_521 = (2 * x + 1) - 2^521
 // and otherwise just 2 * x. Feed in the condition as the carry bit
 // to get 2 * x + [2 * x >= p_521] then just mask it off to 521 bits.
 
-                ldp     l, h, [x]
-                adcs    l, l, l
-                adcs    h, h, h
-                stp     l, h, [z]
+        ldp     l, h, [x]
+        adcs    l, l, l
+        adcs    h, h, h
+        stp     l, h, [z]
 
-                ldp     l, h, [x, #16]
-                adcs    l, l, l
-                adcs    h, h, h
-                stp     l, h, [z, #16]
+        ldp     l, h, [x, #16]
+        adcs    l, l, l
+        adcs    h, h, h
+        stp     l, h, [z, #16]
 
-                ldp     l, h, [x, #32]
-                adcs    l, l, l
-                adcs    h, h, h
-                stp     l, h, [z, #32]
+        ldp     l, h, [x, #32]
+        adcs    l, l, l
+        adcs    h, h, h
+        stp     l, h, [z, #32]
 
-                ldp     l, h, [x, #48]
-                adcs    l, l, l
-                adcs    h, h, h
-                stp     l, h, [z, #48]
+        ldp     l, h, [x, #48]
+        adcs    l, l, l
+        adcs    h, h, h
+        stp     l, h, [z, #48]
 
-                adc     c, c, c
-                and     c, c, #0x1FF
-                str     c, [z, #64]
+        adc     c, c, c
+        and     c, c, #0x1FF
+        str     c, [z, #64]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_double_p521
-        .globl  _bignum_double_p521
+        .globl bignum_double_p521
+        .private_extern bignum_double_p521
+
+        .globl _bignum_double_p521
+        .private_extern _bignum_double_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_double_p521
-        .private_extern bignum_double_p521
+        S2N_ASM_HIDDEN(bignum_double_p521)
 
         .globl _bignum_double_p521
-        .private_extern _bignum_double_p521
+        S2N_ASM_HIDDEN(_bignum_double_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
@@ -25,8 +25,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_fromlebytes_p521
-        .globl  _bignum_fromlebytes_p521
+        .globl bignum_fromlebytes_p521
+        .private_extern bignum_fromlebytes_p521
+
+        .globl _bignum_fromlebytes_p521
+        .private_extern _bignum_fromlebytes_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
@@ -24,12 +24,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_fromlebytes_p521
-        .private_extern bignum_fromlebytes_p521
+        S2N_ASM_HIDDEN(bignum_fromlebytes_p521)
 
         .globl _bignum_fromlebytes_p521
-        .private_extern _bignum_fromlebytes_p521
+        S2N_ASM_HIDDEN(_bignum_fromlebytes_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
@@ -24,14 +24,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_fromlebytes_p521
-        S2N_ASM_HIDDEN(bignum_fromlebytes_p521)
-
-        .globl _bignum_fromlebytes_p521
-        S2N_ASM_HIDDEN(_bignum_fromlebytes_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_fromlebytes_p521)
         .text
         .balign 4
 
@@ -42,178 +38,177 @@
 #define dshort w2
 #define a x3
 
-bignum_fromlebytes_p521:
-_bignum_fromlebytes_p521:
+S2N_BN_SYMBOL(bignum_fromlebytes_p521):
 
 // word 0
 
-                ldrb    dshort, [x]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #1]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #2]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #3]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #4]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #5]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #6]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #7]
-                extr    a, d, a, #8
-                str     a, [z]
+        ldrb    dshort, [x]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #1]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #2]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #3]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #4]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #5]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #6]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #7]
+        extr    a, d, a, #8
+        str     a, [z]
 
 // word 1
 
-                ldrb    dshort, [x, #8]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #9]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #10]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #11]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #12]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #13]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #14]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #15]
-                extr    a, d, a, #8
-                str     a, [z, #8]
+        ldrb    dshort, [x, #8]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #9]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #10]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #11]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #12]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #13]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #14]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #15]
+        extr    a, d, a, #8
+        str     a, [z, #8]
 
 // word 2
 
-                ldrb    dshort, [x, #16]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #17]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #18]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #19]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #20]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #21]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #22]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #23]
-                extr    a, d, a, #8
-                str     a, [z, #16]
+        ldrb    dshort, [x, #16]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #17]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #18]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #19]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #20]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #21]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #22]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #23]
+        extr    a, d, a, #8
+        str     a, [z, #16]
 
 // word 3
 
-                ldrb    dshort, [x, #24]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #25]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #26]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #27]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #28]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #29]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #30]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #31]
-                extr    a, d, a, #8
-                str     a, [z, #24]
+        ldrb    dshort, [x, #24]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #25]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #26]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #27]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #28]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #29]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #30]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #31]
+        extr    a, d, a, #8
+        str     a, [z, #24]
 
 // word 4
 
-                ldrb    dshort, [x, #32]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #33]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #34]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #35]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #36]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #37]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #38]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #39]
-                extr    a, d, a, #8
-                str     a, [z, #32]
+        ldrb    dshort, [x, #32]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #33]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #34]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #35]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #36]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #37]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #38]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #39]
+        extr    a, d, a, #8
+        str     a, [z, #32]
 
 // word 5
 
-                ldrb    dshort, [x, #40]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #41]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #42]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #43]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #44]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #45]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #46]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #47]
-                extr    a, d, a, #8
-                str     a, [z, #40]
+        ldrb    dshort, [x, #40]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #41]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #42]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #43]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #44]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #45]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #46]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #47]
+        extr    a, d, a, #8
+        str     a, [z, #40]
 
 // word 6
 
-                ldrb    dshort, [x, #48]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #49]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #50]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #51]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #52]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #53]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #54]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #55]
-                extr    a, d, a, #8
-                str     a, [z, #48]
+        ldrb    dshort, [x, #48]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #49]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #50]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #51]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #52]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #53]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #54]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #55]
+        extr    a, d, a, #8
+        str     a, [z, #48]
 
 // word 7
 
-                ldrb    dshort, [x, #56]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #57]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #58]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #59]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #60]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #61]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #62]
-                extr    a, d, a, #8
-                ldrb    dshort, [x, #63]
-                extr    a, d, a, #8
-                str     a, [z, #56]
+        ldrb    dshort, [x, #56]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #57]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #58]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #59]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #60]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #61]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #62]
+        extr    a, d, a, #8
+        ldrb    dshort, [x, #63]
+        extr    a, d, a, #8
+        str     a, [z, #56]
 
 // word 8
 
-                ldrb    dshort, [x, #64]
-                extr    a, d, xzr, #8
-                ldrb    dshort, [x, #65]
-                extr    a, d, a, #56
-                str     a, [z, #64]
+        ldrb    dshort, [x, #64]
+        extr    a, d, xzr, #8
+        ldrb    dshort, [x, #65]
+        extr    a, d, a, #56
+        str     a, [z, #64]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_half_p521
-        S2N_ASM_HIDDEN(bignum_half_p521)
-
-        .globl _bignum_half_p521
-        S2N_ASM_HIDDEN(_bignum_half_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p521)
         .text
         .balign 4
 
@@ -50,40 +46,39 @@
 #define a x6
 
 
-bignum_half_p521:
-_bignum_half_p521:
+S2N_BN_SYMBOL(bignum_half_p521):
 
 // We do a 521-bit rotation one bit right, since 2^521 == 1 (mod p_521)
 
-                ldp     d0, d1, [x]
-                and     a, d0, #1
-                extr    d0, d1, d0, #1
+        ldp     d0, d1, [x]
+        and     a, d0, #1
+        extr    d0, d1, d0, #1
 
-                ldp     d2, d3, [x, #16]
-                extr    d1, d2, d1, #1
-                stp     d0, d1, [z]
-                extr    d2, d3, d2, #1
+        ldp     d2, d3, [x, #16]
+        extr    d1, d2, d1, #1
+        stp     d0, d1, [z]
+        extr    d2, d3, d2, #1
 
-                ldp     d4, d5, [x, #32]
-                extr    d3, d4, d3, #1
-                stp     d2, d3, [z, #16]
-                extr    d4, d5, d4, #1
+        ldp     d4, d5, [x, #32]
+        extr    d3, d4, d3, #1
+        stp     d2, d3, [z, #16]
+        extr    d4, d5, d4, #1
 
-                ldp     d6, d7, [x, #48]
-                extr    d5, d6, d5, #1
-                stp     d4, d5, [z, #32]
-                extr    d6, d7, d6, #1
+        ldp     d6, d7, [x, #48]
+        extr    d5, d6, d5, #1
+        stp     d4, d5, [z, #32]
+        extr    d6, d7, d6, #1
 
-                ldr     d8, [x, #64]
-                extr    d7, d8, d7, #1
-                stp     d6, d7, [z, #48]
-                lsl     d8, d8, #55
-                extr    d8, a, d8, #56
-                str     d8, [z, #64]
+        ldr     d8, [x, #64]
+        extr    d7, d8, d7, #1
+        stp     d6, d7, [z, #48]
+        lsl     d8, d8, #55
+        extr    d8, a, d8, #56
+        str     d8, [z, #64]
 
 // Return
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_half_p521
-        .private_extern bignum_half_p521
+        S2N_ASM_HIDDEN(bignum_half_p521)
 
         .globl _bignum_half_p521
-        .private_extern _bignum_half_p521
+        S2N_ASM_HIDDEN(_bignum_half_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_half_p521
-        .globl  _bignum_half_p521
+        .globl bignum_half_p521
+        .private_extern bignum_half_p521
+
+        .globl _bignum_half_p521
+        .private_extern _bignum_half_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
@@ -24,20 +24,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_mod_n521_9
-        S2N_ASM_HIDDEN(bignum_mod_n521_9)
-
-        .globl _bignum_mod_n521_9
-        S2N_ASM_HIDDEN(_bignum_mod_n521_9)
-
-        .globl bignum_mod_n521_9_alt
-        S2N_ASM_HIDDEN(bignum_mod_n521_9_alt)
-
-        .globl _bignum_mod_n521_9_alt
-        S2N_ASM_HIDDEN(_bignum_mod_n521_9_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n521_9)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n521_9)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n521_9_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n521_9_alt)
         .text
         .balign 4
 
@@ -67,97 +59,96 @@
 #define t d7
 
 #define movbig(nn,n3,n2,n1,n0)                                              \
-                movz    nn, n0;                                             \
-                movk    nn, n1, lsl #16;                                    \
-                movk    nn, n2, lsl #32;                                    \
-                movk    nn, n3, lsl #48
+        movz    nn, n0;                                             \
+        movk    nn, n1, lsl #16;                                    \
+        movk    nn, n2, lsl #32;                                    \
+        movk    nn, n3, lsl #48
 
-bignum_mod_n521_9:
-_bignum_mod_n521_9:
-bignum_mod_n521_9_alt:
-_bignum_mod_n521_9_alt:
+S2N_BN_SYMBOL(bignum_mod_n521_9):
+
+S2N_BN_SYMBOL(bignum_mod_n521_9_alt):
 
 // Load the top digit first into d8.
 // The initial quotient estimate is q = h + 1 where x = 2^521 * h + t
 
-                ldr     d8, [x, #64]
-                lsr     q, d8, #9
-                add     q, q, #1
+        ldr     d8, [x, #64]
+        lsr     q, d8, #9
+        add     q, q, #1
 
 // Let [5; n3; n2; n1; n0] = r_521 = 2^521 - n_521
 // and form [d4;d3;d2;d1;d0] = q * r_521
 
-                movbig( n0, #0x4490, #0x48e1, #0x6ec7, #0x9bf7)
-                mul     d0, n0, q
-                movbig( n1, #0xc44a, #0x3647, #0x7663, #0xb851)
-                mul     d1, n1, q
-                movbig( n2, #0x8033, #0xfeb7, #0x08f6, #0x5a2f)
-                mul     d2, n2, q
-                movbig( n3, #0xae79, #0x787c, #0x40d0, #0x6994)
-                mul     d3, n3, q
-                lsl     d4, q, #2
-                add     d4, d4, q
-                umulh   t, n0, q
-                adds    d1, d1, t
-                umulh   t, n1, q
-                adcs    d2, d2, t
-                umulh   t, n2, q
-                adcs    d3, d3, t
-                umulh   t, n3, q
-                adc     d4, d4, t
+        movbig( n0, #0x4490, #0x48e1, #0x6ec7, #0x9bf7)
+        mul     d0, n0, q
+        movbig( n1, #0xc44a, #0x3647, #0x7663, #0xb851)
+        mul     d1, n1, q
+        movbig( n2, #0x8033, #0xfeb7, #0x08f6, #0x5a2f)
+        mul     d2, n2, q
+        movbig( n3, #0xae79, #0x787c, #0x40d0, #0x6994)
+        mul     d3, n3, q
+        lsl     d4, q, #2
+        add     d4, d4, q
+        umulh   t, n0, q
+        adds    d1, d1, t
+        umulh   t, n1, q
+        adcs    d2, d2, t
+        umulh   t, n2, q
+        adcs    d3, d3, t
+        umulh   t, n3, q
+        adc     d4, d4, t
 
 // Now load other digits and form r = x - q * n_521 = (q * r_521 + t) - 2^521.
 // But the computed result stuffs in 1s from bit 521 onwards and actually
 // gives r' = (q * r_521 + t) + (2^576 - 2^521) = r + 2^576, including the
 // top carry. Hence CF <=> r >= 0, while r' == r (mod 2^521).
 
-                ldp     s, t, [x]
-                adds    d0, d0, s
-                adcs    d1, d1, t
-                ldp     s, t, [x, #16]
-                adcs    d2, d2, s
-                adcs    d3, d3, t
-                ldp     t, d5, [x, #32]
-                adcs    d4, d4, t
-                adcs    d5, d5, xzr
-                ldp     d6, d7, [x, #48]
-                adcs    d6, d6, xzr
-                adcs    d7, d7, xzr
-                orr     d8, d8, #~0x1FF
-                adcs    d8, d8, xzr
+        ldp     s, t, [x]
+        adds    d0, d0, s
+        adcs    d1, d1, t
+        ldp     s, t, [x, #16]
+        adcs    d2, d2, s
+        adcs    d3, d3, t
+        ldp     t, d5, [x, #32]
+        adcs    d4, d4, t
+        adcs    d5, d5, xzr
+        ldp     d6, d7, [x, #48]
+        adcs    d6, d6, xzr
+        adcs    d7, d7, xzr
+        orr     d8, d8, #~0x1FF
+        adcs    d8, d8, xzr
 
 // We already know r < n_521, but if it actually went negative then
 // we need to add back n_521 again. Recycle q as a bitmask for r < n_521,
 // and just subtract r_521 and mask rather than literally adding 2^521.
 // This also gets rid of the bit-stuffing above.
 
-                csetm   q, cc
-                and     n0, n0, q
-                subs    d0, d0, n0
-                and     n1, n1, q
-                sbcs    d1, d1, n1
-                and     n2, n2, q
-                sbcs    d2, d2, n2
-                and     n3, n3, q
-                sbcs    d3, d3, n3
-                mov     n0, #5
-                and     n0, n0, q
-                sbcs    d4, d4, n0
-                sbcs    d5, d5, xzr
-                sbcs    d6, d6, xzr
-                sbcs    d7, d7, xzr
-                sbc     d8, d8, xzr
-                and     d8, d8, #0x1FF
+        csetm   q, cc
+        and     n0, n0, q
+        subs    d0, d0, n0
+        and     n1, n1, q
+        sbcs    d1, d1, n1
+        and     n2, n2, q
+        sbcs    d2, d2, n2
+        and     n3, n3, q
+        sbcs    d3, d3, n3
+        mov     n0, #5
+        and     n0, n0, q
+        sbcs    d4, d4, n0
+        sbcs    d5, d5, xzr
+        sbcs    d6, d6, xzr
+        sbcs    d7, d7, xzr
+        sbc     d8, d8, xzr
+        and     d8, d8, #0x1FF
 
 // Store the end result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
@@ -24,18 +24,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n521_9
-        .private_extern bignum_mod_n521_9
+        S2N_ASM_HIDDEN(bignum_mod_n521_9)
 
         .globl _bignum_mod_n521_9
-        .private_extern _bignum_mod_n521_9
+        S2N_ASM_HIDDEN(_bignum_mod_n521_9)
 
         .globl bignum_mod_n521_9_alt
-        .private_extern bignum_mod_n521_9_alt
+        S2N_ASM_HIDDEN(bignum_mod_n521_9_alt)
 
         .globl _bignum_mod_n521_9_alt
-        .private_extern _bignum_mod_n521_9_alt
+        S2N_ASM_HIDDEN(_bignum_mod_n521_9_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
@@ -25,10 +25,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_n521_9
-        .globl  _bignum_mod_n521_9
-        .globl  bignum_mod_n521_9_alt
-        .globl  _bignum_mod_n521_9_alt
+        .globl bignum_mod_n521_9
+        .private_extern bignum_mod_n521_9
+
+        .globl _bignum_mod_n521_9
+        .private_extern _bignum_mod_n521_9
+
+        .globl bignum_mod_n521_9_alt
+        .private_extern bignum_mod_n521_9_alt
+
+        .globl _bignum_mod_n521_9_alt
+        .private_extern _bignum_mod_n521_9_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_mod_p521_9
-        S2N_ASM_HIDDEN(bignum_mod_p521_9)
-
-        .globl _bignum_mod_p521_9
-        S2N_ASM_HIDDEN(_bignum_mod_p521_9)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p521_9)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p521_9)
         .text
         .balign 4
 
@@ -48,15 +44,14 @@
 #define d7 x11
 #define d8 x12
 
-bignum_mod_p521_9:
-_bignum_mod_p521_9:
+S2N_BN_SYMBOL(bignum_mod_p521_9):
 
 // Load top digit first and get its upper bits in h so that we
 // separate out x = 2^521 * H + L with h = H. Now x mod p_521 =
 // (H + L) mod p_521 = if H + L >= p_521 then H + L - p_521 else H + L.
 
-                ldr     d8, [x, #64]
-                lsr     h, d8, #9
+        ldr     d8, [x, #64]
+        lsr     h, d8, #9
 
 // Load in the other digits and decide whether H + L >= p_521. This is
 // equivalent to H + L + 1 >= 2^521, and since this can only happen if
@@ -65,45 +60,45 @@ _bignum_mod_p521_9:
 // This condenses only three pairs; the payoff beyond that seems limited.
 // By stuffing in 1 bits from 521 position upwards, get CF directly
 
-                subs    xzr, xzr, xzr
-                ldp     d0, d1, [x]
-                adcs    xzr, d0, h
-                adcs    xzr, d1, xzr
-                ldp     d2, d3, [x, #16]
-                and     t, d2, d3
-                adcs    xzr, t, xzr
-                ldp     d4, d5, [x, #32]
-                and     t, d4, d5
-                adcs    xzr, t, xzr
-                ldp     d6, d7, [x, #48]
-                and     t, d6, d7
-                adcs    xzr, t, xzr
-                orr     t, d8, #~0x1FF
-                adcs    t, t, xzr
+        subs    xzr, xzr, xzr
+        ldp     d0, d1, [x]
+        adcs    xzr, d0, h
+        adcs    xzr, d1, xzr
+        ldp     d2, d3, [x, #16]
+        and     t, d2, d3
+        adcs    xzr, t, xzr
+        ldp     d4, d5, [x, #32]
+        and     t, d4, d5
+        adcs    xzr, t, xzr
+        ldp     d6, d7, [x, #48]
+        and     t, d6, d7
+        adcs    xzr, t, xzr
+        orr     t, d8, #~0x1FF
+        adcs    t, t, xzr
 
 // Now H + L >= p_521 <=> H + L + 1 >= 2^521 <=> CF from this comparison.
 // So if CF is set we want (H + L) - p_521 = (H + L + 1) - 2^521
 // while otherwise we want just H + L. So mask H + L + CF to 521 bits.
 
-                adcs    d0, d0, h
-                adcs    d1, d1, xzr
-                adcs    d2, d2, xzr
-                adcs    d3, d3, xzr
-                adcs    d4, d4, xzr
-                adcs    d5, d5, xzr
-                adcs    d6, d6, xzr
-                adcs    d7, d7, xzr
-                adc     d8, d8, xzr
-                and     d8, d8, #0x1FF
+        adcs    d0, d0, h
+        adcs    d1, d1, xzr
+        adcs    d2, d2, xzr
+        adcs    d3, d3, xzr
+        adcs    d4, d4, xzr
+        adcs    d5, d5, xzr
+        adcs    d6, d6, xzr
+        adcs    d7, d7, xzr
+        adc     d8, d8, xzr
+        and     d8, d8, #0x1FF
 
 // Store the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
-                ret
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p521_9
-        .private_extern bignum_mod_p521_9
+        S2N_ASM_HIDDEN(bignum_mod_p521_9)
 
         .globl _bignum_mod_p521_9
-        .private_extern _bignum_mod_p521_9
+        S2N_ASM_HIDDEN(_bignum_mod_p521_9)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mod_p521_9
-        .globl  _bignum_mod_p521_9
+        .globl bignum_mod_p521_9
+        .private_extern bignum_mod_p521_9
+
+        .globl _bignum_mod_p521_9
+        .private_extern _bignum_mod_p521_9
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
@@ -28,8 +28,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montmul_p521
-        .globl  _bignum_montmul_p521
+        .globl bignum_montmul_p521
+        .private_extern bignum_montmul_p521
+
+        .globl _bignum_montmul_p521
+        .private_extern _bignum_montmul_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
@@ -27,14 +27,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_montmul_p521
-        S2N_ASM_HIDDEN(bignum_montmul_p521)
-
-        .globl _bignum_montmul_p521
-        S2N_ASM_HIDDEN(_bignum_montmul_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p521)
         .text
         .balign 4
 
@@ -100,174 +96,173 @@
 
 #define mul4                                                            \
 /*  First accumulate all the "simple" products as [s7,s6,s5,s4,s0] */   \
-                                                                        \
-                mul     s0, a0, b0;                                     \
-                mul     s4, a1, b1;                                     \
-                mul     s5, a2, b2;                                     \
-                mul     s6, a3, b3;                                     \
-                                                                        \
-                umulh   s7, a0, b0;                                     \
-                adds    s4, s4, s7;                                     \
-                umulh   s7, a1, b1;                                     \
-                adcs    s5, s5, s7;                                     \
-                umulh   s7, a2, b2;                                     \
-                adcs    s6, s6, s7;                                     \
-                umulh   s7, a3, b3;                                     \
-                adc     s7, s7, xzr;                                    \
-                                                                        \
+        \
+        mul     s0, a0, b0;                                     \
+        mul     s4, a1, b1;                                     \
+        mul     s5, a2, b2;                                     \
+        mul     s6, a3, b3;                                     \
+        \
+        umulh   s7, a0, b0;                                     \
+        adds    s4, s4, s7;                                     \
+        umulh   s7, a1, b1;                                     \
+        adcs    s5, s5, s7;                                     \
+        umulh   s7, a2, b2;                                     \
+        adcs    s6, s6, s7;                                     \
+        umulh   s7, a3, b3;                                     \
+        adc     s7, s7, xzr;                                    \
+        \
 /*  Multiply by B + 1 to get [s7;s6;s5;s4;s1;s0] */                     \
-                                                                        \
-                adds    s1, s4, s0;                                     \
-                adcs    s4, s5, s4;                                     \
-                adcs    s5, s6, s5;                                     \
-                adcs    s6, s7, s6;                                     \
-                adc     s7, xzr, s7;                                    \
-                                                                        \
+        \
+        adds    s1, s4, s0;                                     \
+        adcs    s4, s5, s4;                                     \
+        adcs    s5, s6, s5;                                     \
+        adcs    s6, s7, s6;                                     \
+        adc     s7, xzr, s7;                                    \
+        \
 /*  Multiply by B^2 + 1 to get [s7;s6;s5;s4;s3;s2;s1;s0] */             \
-                                                                        \
-                adds    s2, s4, s0;                                     \
-                adcs    s3, s5, s1;                                     \
-                adcs    s4, s6, s4;                                     \
-                adcs    s5, s7, s5;                                     \
-                adcs    s6, xzr, s6;                                    \
-                adc     s7, xzr, s7;                                    \
-                                                                        \
+        \
+        adds    s2, s4, s0;                                     \
+        adcs    s3, s5, s1;                                     \
+        adcs    s4, s6, s4;                                     \
+        adcs    s5, s7, s5;                                     \
+        adcs    s6, xzr, s6;                                    \
+        adc     s7, xzr, s7;                                    \
+        \
 /*  Now add in all the "complicated" terms. */                          \
-                                                                        \
-                muldiffnadd(s6,s5, a2,a3, b3,b2);                       \
-                adc     s7, s7, c;                                      \
-                                                                        \
-                muldiffnadd(s2,s1, a0,a1, b1,b0);                       \
-                adcs    s3, s3, c;                                      \
-                adcs    s4, s4, c;                                      \
-                adcs    s5, s5, c;                                      \
-                adcs    s6, s6, c;                                      \
-                adc     s7, s7, c;                                      \
-                                                                        \
-                muldiffnadd(s5,s4, a1,a3, b3,b1);                       \
-                adcs    s6, s6, c;                                      \
-                adc     s7, s7, c;                                      \
-                                                                        \
-                muldiffnadd(s3,s2, a0,a2, b2,b0);                       \
-                adcs    s4, s4, c;                                      \
-                adcs    s5, s5, c;                                      \
-                adcs    s6, s6, c;                                      \
-                adc     s7, s7, c;                                      \
-                                                                        \
-                muldiffnadd(s4,s3, a0,a3, b3,b0);                       \
-                adcs    s5, s5, c;                                      \
-                adcs    s6, s6, c;                                      \
-                adc     s7, s7, c;                                      \
-                muldiffnadd(s4,s3, a1,a2, b2,b1);                       \
-                adcs    s5, s5, c;                                      \
-                adcs    s6, s6, c;                                      \
-                adc     s7, s7, c                                       \
+        \
+        muldiffnadd(s6,s5, a2,a3, b3,b2);                       \
+        adc     s7, s7, c;                                      \
+        \
+        muldiffnadd(s2,s1, a0,a1, b1,b0);                       \
+        adcs    s3, s3, c;                                      \
+        adcs    s4, s4, c;                                      \
+        adcs    s5, s5, c;                                      \
+        adcs    s6, s6, c;                                      \
+        adc     s7, s7, c;                                      \
+        \
+        muldiffnadd(s5,s4, a1,a3, b3,b1);                       \
+        adcs    s6, s6, c;                                      \
+        adc     s7, s7, c;                                      \
+        \
+        muldiffnadd(s3,s2, a0,a2, b2,b0);                       \
+        adcs    s4, s4, c;                                      \
+        adcs    s5, s5, c;                                      \
+        adcs    s6, s6, c;                                      \
+        adc     s7, s7, c;                                      \
+        \
+        muldiffnadd(s4,s3, a0,a3, b3,b0);                       \
+        adcs    s5, s5, c;                                      \
+        adcs    s6, s6, c;                                      \
+        adc     s7, s7, c;                                      \
+        muldiffnadd(s4,s3, a1,a2, b2,b1);                       \
+        adcs    s5, s5, c;                                      \
+        adcs    s6, s6, c;                                      \
+        adc     s7, s7, c                                       \
 
-bignum_montmul_p521:
-_bignum_montmul_p521:
+S2N_BN_SYMBOL(bignum_montmul_p521):
 
 // Save registers and make space for the temporary buffer
 
-                stp     x19, x20, [sp, #-16]!
-                stp     x21, x22, [sp, #-16]!
-                stp     x23, x24, [sp, #-16]!
-                stp     x25, x26, [sp, #-16]!
-                sub     sp, sp, #80
+        stp     x19, x20, [sp, #-16]!
+        stp     x21, x22, [sp, #-16]!
+        stp     x23, x24, [sp, #-16]!
+        stp     x25, x26, [sp, #-16]!
+        sub     sp, sp, #80
 
 // Load 4-digit low parts and multiply them to get L
 
-                ldp     a0, a1, [x]
-                ldp     a2, a3, [x, #16]
-                ldp     b0, b1, [y]
-                ldp     b2, b3, [y, #16]
-                mul4
+        ldp     a0, a1, [x]
+        ldp     a2, a3, [x, #16]
+        ldp     b0, b1, [y]
+        ldp     b2, b3, [y, #16]
+        mul4
 
 // Shift right 256 bits modulo p_521 and stash in temp buffer
 
-                lsl     c, s0, #9
-                extr    s0, s1, s0, #55
-                extr    s1, s2, s1, #55
-                extr    s2, s3, s2, #55
-                lsr     s3, s3, #55
-                stp     s4, s5, [sp]
-                stp     s6, s7, [sp, #16]
-                stp     c, s0, [sp, #32]
-                stp     s1, s2, [sp, #48]
-                str     s3, [sp, #64]
+        lsl     c, s0, #9
+        extr    s0, s1, s0, #55
+        extr    s1, s2, s1, #55
+        extr    s2, s3, s2, #55
+        lsr     s3, s3, #55
+        stp     s4, s5, [sp]
+        stp     s6, s7, [sp, #16]
+        stp     c, s0, [sp, #32]
+        stp     s1, s2, [sp, #48]
+        str     s3, [sp, #64]
 
 // Load 4-digit low parts and multiply them to get H
 
-                ldp     a0, a1, [x, #32]
-                ldp     a2, a3, [x, #48]
-                ldp     b0, b1, [y, #32]
-                ldp     b2, b3, [y, #48]
-                mul4
+        ldp     a0, a1, [x, #32]
+        ldp     a2, a3, [x, #48]
+        ldp     b0, b1, [y, #32]
+        ldp     b2, b3, [y, #48]
+        mul4
 
 // Add to the existing temporary buffer and re-stash.
 // This gives a result HL congruent to (2^256 * H + L) / 2^256 modulo p_521
 
-                ldp     l, h, [sp]
-                adds    s0, s0, l
-                adcs    s1, s1, h
-                stp     s0, s1, [sp]
-                ldp     l, h, [sp, #16]
-                adcs    s2, s2, l
-                adcs    s3, s3, h
-                stp     s2, s3, [sp, #16]
-                ldp     l, h, [sp, #32]
-                adcs    s4, s4, l
-                adcs    s5, s5, h
-                stp     s4, s5, [sp, #32]
-                ldp     l, h, [sp, #48]
-                adcs    s6, s6, l
-                adcs    s7, s7, h
-                stp     s6, s7, [sp, #48]
-                ldr     c, [sp, #64]
-                adc     c, c, xzr
-                str     c, [sp, #64]
+        ldp     l, h, [sp]
+        adds    s0, s0, l
+        adcs    s1, s1, h
+        stp     s0, s1, [sp]
+        ldp     l, h, [sp, #16]
+        adcs    s2, s2, l
+        adcs    s3, s3, h
+        stp     s2, s3, [sp, #16]
+        ldp     l, h, [sp, #32]
+        adcs    s4, s4, l
+        adcs    s5, s5, h
+        stp     s4, s5, [sp, #32]
+        ldp     l, h, [sp, #48]
+        adcs    s6, s6, l
+        adcs    s7, s7, h
+        stp     s6, s7, [sp, #48]
+        ldr     c, [sp, #64]
+        adc     c, c, xzr
+        str     c, [sp, #64]
 
 // Compute t,[a3,a2,a1,a0] = x_hi - x_lo
 // and     s,[b3,b2,b1,b0] = y_lo - y_hi
 // sign-magnitude differences, then XOR overall sign bitmask into s
 
-                ldp     l, h, [x]
-                subs    a0, a0, l
-                sbcs    a1, a1, h
-                ldp     l, h, [x, #16]
-                sbcs    a2, a2, l
-                sbcs    a3, a3, h
-                csetm   t, cc
-                ldp     l, h, [y]
-                subs    b0, l, b0
-                sbcs    b1, h, b1
-                ldp     l, h, [y, #16]
-                sbcs    b2, l, b2
-                sbcs    b3, h, b3
-                csetm   s, cc
+        ldp     l, h, [x]
+        subs    a0, a0, l
+        sbcs    a1, a1, h
+        ldp     l, h, [x, #16]
+        sbcs    a2, a2, l
+        sbcs    a3, a3, h
+        csetm   t, cc
+        ldp     l, h, [y]
+        subs    b0, l, b0
+        sbcs    b1, h, b1
+        ldp     l, h, [y, #16]
+        sbcs    b2, l, b2
+        sbcs    b3, h, b3
+        csetm   s, cc
 
-                eor     a0, a0, t
-                subs    a0, a0, t
-                eor     a1, a1, t
-                sbcs    a1, a1, t
-                eor     a2, a2, t
-                sbcs    a2, a2, t
-                eor     a3, a3, t
-                sbc     a3, a3, t
+        eor     a0, a0, t
+        subs    a0, a0, t
+        eor     a1, a1, t
+        sbcs    a1, a1, t
+        eor     a2, a2, t
+        sbcs    a2, a2, t
+        eor     a3, a3, t
+        sbc     a3, a3, t
 
-                eor     b0, b0, s
-                subs    b0, b0, s
-                eor     b1, b1, s
-                sbcs    b1, b1, s
-                eor     b2, b2, s
-                sbcs    b2, b2, s
-                eor     b3, b3, s
-                sbc     b3, b3, s
+        eor     b0, b0, s
+        subs    b0, b0, s
+        eor     b1, b1, s
+        sbcs    b1, b1, s
+        eor     b2, b2, s
+        sbcs    b2, b2, s
+        eor     b3, b3, s
+        sbc     b3, b3, s
 
-                eor     s, s, t
+        eor     s, s, t
 
 // Now do yet a third 4x4 multiply to get mid-term product M
 
-                mul4
+        mul4
 
 // We now want, at the 256 position, 2^256 * HL + HL + (-1)^s * M
 // To keep things positive we use M' = p_521 - M in place of -M,
@@ -283,48 +278,48 @@ _bignum_montmul_p521:
 // small c (s8 + suspended carry) to add at the 256 position here (512
 // overall). This can be added in the next block (to b0 = sum4).
 
-                ldp     a0, a1, [sp]
-                ldp     a2, a3, [sp, #16]
+        ldp     a0, a1, [sp]
+        ldp     a2, a3, [sp, #16]
 
-                eor     s0, s0, s
-                adds    s0, s0, a0
-                eor     s1, s1, s
-                adcs    s1, s1, a1
-                eor     s2, s2, s
-                adcs    s2, s2, a2
-                eor     s3, s3, s
-                adcs    s3, s3, a3
-                eor     s4, s4, s
+        eor     s0, s0, s
+        adds    s0, s0, a0
+        eor     s1, s1, s
+        adcs    s1, s1, a1
+        eor     s2, s2, s
+        adcs    s2, s2, a2
+        eor     s3, s3, s
+        adcs    s3, s3, a3
+        eor     s4, s4, s
 
-                ldp     b0, b1, [sp, #32]
-                ldp     b2, b3, [sp, #48]
-                ldr     s8, [sp, #64]
+        ldp     b0, b1, [sp, #32]
+        ldp     b2, b3, [sp, #48]
+        ldr     s8, [sp, #64]
 
-                adcs    s4, s4, b0
-                eor     s5, s5, s
-                adcs    s5, s5, b1
-                eor     s6, s6, s
-                adcs    s6, s6, b2
-                eor     s7, s7, s
-                adcs    s7, s7, b3
-                adc     c, s8, xzr
+        adcs    s4, s4, b0
+        eor     s5, s5, s
+        adcs    s5, s5, b1
+        eor     s6, s6, s
+        adcs    s6, s6, b2
+        eor     s7, s7, s
+        adcs    s7, s7, b3
+        adc     c, s8, xzr
 
-                adds    s4, s4, a0
-                adcs    s5, s5, a1
-                adcs    s6, s6, a2
-                adcs    s7, s7, a3
-                and     s, s, #0x1FF
-                lsl     t, s0, #9
-                orr     t, t, s
-                adcs    b0, b0, t
-                extr    t, s1, s0, #55
-                adcs    b1, b1, t
-                extr    t, s2, s1, #55
-                adcs    b2, b2, t
-                extr    t, s3, s2, #55
-                adcs    b3, b3, t
-                lsr     t, s3, #55
-                adc     s8, t, s8
+        adds    s4, s4, a0
+        adcs    s5, s5, a1
+        adcs    s6, s6, a2
+        adcs    s7, s7, a3
+        and     s, s, #0x1FF
+        lsl     t, s0, #9
+        orr     t, t, s
+        adcs    b0, b0, t
+        extr    t, s1, s0, #55
+        adcs    b1, b1, t
+        extr    t, s2, s1, #55
+        adcs    b2, b2, t
+        extr    t, s3, s2, #55
+        adcs    b3, b3, t
+        lsr     t, s3, #55
+        adc     s8, t, s8
 
 // Augment the total with the contribution from the top little words
 // w and v. If we write the inputs as 2^512 * w + x and 2^512 * v + y
@@ -371,239 +366,239 @@ _bignum_montmul_p521:
 
 // 0 * 52 = 64 * 0 + 0
 
-                ldr     v, [y, #64]
-                ldp     c0, c1, [x]
-                and     l, c0, #0x000fffffffffffff
-                mul     l, v, l
-                ldr     w, [x, #64]
-                ldp     d0, d1, [y]
-                and     t, d0, #0x000fffffffffffff
-                mul     t, w, t
-                add     l, l, t
+        ldr     v, [y, #64]
+        ldp     c0, c1, [x]
+        and     l, c0, #0x000fffffffffffff
+        mul     l, v, l
+        ldr     w, [x, #64]
+        ldp     d0, d1, [y]
+        and     t, d0, #0x000fffffffffffff
+        mul     t, w, t
+        add     l, l, t
 
 // 1 * 52 = 64 * 0 + 52
 
-                extr    t, c1, c0, #52
-                and     t, t, #0x000fffffffffffff
-                mul     h, v, t
-                extr    t, d1, d0, #52
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     h, h, t
-                lsr     t, l, #52
-                add     h, h, t
+        extr    t, c1, c0, #52
+        and     t, t, #0x000fffffffffffff
+        mul     h, v, t
+        extr    t, d1, d0, #52
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     h, h, t
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #12
-                adds    sum0, sum0, t
+        lsl     l, l, #12
+        extr    t, h, l, #12
+        adds    sum0, sum0, t
 
 // 2 * 52 = 64 * 1 + 40
 
-                ldp     c2, c3, [x, #16]
-                ldp     d2, d3, [y, #16]
-                extr    t, c2, c1, #40
-                and     t, t, #0x000fffffffffffff
-                mul     l, v, t
-                extr    t, d2, d1, #40
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     l, l, t
-                lsr     t, h, #52
-                add     l, l, t
+        ldp     c2, c3, [x, #16]
+        ldp     d2, d3, [y, #16]
+        extr    t, c2, c1, #40
+        and     t, t, #0x000fffffffffffff
+        mul     l, v, t
+        extr    t, d2, d1, #40
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     l, l, t
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #24
-                adcs    sum1, sum1, t
+        lsl     h, h, #12
+        extr    t, l, h, #24
+        adcs    sum1, sum1, t
 
 // 3 * 52 = 64 * 2 + 28
 
-                extr    t, c3, c2, #28
-                and     t, t, #0x000fffffffffffff
-                mul     h, v, t
-                extr    t, d3, d2, #28
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     h, h, t
-                lsr     t, l, #52
-                add     h, h, t
+        extr    t, c3, c2, #28
+        and     t, t, #0x000fffffffffffff
+        mul     h, v, t
+        extr    t, d3, d2, #28
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     h, h, t
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #36
-                adcs    sum2, sum2, t
-                and     u, sum1, sum2
+        lsl     l, l, #12
+        extr    t, h, l, #36
+        adcs    sum2, sum2, t
+        and     u, sum1, sum2
 
 // 4 * 52 = 64 * 3 + 16
 // At this point we also fold in the addition of c at the right place.
 // Note that 4 * 64 = 4 * 52 + 48 so we shift c left 48 places to align.
 
-                ldp     c4, c5, [x, #32]
-                ldp     d4, d5, [y, #32]
-                extr    t, c4, c3, #16
-                and     t, t, #0x000fffffffffffff
-                mul     l, v, t
-                extr    t, d4, d3, #16
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     l, l, t
+        ldp     c4, c5, [x, #32]
+        ldp     d4, d5, [y, #32]
+        extr    t, c4, c3, #16
+        and     t, t, #0x000fffffffffffff
+        mul     l, v, t
+        extr    t, d4, d3, #16
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     l, l, t
 
-                lsl     c, c, #48
-                add     l, l, c
+        lsl     c, c, #48
+        add     l, l, c
 
-                lsr     t, h, #52
-                add     l, l, t
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #48
-                adcs    sum3, sum3, t
-                and     u, u, sum3
+        lsl     h, h, #12
+        extr    t, l, h, #48
+        adcs    sum3, sum3, t
+        and     u, u, sum3
 
 // 5 * 52 = 64 * 4 + 4
 
-                lsr     t, c4, #4
-                and     t, t, #0x000fffffffffffff
-                mul     h, v, t
-                lsr     t, d4, #4
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     h, h, t
+        lsr     t, c4, #4
+        and     t, t, #0x000fffffffffffff
+        mul     h, v, t
+        lsr     t, d4, #4
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     h, h, t
 
-                lsr     t, l, #52
-                add     h, h, t
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    s, h, l, #60
+        lsl     l, l, #12
+        extr    s, h, l, #60
 
 // 6 * 52 = 64 * 4 + 56
 
-                extr    t, c5, c4, #56
-                and     t, t, #0x000fffffffffffff
-                mul     l, v, t
-                extr    t, d5, d4, #56
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     l, l, t
+        extr    t, c5, c4, #56
+        and     t, t, #0x000fffffffffffff
+        mul     l, v, t
+        extr    t, d5, d4, #56
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     l, l, t
 
-                lsr     t, h, #52
-                add     l, l, t
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     s, s, #8
-                extr    t, l, s, #8
-                adcs    sum4, sum4, t
-                and     u, u, sum4
+        lsl     s, s, #8
+        extr    t, l, s, #8
+        adcs    sum4, sum4, t
+        and     u, u, sum4
 
 // 7 * 52 = 64 * 5 + 44
 
-                ldp     c6, c7, [x, #48]
-                ldp     d6, d7, [y, #48]
-                extr    t, c6, c5, #44
-                and     t, t, #0x000fffffffffffff
-                mul     h, v, t
-                extr    t, d6, d5, #44
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     h, h, t
+        ldp     c6, c7, [x, #48]
+        ldp     d6, d7, [y, #48]
+        extr    t, c6, c5, #44
+        and     t, t, #0x000fffffffffffff
+        mul     h, v, t
+        extr    t, d6, d5, #44
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     h, h, t
 
-                lsr     t, l, #52
-                add     h, h, t
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #20
-                adcs    sum5, sum5, t
-                and     u, u, sum5
+        lsl     l, l, #12
+        extr    t, h, l, #20
+        adcs    sum5, sum5, t
+        and     u, u, sum5
 
 // 8 * 52 = 64 * 6 + 32
 
-                extr    t, c7, c6, #32
-                and     t, t, #0x000fffffffffffff
-                mul     l, v, t
-                extr    t, d7, d6, #32
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     l, l, t
+        extr    t, c7, c6, #32
+        and     t, t, #0x000fffffffffffff
+        mul     l, v, t
+        extr    t, d7, d6, #32
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     l, l, t
 
-                lsr     t, h, #52
-                add     l, l, t
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #32
-                adcs    sum6, sum6, t
-                and     u, u, sum6
+        lsl     h, h, #12
+        extr    t, l, h, #32
+        adcs    sum6, sum6, t
+        and     u, u, sum6
 
 // 9 * 52 = 64 * 7 + 20
 
-                lsr     t, c7, #20
-                mul     h, v, t
-                lsr     t, d7, #20
-                mul     t, w, t
-                add     h, h, t
+        lsr     t, c7, #20
+        mul     h, v, t
+        lsr     t, d7, #20
+        mul     t, w, t
+        add     h, h, t
 
-                lsr     t, l, #52
-                add     h, h, t
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #44
-                adcs    sum7, sum7, t
-                and     u, u, sum7
+        lsl     l, l, #12
+        extr    t, h, l, #44
+        adcs    sum7, sum7, t
+        and     u, u, sum7
 
 // Top word
 
-                mul     t, v, w
-                lsr     h, h, #44
-                add     t, t, h
-                adc     sum8, sum8, t
+        mul     t, v, w
+        lsr     h, h, #44
+        add     t, t, h
+        adc     sum8, sum8, t
 
 // Extract the high part h and mask off the low part l = [sum8;sum7;...;sum0]
 // but stuff sum8 with 1 bits at the left to ease a comparison below
 
-                lsr     h, sum8, #9
-                orr     sum8, sum8, #~0x1FF
+        lsr     h, sum8, #9
+        orr     sum8, sum8, #~0x1FF
 
 // Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
 // happen if digits sum7,...sum1 are all 1s, we use the AND of them "u" to
 // condense the carry chain, and since we stuffed 1 bits into sum8 we get
 // the result in CF without an additional comparison.
 
-                subs    xzr, xzr, xzr
-                adcs    xzr, sum0, h
-                adcs    xzr, u, xzr
-                adcs    xzr, sum8, xzr
+        subs    xzr, xzr, xzr
+        adcs    xzr, sum0, h
+        adcs    xzr, u, xzr
+        adcs    xzr, sum8, xzr
 
 // Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
 // while otherwise we want just h + l. So mask h + l + CF to 521 bits.
 // The masking is combined with the writeback in the next block.
 
-                adcs    sum0, sum0, h
-                adcs    sum1, sum1, xzr
-                adcs    sum2, sum2, xzr
-                adcs    sum3, sum3, xzr
-                adcs    sum4, sum4, xzr
-                adcs    sum5, sum5, xzr
-                adcs    sum6, sum6, xzr
-                adcs    sum7, sum7, xzr
-                adc     sum8, sum8, xzr
+        adcs    sum0, sum0, h
+        adcs    sum1, sum1, xzr
+        adcs    sum2, sum2, xzr
+        adcs    sum3, sum3, xzr
+        adcs    sum4, sum4, xzr
+        adcs    sum5, sum5, xzr
+        adcs    sum6, sum6, xzr
+        adcs    sum7, sum7, xzr
+        adc     sum8, sum8, xzr
 
 // The result is actually [sum8;...;sum0] == product / 2^512, since we are
 // in the 512 position. For Montgomery we want product / 2^576, so write
 // back [sum8;...;sum0] rotated right by 64 bits, as a 521-bit quantity.
 
-                stp     sum1, sum2, [z]
-                stp     sum3, sum4, [z, #16]
-                stp     sum5, sum6, [z, #32]
-                lsl     h, sum0, #9
-                and     sum8, sum8, #0x1FF
-                orr     sum8, sum8, h
-                stp     sum7, sum8, [z, #48]
-                lsr     sum0, sum0, #55
-                str     sum0, [z, #64]
+        stp     sum1, sum2, [z]
+        stp     sum3, sum4, [z, #16]
+        stp     sum5, sum6, [z, #32]
+        lsl     h, sum0, #9
+        and     sum8, sum8, #0x1FF
+        orr     sum8, sum8, h
+        stp     sum7, sum8, [z, #48]
+        lsr     sum0, sum0, #55
+        str     sum0, [z, #64]
 
 // Restore regs and return
 
-                add     sp, sp, #80
-                ldp     x25, x26, [sp], #16
-                ldp     x23, x24, [sp], #16
-                ldp     x21, x22, [sp], #16
-                ldp     x19, x20, [sp], #16
-                ret
+        add     sp, sp, #80
+        ldp     x25, x26, [sp], #16
+        ldp     x23, x24, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
@@ -27,12 +27,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p521
-        .private_extern bignum_montmul_p521
+        S2N_ASM_HIDDEN(bignum_montmul_p521)
 
         .globl _bignum_montmul_p521
-        .private_extern _bignum_montmul_p521
+        S2N_ASM_HIDDEN(_bignum_montmul_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
@@ -28,8 +28,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montmul_p521_alt
-        .globl  _bignum_montmul_p521_alt
+        .globl bignum_montmul_p521_alt
+        .private_extern bignum_montmul_p521_alt
+
+        .globl _bignum_montmul_p521_alt
+        .private_extern _bignum_montmul_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
@@ -27,12 +27,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p521_alt
-        .private_extern bignum_montmul_p521_alt
+        S2N_ASM_HIDDEN(bignum_montmul_p521_alt)
 
         .globl _bignum_montmul_p521_alt
-        .private_extern _bignum_montmul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_montmul_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
@@ -27,14 +27,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_montmul_p521_alt
-        S2N_ASM_HIDDEN(bignum_montmul_p521_alt)
-
-        .globl _bignum_montmul_p521_alt
-        S2N_ASM_HIDDEN(_bignum_montmul_p521_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p521_alt)
         .text
         .balign 4
 
@@ -87,483 +83,482 @@
 #define u15 x20
 #define u16 x21
 
-bignum_montmul_p521_alt:
-_bignum_montmul_p521_alt:
+S2N_BN_SYMBOL(bignum_montmul_p521_alt):
 
 // Save more registers and make space for the temporary buffer
 
-                stp     x19, x20, [sp, #-16]!
-                stp     x21, x22, [sp, #-16]!
-                stp     x23, x24, [sp, #-16]!
-                stp     x25, x26, [sp, #-16]!
-                sub     sp, sp, #64
+        stp     x19, x20, [sp, #-16]!
+        stp     x21, x22, [sp, #-16]!
+        stp     x23, x24, [sp, #-16]!
+        stp     x25, x26, [sp, #-16]!
+        sub     sp, sp, #64
 
 // Load operands and set up row 0 = [u9;...;u0] = a0 * [b8;...;b0]
 
-                ldp     a0, a1, [x]
-                ldp     b0, b1, [y]
+        ldp     a0, a1, [x]
+        ldp     b0, b1, [y]
 
-                mul     u0, a0, b0
-                umulh   u1, a0, b0
-                mul     t, a0, b1
-                umulh   u2, a0, b1
-                adds    u1, u1, t
+        mul     u0, a0, b0
+        umulh   u1, a0, b0
+        mul     t, a0, b1
+        umulh   u2, a0, b1
+        adds    u1, u1, t
 
-                ldp     b2, b3, [y, #16]
+        ldp     b2, b3, [y, #16]
 
-                mul     t, a0, b2
-                umulh   u3, a0, b2
-                adcs    u2, u2, t
+        mul     t, a0, b2
+        umulh   u3, a0, b2
+        adcs    u2, u2, t
 
-                mul     t, a0, b3
-                umulh   u4, a0, b3
-                adcs    u3, u3, t
+        mul     t, a0, b3
+        umulh   u4, a0, b3
+        adcs    u3, u3, t
 
-                ldp     b4, b5, [y, #32]
+        ldp     b4, b5, [y, #32]
 
-                mul     t, a0, b4
-                umulh   u5, a0, b4
-                adcs    u4, u4, t
+        mul     t, a0, b4
+        umulh   u5, a0, b4
+        adcs    u4, u4, t
 
-                mul     t, a0, b5
-                umulh   u6, a0, b5
-                adcs    u5, u5, t
+        mul     t, a0, b5
+        umulh   u6, a0, b5
+        adcs    u5, u5, t
 
-                ldp     b6, b7, [y, #48]
+        ldp     b6, b7, [y, #48]
 
-                mul     t, a0, b6
-                umulh   u7, a0, b6
-                adcs    u6, u6, t
+        mul     t, a0, b6
+        umulh   u7, a0, b6
+        adcs    u6, u6, t
 
-                ldr     b8, [y, #64]
+        ldr     b8, [y, #64]
 
-                mul     t, a0, b7
-                umulh   u8, a0, b7
-                adcs    u7, u7, t
+        mul     t, a0, b7
+        umulh   u8, a0, b7
+        adcs    u7, u7, t
 
-                mul     t, a0, b8
-                umulh   u9, a0, b8
-                adcs    u8, u8, t
+        mul     t, a0, b8
+        umulh   u9, a0, b8
+        adcs    u8, u8, t
 
-                adc     u9, u9, xzr
+        adc     u9, u9, xzr
 
 // Row 1 = [u10;...;u0] = [a1;a0] * [b8;...;b0]
 
-                mul     t, a1, b0
-                adds    u1, u1, t
-                mul     t, a1, b1
-                adcs    u2, u2, t
-                mul     t, a1, b2
-                adcs    u3, u3, t
-                mul     t, a1, b3
-                adcs    u4, u4, t
-                mul     t, a1, b4
-                adcs    u5, u5, t
-                mul     t, a1, b5
-                adcs    u6, u6, t
-                mul     t, a1, b6
-                adcs    u7, u7, t
-                mul     t, a1, b7
-                adcs    u8, u8, t
-                mul     t, a1, b8
-                adcs    u9, u9, t
-                cset    u10, cs
+        mul     t, a1, b0
+        adds    u1, u1, t
+        mul     t, a1, b1
+        adcs    u2, u2, t
+        mul     t, a1, b2
+        adcs    u3, u3, t
+        mul     t, a1, b3
+        adcs    u4, u4, t
+        mul     t, a1, b4
+        adcs    u5, u5, t
+        mul     t, a1, b5
+        adcs    u6, u6, t
+        mul     t, a1, b6
+        adcs    u7, u7, t
+        mul     t, a1, b7
+        adcs    u8, u8, t
+        mul     t, a1, b8
+        adcs    u9, u9, t
+        cset    u10, cs
 
-                umulh   t, a1, b0
-                adds    u2, u2, t
-                umulh   t, a1, b1
-                adcs    u3, u3, t
-                umulh   t, a1, b2
-                adcs    u4, u4, t
-                umulh   t, a1, b3
-                adcs    u5, u5, t
-                umulh   t, a1, b4
-                adcs    u6, u6, t
-                umulh   t, a1, b5
-                adcs    u7, u7, t
-                umulh   t, a1, b6
-                adcs    u8, u8, t
-                umulh   t, a1, b7
-                adcs    u9, u9, t
-                umulh   t, a1, b8
-                adc     u10, u10, t
+        umulh   t, a1, b0
+        adds    u2, u2, t
+        umulh   t, a1, b1
+        adcs    u3, u3, t
+        umulh   t, a1, b2
+        adcs    u4, u4, t
+        umulh   t, a1, b3
+        adcs    u5, u5, t
+        umulh   t, a1, b4
+        adcs    u6, u6, t
+        umulh   t, a1, b5
+        adcs    u7, u7, t
+        umulh   t, a1, b6
+        adcs    u8, u8, t
+        umulh   t, a1, b7
+        adcs    u9, u9, t
+        umulh   t, a1, b8
+        adc     u10, u10, t
 
-                stp     u0, u1, [sp]
+        stp     u0, u1, [sp]
 
 // Row 2 = [u11;...;u0] = [a2;a1;a0] * [b8;...;b0]
 
-                ldp     a2, a3, [x, #16]
+        ldp     a2, a3, [x, #16]
 
-                mul     t, a2, b0
-                adds    u2, u2, t
-                mul     t, a2, b1
-                adcs    u3, u3, t
-                mul     t, a2, b2
-                adcs    u4, u4, t
-                mul     t, a2, b3
-                adcs    u5, u5, t
-                mul     t, a2, b4
-                adcs    u6, u6, t
-                mul     t, a2, b5
-                adcs    u7, u7, t
-                mul     t, a2, b6
-                adcs    u8, u8, t
-                mul     t, a2, b7
-                adcs    u9, u9, t
-                mul     t, a2, b8
-                adcs    u10, u10, t
-                cset    u11, cs
+        mul     t, a2, b0
+        adds    u2, u2, t
+        mul     t, a2, b1
+        adcs    u3, u3, t
+        mul     t, a2, b2
+        adcs    u4, u4, t
+        mul     t, a2, b3
+        adcs    u5, u5, t
+        mul     t, a2, b4
+        adcs    u6, u6, t
+        mul     t, a2, b5
+        adcs    u7, u7, t
+        mul     t, a2, b6
+        adcs    u8, u8, t
+        mul     t, a2, b7
+        adcs    u9, u9, t
+        mul     t, a2, b8
+        adcs    u10, u10, t
+        cset    u11, cs
 
-                umulh   t, a2, b0
-                adds    u3, u3, t
-                umulh   t, a2, b1
-                adcs    u4, u4, t
-                umulh   t, a2, b2
-                adcs    u5, u5, t
-                umulh   t, a2, b3
-                adcs    u6, u6, t
-                umulh   t, a2, b4
-                adcs    u7, u7, t
-                umulh   t, a2, b5
-                adcs    u8, u8, t
-                umulh   t, a2, b6
-                adcs    u9, u9, t
-                umulh   t, a2, b7
-                adcs    u10, u10, t
-                umulh   t, a2, b8
-                adc     u11, u11, t
+        umulh   t, a2, b0
+        adds    u3, u3, t
+        umulh   t, a2, b1
+        adcs    u4, u4, t
+        umulh   t, a2, b2
+        adcs    u5, u5, t
+        umulh   t, a2, b3
+        adcs    u6, u6, t
+        umulh   t, a2, b4
+        adcs    u7, u7, t
+        umulh   t, a2, b5
+        adcs    u8, u8, t
+        umulh   t, a2, b6
+        adcs    u9, u9, t
+        umulh   t, a2, b7
+        adcs    u10, u10, t
+        umulh   t, a2, b8
+        adc     u11, u11, t
 
 // Row 3 = [u12;...;u0] = [a3;a2;a1;a0] * [b8;...;b0]
 
-                mul     t, a3, b0
-                adds    u3, u3, t
-                mul     t, a3, b1
-                adcs    u4, u4, t
-                mul     t, a3, b2
-                adcs    u5, u5, t
-                mul     t, a3, b3
-                adcs    u6, u6, t
-                mul     t, a3, b4
-                adcs    u7, u7, t
-                mul     t, a3, b5
-                adcs    u8, u8, t
-                mul     t, a3, b6
-                adcs    u9, u9, t
-                mul     t, a3, b7
-                adcs    u10, u10, t
-                mul     t, a3, b8
-                adcs    u11, u11, t
-                cset    u12, cs
+        mul     t, a3, b0
+        adds    u3, u3, t
+        mul     t, a3, b1
+        adcs    u4, u4, t
+        mul     t, a3, b2
+        adcs    u5, u5, t
+        mul     t, a3, b3
+        adcs    u6, u6, t
+        mul     t, a3, b4
+        adcs    u7, u7, t
+        mul     t, a3, b5
+        adcs    u8, u8, t
+        mul     t, a3, b6
+        adcs    u9, u9, t
+        mul     t, a3, b7
+        adcs    u10, u10, t
+        mul     t, a3, b8
+        adcs    u11, u11, t
+        cset    u12, cs
 
-                umulh   t, a3, b0
-                adds    u4, u4, t
-                umulh   t, a3, b1
-                adcs    u5, u5, t
-                umulh   t, a3, b2
-                adcs    u6, u6, t
-                umulh   t, a3, b3
-                adcs    u7, u7, t
-                umulh   t, a3, b4
-                adcs    u8, u8, t
-                umulh   t, a3, b5
-                adcs    u9, u9, t
-                umulh   t, a3, b6
-                adcs    u10, u10, t
-                umulh   t, a3, b7
-                adcs    u11, u11, t
-                umulh   t, a3, b8
-                adc     u12, u12, t
+        umulh   t, a3, b0
+        adds    u4, u4, t
+        umulh   t, a3, b1
+        adcs    u5, u5, t
+        umulh   t, a3, b2
+        adcs    u6, u6, t
+        umulh   t, a3, b3
+        adcs    u7, u7, t
+        umulh   t, a3, b4
+        adcs    u8, u8, t
+        umulh   t, a3, b5
+        adcs    u9, u9, t
+        umulh   t, a3, b6
+        adcs    u10, u10, t
+        umulh   t, a3, b7
+        adcs    u11, u11, t
+        umulh   t, a3, b8
+        adc     u12, u12, t
 
-                stp     u2, u3, [sp, #16]
+        stp     u2, u3, [sp, #16]
 
 // Row 4 = [u13;...;u0] = [a4;a3;a2;a1;a0] * [b8;...;b0]
 
-                ldp     a4, a5, [x, #32]
+        ldp     a4, a5, [x, #32]
 
-                mul     t, a4, b0
-                adds    u4, u4, t
-                mul     t, a4, b1
-                adcs    u5, u5, t
-                mul     t, a4, b2
-                adcs    u6, u6, t
-                mul     t, a4, b3
-                adcs    u7, u7, t
-                mul     t, a4, b4
-                adcs    u8, u8, t
-                mul     t, a4, b5
-                adcs    u9, u9, t
-                mul     t, a4, b6
-                adcs    u10, u10, t
-                mul     t, a4, b7
-                adcs    u11, u11, t
-                mul     t, a4, b8
-                adcs    u12, u12, t
-                cset    u13, cs
+        mul     t, a4, b0
+        adds    u4, u4, t
+        mul     t, a4, b1
+        adcs    u5, u5, t
+        mul     t, a4, b2
+        adcs    u6, u6, t
+        mul     t, a4, b3
+        adcs    u7, u7, t
+        mul     t, a4, b4
+        adcs    u8, u8, t
+        mul     t, a4, b5
+        adcs    u9, u9, t
+        mul     t, a4, b6
+        adcs    u10, u10, t
+        mul     t, a4, b7
+        adcs    u11, u11, t
+        mul     t, a4, b8
+        adcs    u12, u12, t
+        cset    u13, cs
 
-                umulh   t, a4, b0
-                adds    u5, u5, t
-                umulh   t, a4, b1
-                adcs    u6, u6, t
-                umulh   t, a4, b2
-                adcs    u7, u7, t
-                umulh   t, a4, b3
-                adcs    u8, u8, t
-                umulh   t, a4, b4
-                adcs    u9, u9, t
-                umulh   t, a4, b5
-                adcs    u10, u10, t
-                umulh   t, a4, b6
-                adcs    u11, u11, t
-                umulh   t, a4, b7
-                adcs    u12, u12, t
-                umulh   t, a4, b8
-                adc     u13, u13, t
+        umulh   t, a4, b0
+        adds    u5, u5, t
+        umulh   t, a4, b1
+        adcs    u6, u6, t
+        umulh   t, a4, b2
+        adcs    u7, u7, t
+        umulh   t, a4, b3
+        adcs    u8, u8, t
+        umulh   t, a4, b4
+        adcs    u9, u9, t
+        umulh   t, a4, b5
+        adcs    u10, u10, t
+        umulh   t, a4, b6
+        adcs    u11, u11, t
+        umulh   t, a4, b7
+        adcs    u12, u12, t
+        umulh   t, a4, b8
+        adc     u13, u13, t
 
 // Row 5 = [u14;...;u0] = [a5;a4;a3;a2;a1;a0] * [b8;...;b0]
 
-                mul     t, a5, b0
-                adds    u5, u5, t
-                mul     t, a5, b1
-                adcs    u6, u6, t
-                mul     t, a5, b2
-                adcs    u7, u7, t
-                mul     t, a5, b3
-                adcs    u8, u8, t
-                mul     t, a5, b4
-                adcs    u9, u9, t
-                mul     t, a5, b5
-                adcs    u10, u10, t
-                mul     t, a5, b6
-                adcs    u11, u11, t
-                mul     t, a5, b7
-                adcs    u12, u12, t
-                mul     t, a5, b8
-                adcs    u13, u13, t
-                cset    u14, cs
+        mul     t, a5, b0
+        adds    u5, u5, t
+        mul     t, a5, b1
+        adcs    u6, u6, t
+        mul     t, a5, b2
+        adcs    u7, u7, t
+        mul     t, a5, b3
+        adcs    u8, u8, t
+        mul     t, a5, b4
+        adcs    u9, u9, t
+        mul     t, a5, b5
+        adcs    u10, u10, t
+        mul     t, a5, b6
+        adcs    u11, u11, t
+        mul     t, a5, b7
+        adcs    u12, u12, t
+        mul     t, a5, b8
+        adcs    u13, u13, t
+        cset    u14, cs
 
-                umulh   t, a5, b0
-                adds    u6, u6, t
-                umulh   t, a5, b1
-                adcs    u7, u7, t
-                umulh   t, a5, b2
-                adcs    u8, u8, t
-                umulh   t, a5, b3
-                adcs    u9, u9, t
-                umulh   t, a5, b4
-                adcs    u10, u10, t
-                umulh   t, a5, b5
-                adcs    u11, u11, t
-                umulh   t, a5, b6
-                adcs    u12, u12, t
-                umulh   t, a5, b7
-                adcs    u13, u13, t
-                umulh   t, a5, b8
-                adc     u14, u14, t
+        umulh   t, a5, b0
+        adds    u6, u6, t
+        umulh   t, a5, b1
+        adcs    u7, u7, t
+        umulh   t, a5, b2
+        adcs    u8, u8, t
+        umulh   t, a5, b3
+        adcs    u9, u9, t
+        umulh   t, a5, b4
+        adcs    u10, u10, t
+        umulh   t, a5, b5
+        adcs    u11, u11, t
+        umulh   t, a5, b6
+        adcs    u12, u12, t
+        umulh   t, a5, b7
+        adcs    u13, u13, t
+        umulh   t, a5, b8
+        adc     u14, u14, t
 
-                stp     u4, u5, [sp, #32]
+        stp     u4, u5, [sp, #32]
 
 // Row 6 = [u15;...;u0] = [a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
 
-                ldp     a6, a7, [x, #48]
+        ldp     a6, a7, [x, #48]
 
-                mul     t, a6, b0
-                adds    u6, u6, t
-                mul     t, a6, b1
-                adcs    u7, u7, t
-                mul     t, a6, b2
-                adcs    u8, u8, t
-                mul     t, a6, b3
-                adcs    u9, u9, t
-                mul     t, a6, b4
-                adcs    u10, u10, t
-                mul     t, a6, b5
-                adcs    u11, u11, t
-                mul     t, a6, b6
-                adcs    u12, u12, t
-                mul     t, a6, b7
-                adcs    u13, u13, t
-                mul     t, a6, b8
-                adcs    u14, u14, t
-                cset    u15, cs
+        mul     t, a6, b0
+        adds    u6, u6, t
+        mul     t, a6, b1
+        adcs    u7, u7, t
+        mul     t, a6, b2
+        adcs    u8, u8, t
+        mul     t, a6, b3
+        adcs    u9, u9, t
+        mul     t, a6, b4
+        adcs    u10, u10, t
+        mul     t, a6, b5
+        adcs    u11, u11, t
+        mul     t, a6, b6
+        adcs    u12, u12, t
+        mul     t, a6, b7
+        adcs    u13, u13, t
+        mul     t, a6, b8
+        adcs    u14, u14, t
+        cset    u15, cs
 
-                umulh   t, a6, b0
-                adds    u7, u7, t
-                umulh   t, a6, b1
-                adcs    u8, u8, t
-                umulh   t, a6, b2
-                adcs    u9, u9, t
-                umulh   t, a6, b3
-                adcs    u10, u10, t
-                umulh   t, a6, b4
-                adcs    u11, u11, t
-                umulh   t, a6, b5
-                adcs    u12, u12, t
-                umulh   t, a6, b6
-                adcs    u13, u13, t
-                umulh   t, a6, b7
-                adcs    u14, u14, t
-                umulh   t, a6, b8
-                adc     u15, u15, t
+        umulh   t, a6, b0
+        adds    u7, u7, t
+        umulh   t, a6, b1
+        adcs    u8, u8, t
+        umulh   t, a6, b2
+        adcs    u9, u9, t
+        umulh   t, a6, b3
+        adcs    u10, u10, t
+        umulh   t, a6, b4
+        adcs    u11, u11, t
+        umulh   t, a6, b5
+        adcs    u12, u12, t
+        umulh   t, a6, b6
+        adcs    u13, u13, t
+        umulh   t, a6, b7
+        adcs    u14, u14, t
+        umulh   t, a6, b8
+        adc     u15, u15, t
 
 // Row 7 = [u16;...;u0] = [a7;a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
 
-                mul     t, a7, b0
-                adds    u7, u7, t
-                mul     t, a7, b1
-                adcs    u8, u8, t
-                mul     t, a7, b2
-                adcs    u9, u9, t
-                mul     t, a7, b3
-                adcs    u10, u10, t
-                mul     t, a7, b4
-                adcs    u11, u11, t
-                mul     t, a7, b5
-                adcs    u12, u12, t
-                mul     t, a7, b6
-                adcs    u13, u13, t
-                mul     t, a7, b7
-                adcs    u14, u14, t
-                mul     t, a7, b8
-                adcs    u15, u15, t
-                cset    u16, cs
+        mul     t, a7, b0
+        adds    u7, u7, t
+        mul     t, a7, b1
+        adcs    u8, u8, t
+        mul     t, a7, b2
+        adcs    u9, u9, t
+        mul     t, a7, b3
+        adcs    u10, u10, t
+        mul     t, a7, b4
+        adcs    u11, u11, t
+        mul     t, a7, b5
+        adcs    u12, u12, t
+        mul     t, a7, b6
+        adcs    u13, u13, t
+        mul     t, a7, b7
+        adcs    u14, u14, t
+        mul     t, a7, b8
+        adcs    u15, u15, t
+        cset    u16, cs
 
-                umulh   t, a7, b0
-                adds    u8, u8, t
-                umulh   t, a7, b1
-                adcs    u9, u9, t
-                umulh   t, a7, b2
-                adcs    u10, u10, t
-                umulh   t, a7, b3
-                adcs    u11, u11, t
-                umulh   t, a7, b4
-                adcs    u12, u12, t
-                umulh   t, a7, b5
-                adcs    u13, u13, t
-                umulh   t, a7, b6
-                adcs    u14, u14, t
-                umulh   t, a7, b7
-                adcs    u15, u15, t
-                umulh   t, a7, b8
-                adc     u16, u16, t
+        umulh   t, a7, b0
+        adds    u8, u8, t
+        umulh   t, a7, b1
+        adcs    u9, u9, t
+        umulh   t, a7, b2
+        adcs    u10, u10, t
+        umulh   t, a7, b3
+        adcs    u11, u11, t
+        umulh   t, a7, b4
+        adcs    u12, u12, t
+        umulh   t, a7, b5
+        adcs    u13, u13, t
+        umulh   t, a7, b6
+        adcs    u14, u14, t
+        umulh   t, a7, b7
+        adcs    u15, u15, t
+        umulh   t, a7, b8
+        adc     u16, u16, t
 
-                stp     u6, u7, [sp, #48]
+        stp     u6, u7, [sp, #48]
 
 // Row 8 = [u16;...;u0] = [a8;a7;a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
 
-                ldr     a8, [x, #64]
+        ldr     a8, [x, #64]
 
-                mul     t, a8, b0
-                adds    u8, u8, t
-                mul     t, a8, b1
-                adcs    u9, u9, t
-                mul     t, a8, b2
-                adcs    u10, u10, t
-                mul     t, a8, b3
-                adcs    u11, u11, t
-                mul     t, a8, b4
-                adcs    u12, u12, t
-                mul     t, a8, b5
-                adcs    u13, u13, t
-                mul     t, a8, b6
-                adcs    u14, u14, t
-                mul     t, a8, b7
-                adcs    u15, u15, t
-                mul     t, a8, b8
-                adc     u16, u16, t
+        mul     t, a8, b0
+        adds    u8, u8, t
+        mul     t, a8, b1
+        adcs    u9, u9, t
+        mul     t, a8, b2
+        adcs    u10, u10, t
+        mul     t, a8, b3
+        adcs    u11, u11, t
+        mul     t, a8, b4
+        adcs    u12, u12, t
+        mul     t, a8, b5
+        adcs    u13, u13, t
+        mul     t, a8, b6
+        adcs    u14, u14, t
+        mul     t, a8, b7
+        adcs    u15, u15, t
+        mul     t, a8, b8
+        adc     u16, u16, t
 
-                umulh   t, a8, b0
-                adds    u9, u9, t
-                umulh   t, a8, b1
-                adcs    u10, u10, t
-                umulh   t, a8, b2
-                adcs    u11, u11, t
-                umulh   t, a8, b3
-                adcs    u12, u12, t
-                umulh   t, a8, b4
-                adcs    u13, u13, t
-                umulh   t, a8, b5
-                adcs    u14, u14, t
-                umulh   t, a8, b6
-                adcs    u15, u15, t
-                umulh   t, a8, b7
-                adc     u16, u16, t
+        umulh   t, a8, b0
+        adds    u9, u9, t
+        umulh   t, a8, b1
+        adcs    u10, u10, t
+        umulh   t, a8, b2
+        adcs    u11, u11, t
+        umulh   t, a8, b3
+        adcs    u12, u12, t
+        umulh   t, a8, b4
+        adcs    u13, u13, t
+        umulh   t, a8, b5
+        adcs    u14, u14, t
+        umulh   t, a8, b6
+        adcs    u15, u15, t
+        umulh   t, a8, b7
+        adc     u16, u16, t
 
 // Now we have the full product, which we consider as
 // 2^521 * h + l. Form h + l + 1
 
-                subs    xzr, xzr, xzr
-                ldp     b0, b1, [sp]
-                extr    t, u9, u8, #9
-                adcs    b0, b0, t
-                extr    t, u10, u9, #9
-                adcs    b1, b1, t
-                ldp     b2, b3, [sp, #16]
-                extr    t, u11, u10, #9
-                adcs    b2, b2, t
-                extr    t, u12, u11, #9
-                adcs    b3, b3, t
-                ldp     b4, b5, [sp, #32]
-                extr    t, u13, u12, #9
-                adcs    b4, b4, t
-                extr    t, u14, u13, #9
-                adcs    b5, b5, t
-                ldp     b6, b7, [sp, #48]
-                extr    t, u15, u14, #9
-                adcs    b6, b6, t
-                extr    t, u16, u15, #9
-                adcs    b7, b7, t
-                orr     b8, u8, #~0x1FF
-                lsr     t, u16, #9
-                adcs    b8, b8, t
+        subs    xzr, xzr, xzr
+        ldp     b0, b1, [sp]
+        extr    t, u9, u8, #9
+        adcs    b0, b0, t
+        extr    t, u10, u9, #9
+        adcs    b1, b1, t
+        ldp     b2, b3, [sp, #16]
+        extr    t, u11, u10, #9
+        adcs    b2, b2, t
+        extr    t, u12, u11, #9
+        adcs    b3, b3, t
+        ldp     b4, b5, [sp, #32]
+        extr    t, u13, u12, #9
+        adcs    b4, b4, t
+        extr    t, u14, u13, #9
+        adcs    b5, b5, t
+        ldp     b6, b7, [sp, #48]
+        extr    t, u15, u14, #9
+        adcs    b6, b6, t
+        extr    t, u16, u15, #9
+        adcs    b7, b7, t
+        orr     b8, u8, #~0x1FF
+        lsr     t, u16, #9
+        adcs    b8, b8, t
 
 // Now CF is set if h + l + 1 >= 2^521, which means it's already
 // the answer, while if ~CF the answer is h + l so we should subtract
 // 1 (all considered in 521 bits). Hence subtract ~CF and mask.
 
-                sbcs    b0, b0, xzr
-                sbcs    b1, b1, xzr
-                sbcs    b2, b2, xzr
-                sbcs    b3, b3, xzr
-                sbcs    b4, b4, xzr
-                sbcs    b5, b5, xzr
-                sbcs    b6, b6, xzr
-                sbcs    b7, b7, xzr
-                sbc     b8, b8, xzr
-                and     b8, b8, #0x1FF
+        sbcs    b0, b0, xzr
+        sbcs    b1, b1, xzr
+        sbcs    b2, b2, xzr
+        sbcs    b3, b3, xzr
+        sbcs    b4, b4, xzr
+        sbcs    b5, b5, xzr
+        sbcs    b6, b6, xzr
+        sbcs    b7, b7, xzr
+        sbc     b8, b8, xzr
+        and     b8, b8, #0x1FF
 
 // So far, this has been the same as a pure modular multiplication.
 // Now finally the Montgomery ingredient, which is just a 521-bit
 // rotation by 9*64 - 521 = 55 bits right.
 
-                lsl     t, b0, #9
-                extr    b0, b1, b0, #55
-                extr    b1, b2, b1, #55
-                extr    b2, b3, b2, #55
-                extr    b3, b4, b3, #55
-                orr     b8, b8, t
-                extr    b4, b5, b4, #55
-                extr    b5, b6, b5, #55
-                extr    b6, b7, b6, #55
-                extr    b7, b8, b7, #55
-                lsr     b8, b8, #55
+        lsl     t, b0, #9
+        extr    b0, b1, b0, #55
+        extr    b1, b2, b1, #55
+        extr    b2, b3, b2, #55
+        extr    b3, b4, b3, #55
+        orr     b8, b8, t
+        extr    b4, b5, b4, #55
+        extr    b5, b6, b5, #55
+        extr    b6, b7, b6, #55
+        extr    b7, b8, b7, #55
+        lsr     b8, b8, #55
 
 // Store back digits of final result
 
-                stp     b0, b1, [z]
-                stp     b2, b3, [z, #16]
-                stp     b4, b5, [z, #32]
-                stp     b6, b7, [z, #48]
-                str     b8, [z, #64]
+        stp     b0, b1, [z]
+        stp     b2, b3, [z, #16]
+        stp     b4, b5, [z, #32]
+        stp     b6, b7, [z, #48]
+        str     b8, [z, #64]
 
 // Restore registers
 
-                add     sp, sp, #64
-                ldp     x25, x26, [sp], #16
-                ldp     x23, x24, [sp], #16
-                ldp     x21, x22, [sp], #16
-                ldp     x19, x20, [sp], #16
+        add     sp, sp, #64
+        ldp     x25, x26, [sp], #16
+        ldp     x23, x24, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
@@ -27,14 +27,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_montsqr_p521
-        S2N_ASM_HIDDEN(bignum_montsqr_p521)
-
-        .globl _bignum_montsqr_p521
-        S2N_ASM_HIDDEN(_bignum_montsqr_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p521)
         .text
         .balign 4
 
@@ -78,87 +74,86 @@
 #define d7 x9
 #define d8 x10
 
-bignum_montsqr_p521:
-_bignum_montsqr_p521:
+S2N_BN_SYMBOL(bignum_montsqr_p521):
 
 // Save registers
 
-                stp     x19, x20, [sp, #-16]!
-                stp     x21, x22, [sp, #-16]!
-                stp     x23, x24, [sp, #-16]!
+        stp     x19, x20, [sp, #-16]!
+        stp     x21, x22, [sp, #-16]!
+        stp     x23, x24, [sp, #-16]!
 
 // Load all the inputs first
 
-                ldp     a0, a1, [x]
-                ldp     a2, a3, [x, #16]
-                ldp     b0, b1, [x, #32]
-                ldp     b2, b3, [x, #48]
+        ldp     a0, a1, [x]
+        ldp     a2, a3, [x, #16]
+        ldp     b0, b1, [x, #32]
+        ldp     b2, b3, [x, #48]
 
 // Square the upper half with a register-renamed variant of bignum_sqr_4_8
 
-                mul     s2, b0, b2
-                mul     s7, b1, b3
-                umulh   t, b0, b2
-                subs    u, b0, b1
-                cneg    u, u, cc
-                csetm   s1, cc
-                subs    s0, b3, b2
-                cneg    s0, s0, cc
-                mul     s6, u, s0
-                umulh   s0, u, s0
-                cinv    s1, s1, cc
-                eor     s6, s6, s1
-                eor     s0, s0, s1
-                adds    s3, s2, t
-                adc     t, t, xzr
-                umulh   u, b1, b3
-                adds    s3, s3, s7
-                adcs    t, t, u
-                adc     u, u, xzr
-                adds    t, t, s7
-                adc     u, u, xzr
-                cmn     s1, #0x1
-                adcs    s3, s3, s6
-                adcs    t, t, s0
-                adc     u, u, s1
-                adds    s2, s2, s2
-                adcs    s3, s3, s3
-                adcs    t, t, t
-                adcs    u, u, u
-                adc     c, xzr, xzr
-                mul     s0, b0, b0
-                mul     s6, b1, b1
-                mul     l, b0, b1
-                umulh   s1, b0, b0
-                umulh   s7, b1, b1
-                umulh   h, b0, b1
-                adds    s1, s1, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s1, s1, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s2, s2, s6
-                adcs    s3, s3, s7
-                adcs    t, t, xzr
-                adcs    u, u, xzr
-                adc     c, c, xzr
-                mul     s4, b2, b2
-                mul     s6, b3, b3
-                mul     l, b2, b3
-                umulh   s5, b2, b2
-                umulh   s7, b3, b3
-                umulh   h, b2, b3
-                adds    s5, s5, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s5, s5, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s4, s4, t
-                adcs    s5, s5, u
-                adcs    s6, s6, c
-                adc     s7, s7, xzr
+        mul     s2, b0, b2
+        mul     s7, b1, b3
+        umulh   t, b0, b2
+        subs    u, b0, b1
+        cneg    u, u, cc
+        csetm   s1, cc
+        subs    s0, b3, b2
+        cneg    s0, s0, cc
+        mul     s6, u, s0
+        umulh   s0, u, s0
+        cinv    s1, s1, cc
+        eor     s6, s6, s1
+        eor     s0, s0, s1
+        adds    s3, s2, t
+        adc     t, t, xzr
+        umulh   u, b1, b3
+        adds    s3, s3, s7
+        adcs    t, t, u
+        adc     u, u, xzr
+        adds    t, t, s7
+        adc     u, u, xzr
+        cmn     s1, #0x1
+        adcs    s3, s3, s6
+        adcs    t, t, s0
+        adc     u, u, s1
+        adds    s2, s2, s2
+        adcs    s3, s3, s3
+        adcs    t, t, t
+        adcs    u, u, u
+        adc     c, xzr, xzr
+        mul     s0, b0, b0
+        mul     s6, b1, b1
+        mul     l, b0, b1
+        umulh   s1, b0, b0
+        umulh   s7, b1, b1
+        umulh   h, b0, b1
+        adds    s1, s1, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s1, s1, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s2, s2, s6
+        adcs    s3, s3, s7
+        adcs    t, t, xzr
+        adcs    u, u, xzr
+        adc     c, c, xzr
+        mul     s4, b2, b2
+        mul     s6, b3, b3
+        mul     l, b2, b3
+        umulh   s5, b2, b2
+        umulh   s7, b3, b3
+        umulh   h, b2, b3
+        adds    s5, s5, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s5, s5, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s4, s4, t
+        adcs    s5, s5, u
+        adcs    s6, s6, c
+        adc     s7, s7, xzr
 
 // Augment the high part with the contribution from the top little word C.
 // If we write the input as 2^512 * C + x then we are otherwise just doing
@@ -173,364 +168,364 @@ _bignum_montsqr_p521:
 // equally well use 53 or 54 since they are still <= 64 - 10, but below
 // 52 we would end up using more multiplications.
 
-                ldr     c, [x, #64]
-                add     u, c, c
-                mul     c, c, c
+        ldr     c, [x, #64]
+        add     u, c, c
+        mul     c, c, c
 
 // 0 * 52 = 64 * 0 + 0
 
-                and     l, a0, #0x000fffffffffffff
-                mul     l, u, l
+        and     l, a0, #0x000fffffffffffff
+        mul     l, u, l
 
 // 1 * 52 = 64 * 0 + 52
 
-                extr    h, a1, a0, #52
-                and     h, h, #0x000fffffffffffff
-                mul     h, u, h
-                lsr     t, l, #52
-                add     h, h, t
+        extr    h, a1, a0, #52
+        and     h, h, #0x000fffffffffffff
+        mul     h, u, h
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #12
-                adds    s0, s0, t
+        lsl     l, l, #12
+        extr    t, h, l, #12
+        adds    s0, s0, t
 
 // 2 * 52 = 64 * 1 + 40
 
-                extr    l, a2, a1, #40
-                and     l, l, #0x000fffffffffffff
-                mul     l, u, l
-                lsr     t, h, #52
-                add     l, l, t
+        extr    l, a2, a1, #40
+        and     l, l, #0x000fffffffffffff
+        mul     l, u, l
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #24
-                adcs    s1, s1, t
+        lsl     h, h, #12
+        extr    t, l, h, #24
+        adcs    s1, s1, t
 
 // 3 * 52 = 64 * 2 + 28
 
-                extr    h, a3, a2, #28
-                and     h, h, #0x000fffffffffffff
-                mul     h, u, h
-                lsr     t, l, #52
-                add     h, h, t
+        extr    h, a3, a2, #28
+        and     h, h, #0x000fffffffffffff
+        mul     h, u, h
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #36
-                adcs    s2, s2, t
+        lsl     l, l, #12
+        extr    t, h, l, #36
+        adcs    s2, s2, t
 
 // 4 * 52 = 64 * 3 + 16
 
-                extr    l, b0, a3, #16
-                and     l, l, #0x000fffffffffffff
-                mul     l, u, l
-                lsr     t, h, #52
-                add     l, l, t
+        extr    l, b0, a3, #16
+        and     l, l, #0x000fffffffffffff
+        mul     l, u, l
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #48
-                adcs    s3, s3, t
+        lsl     h, h, #12
+        extr    t, l, h, #48
+        adcs    s3, s3, t
 
 // 5 * 52 = 64 * 4 + 4
 
-                lsr     h, b0, #4
-                and     h, h, #0x000fffffffffffff
-                mul     h, u, h
-                lsr     t, l, #52
-                add     h, h, t
+        lsr     h, b0, #4
+        and     h, h, #0x000fffffffffffff
+        mul     h, u, h
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    v, h, l, #60
+        lsl     l, l, #12
+        extr    v, h, l, #60
 
 // 6 * 52 = 64 * 4 + 56
 
-                extr    l, b1, b0, #56
-                and     l, l, #0x000fffffffffffff
-                mul     l, u, l
-                lsr     t, h, #52
-                add     l, l, t
+        extr    l, b1, b0, #56
+        and     l, l, #0x000fffffffffffff
+        mul     l, u, l
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     v, v, #8
-                extr    t, l, v, #8
-                adcs    s4, s4, t
+        lsl     v, v, #8
+        extr    t, l, v, #8
+        adcs    s4, s4, t
 
 // 7 * 52 = 64 * 5 + 44
 
-                extr    h, b2, b1, #44
-                and     h, h, #0x000fffffffffffff
-                mul     h, u, h
-                lsr     t, l, #52
-                add     h, h, t
+        extr    h, b2, b1, #44
+        and     h, h, #0x000fffffffffffff
+        mul     h, u, h
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #20
-                adcs    s5, s5, t
+        lsl     l, l, #12
+        extr    t, h, l, #20
+        adcs    s5, s5, t
 
 // 8 * 52 = 64 * 6 + 32
 
-                extr    l, b3, b2, #32
-                and     l, l, #0x000fffffffffffff
-                mul     l, u, l
-                lsr     t, h, #52
-                add     l, l, t
+        extr    l, b3, b2, #32
+        and     l, l, #0x000fffffffffffff
+        mul     l, u, l
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #32
-                adcs    s6, s6, t
+        lsl     h, h, #12
+        extr    t, l, h, #32
+        adcs    s6, s6, t
 
 // 9 * 52 = 64 * 7 + 20
 
-                lsr     h, b3, #20
-                mul     h, u, h
-                lsr     t, l, #52
-                add     h, h, t
+        lsr     h, b3, #20
+        mul     h, u, h
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #44
-                adcs    s7, s7, t
+        lsl     l, l, #12
+        extr    t, h, l, #44
+        adcs    s7, s7, t
 
 // Top word
 
-                lsr     h, h, #44
-                adc     c, c, h
+        lsr     h, h, #44
+        adc     c, c, h
 
 // Rotate [c;s7;...;s0] before storing in the buffer.
 // We want to add 2^512 * H', which splitting H' at bit 9 is
 // 2^521 * H_top + 2^512 * H_bot == 2^512 * H_bot + H_top (mod p_521)
 
-                extr    l, s1, s0, #9
-                extr    h, s2, s1, #9
-                stp     l, h, [z]
+        extr    l, s1, s0, #9
+        extr    h, s2, s1, #9
+        stp     l, h, [z]
 
-                extr    l, s3, s2, #9
-                extr    h, s4, s3, #9
-                stp     l, h, [z, #16]
+        extr    l, s3, s2, #9
+        extr    h, s4, s3, #9
+        stp     l, h, [z, #16]
 
-                extr    l, s5, s4, #9
-                extr    h, s6, s5, #9
-                stp     l, h, [z, #32]
+        extr    l, s5, s4, #9
+        extr    h, s6, s5, #9
+        stp     l, h, [z, #32]
 
-                extr    l, s7, s6, #9
-                extr    h, c, s7, #9
-                stp     l, h, [z, #48]
+        extr    l, s7, s6, #9
+        extr    h, c, s7, #9
+        stp     l, h, [z, #48]
 
-                and     t, s0, #0x1FF
-                lsr     c, c, #9
-                add     t, t, c
-                str     t, [z, #64]
+        and     t, s0, #0x1FF
+        lsr     c, c, #9
+        add     t, t, c
+        str     t, [z, #64]
 
 // Square the lower half with an analogous variant of bignum_sqr_4_8
 
-                mul     s2, a0, a2
-                mul     s7, a1, a3
-                umulh   t, a0, a2
-                subs    u, a0, a1
-                cneg    u, u, cc
-                csetm   s1, cc
-                subs    s0, a3, a2
-                cneg    s0, s0, cc
-                mul     s6, u, s0
-                umulh   s0, u, s0
-                cinv    s1, s1, cc
-                eor     s6, s6, s1
-                eor     s0, s0, s1
-                adds    s3, s2, t
-                adc     t, t, xzr
-                umulh   u, a1, a3
-                adds    s3, s3, s7
-                adcs    t, t, u
-                adc     u, u, xzr
-                adds    t, t, s7
-                adc     u, u, xzr
-                cmn     s1, #0x1
-                adcs    s3, s3, s6
-                adcs    t, t, s0
-                adc     u, u, s1
-                adds    s2, s2, s2
-                adcs    s3, s3, s3
-                adcs    t, t, t
-                adcs    u, u, u
-                adc     c, xzr, xzr
-                mul     s0, a0, a0
-                mul     s6, a1, a1
-                mul     l, a0, a1
-                umulh   s1, a0, a0
-                umulh   s7, a1, a1
-                umulh   h, a0, a1
-                adds    s1, s1, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s1, s1, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s2, s2, s6
-                adcs    s3, s3, s7
-                adcs    t, t, xzr
-                adcs    u, u, xzr
-                adc     c, c, xzr
-                mul     s4, a2, a2
-                mul     s6, a3, a3
-                mul     l, a2, a3
-                umulh   s5, a2, a2
-                umulh   s7, a3, a3
-                umulh   h, a2, a3
-                adds    s5, s5, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s5, s5, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s4, s4, t
-                adcs    s5, s5, u
-                adcs    s6, s6, c
-                adc     s7, s7, xzr
+        mul     s2, a0, a2
+        mul     s7, a1, a3
+        umulh   t, a0, a2
+        subs    u, a0, a1
+        cneg    u, u, cc
+        csetm   s1, cc
+        subs    s0, a3, a2
+        cneg    s0, s0, cc
+        mul     s6, u, s0
+        umulh   s0, u, s0
+        cinv    s1, s1, cc
+        eor     s6, s6, s1
+        eor     s0, s0, s1
+        adds    s3, s2, t
+        adc     t, t, xzr
+        umulh   u, a1, a3
+        adds    s3, s3, s7
+        adcs    t, t, u
+        adc     u, u, xzr
+        adds    t, t, s7
+        adc     u, u, xzr
+        cmn     s1, #0x1
+        adcs    s3, s3, s6
+        adcs    t, t, s0
+        adc     u, u, s1
+        adds    s2, s2, s2
+        adcs    s3, s3, s3
+        adcs    t, t, t
+        adcs    u, u, u
+        adc     c, xzr, xzr
+        mul     s0, a0, a0
+        mul     s6, a1, a1
+        mul     l, a0, a1
+        umulh   s1, a0, a0
+        umulh   s7, a1, a1
+        umulh   h, a0, a1
+        adds    s1, s1, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s1, s1, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s2, s2, s6
+        adcs    s3, s3, s7
+        adcs    t, t, xzr
+        adcs    u, u, xzr
+        adc     c, c, xzr
+        mul     s4, a2, a2
+        mul     s6, a3, a3
+        mul     l, a2, a3
+        umulh   s5, a2, a2
+        umulh   s7, a3, a3
+        umulh   h, a2, a3
+        adds    s5, s5, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s5, s5, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s4, s4, t
+        adcs    s5, s5, u
+        adcs    s6, s6, c
+        adc     s7, s7, xzr
 
 // Add it directly to the existing buffer
 
-                ldp     l, h, [z]
-                adds    l, l, s0
-                adcs    h, h, s1
-                stp     l, h, [z]
+        ldp     l, h, [z]
+        adds    l, l, s0
+        adcs    h, h, s1
+        stp     l, h, [z]
 
-                ldp     l, h, [z, #16]
-                adcs    l, l, s2
-                adcs    h, h, s3
-                stp     l, h, [z, #16]
+        ldp     l, h, [z, #16]
+        adcs    l, l, s2
+        adcs    h, h, s3
+        stp     l, h, [z, #16]
 
-                ldp     l, h, [z, #32]
-                adcs    l, l, s4
-                adcs    h, h, s5
-                stp     l, h, [z, #32]
+        ldp     l, h, [z, #32]
+        adcs    l, l, s4
+        adcs    h, h, s5
+        stp     l, h, [z, #32]
 
-                ldp     l, h, [z, #48]
-                adcs    l, l, s6
-                adcs    h, h, s7
-                stp     l, h, [z, #48]
+        ldp     l, h, [z, #48]
+        adcs    l, l, s6
+        adcs    h, h, s7
+        stp     l, h, [z, #48]
 
-                ldr     t, [z, #64]
-                adc     t, t, xzr
-                str     t, [z, #64]
+        ldr     t, [z, #64]
+        adc     t, t, xzr
+        str     t, [z, #64]
 
 // Now get the cross-product in [s7,...,s0] with variant of bignum_mul_4_8
 
-                mul     s0, a0, b0
-                mul     s4, a1, b1
-                mul     s5, a2, b2
-                mul     s6, a3, b3
-                umulh   s7, a0, b0
-                adds    s4, s4, s7
-                umulh   s7, a1, b1
-                adcs    s5, s5, s7
-                umulh   s7, a2, b2
-                adcs    s6, s6, s7
-                umulh   s7, a3, b3
-                adc     s7, s7, xzr
-                adds    s1, s4, s0
-                adcs    s4, s5, s4
-                adcs    s5, s6, s5
-                adcs    s6, s7, s6
-                adc     s7, xzr, s7
-                adds    s2, s4, s0
-                adcs    s3, s5, s1
-                adcs    s4, s6, s4
-                adcs    s5, s7, s5
-                adcs    s6, xzr, s6
-                adc     s7, xzr, s7
-                subs    t, a2, a3
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b3, b2
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s5, s5, l
-                eor     h, h, c
-                adcs    s6, s6, h
-                adc     s7, s7, c
-                subs    t, a0, a1
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b1, b0
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s1, s1, l
-                eor     h, h, c
-                adcs    s2, s2, h
-                adcs    s3, s3, c
-                adcs    s4, s4, c
-                adcs    s5, s5, c
-                adcs    s6, s6, c
-                adc     s7, s7, c
-                subs    t, a1, a3
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b3, b1
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s4, s4, l
-                eor     h, h, c
-                adcs    s5, s5, h
-                adcs    s6, s6, c
-                adc     s7, s7, c
-                subs    t, a0, a2
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b2, b0
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s2, s2, l
-                eor     h, h, c
-                adcs    s3, s3, h
-                adcs    s4, s4, c
-                adcs    s5, s5, c
-                adcs    s6, s6, c
-                adc     s7, s7, c
-                subs    t, a0, a3
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b3, b0
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s3, s3, l
-                eor     h, h, c
-                adcs    s4, s4, h
-                adcs    s5, s5, c
-                adcs    s6, s6, c
-                adc     s7, s7, c
-                subs    t, a1, a2
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b2, b1
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s3, s3, l
-                eor     h, h, c
-                adcs    s4, s4, h
-                adcs    s5, s5, c
-                adcs    s6, s6, c
-                adc     s7, s7, c
+        mul     s0, a0, b0
+        mul     s4, a1, b1
+        mul     s5, a2, b2
+        mul     s6, a3, b3
+        umulh   s7, a0, b0
+        adds    s4, s4, s7
+        umulh   s7, a1, b1
+        adcs    s5, s5, s7
+        umulh   s7, a2, b2
+        adcs    s6, s6, s7
+        umulh   s7, a3, b3
+        adc     s7, s7, xzr
+        adds    s1, s4, s0
+        adcs    s4, s5, s4
+        adcs    s5, s6, s5
+        adcs    s6, s7, s6
+        adc     s7, xzr, s7
+        adds    s2, s4, s0
+        adcs    s3, s5, s1
+        adcs    s4, s6, s4
+        adcs    s5, s7, s5
+        adcs    s6, xzr, s6
+        adc     s7, xzr, s7
+        subs    t, a2, a3
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b3, b2
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s5, s5, l
+        eor     h, h, c
+        adcs    s6, s6, h
+        adc     s7, s7, c
+        subs    t, a0, a1
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b1, b0
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s1, s1, l
+        eor     h, h, c
+        adcs    s2, s2, h
+        adcs    s3, s3, c
+        adcs    s4, s4, c
+        adcs    s5, s5, c
+        adcs    s6, s6, c
+        adc     s7, s7, c
+        subs    t, a1, a3
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b3, b1
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s4, s4, l
+        eor     h, h, c
+        adcs    s5, s5, h
+        adcs    s6, s6, c
+        adc     s7, s7, c
+        subs    t, a0, a2
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b2, b0
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s2, s2, l
+        eor     h, h, c
+        adcs    s3, s3, h
+        adcs    s4, s4, c
+        adcs    s5, s5, c
+        adcs    s6, s6, c
+        adc     s7, s7, c
+        subs    t, a0, a3
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b3, b0
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s3, s3, l
+        eor     h, h, c
+        adcs    s4, s4, h
+        adcs    s5, s5, c
+        adcs    s6, s6, c
+        adc     s7, s7, c
+        subs    t, a1, a2
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b2, b1
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s3, s3, l
+        eor     h, h, c
+        adcs    s4, s4, h
+        adcs    s5, s5, c
+        adcs    s6, s6, c
+        adc     s7, s7, c
 
 // Let the cross product be M. We want to add 2^256 * 2 * M to the buffer
 // Split M into M_top (248 bits) and M_bot (264 bits), so we add
@@ -539,103 +534,103 @@ _bignum_montsqr_p521:
 // As this sum is built, accumulate t = AND of words d7...d1 to help
 // in condensing the carry chain in the comparison that comes next
 
-                ldp     l, h, [z]
-                extr    d0, s5, s4, #8
-                adds    d0, d0, l
-                extr    d1, s6, s5, #8
-                adcs    d1, d1, h
+        ldp     l, h, [z]
+        extr    d0, s5, s4, #8
+        adds    d0, d0, l
+        extr    d1, s6, s5, #8
+        adcs    d1, d1, h
 
-                ldp     l, h, [z, #16]
-                extr    d2, s7, s6, #8
-                adcs    d2, d2, l
-                and     t, d1, d2
-                lsr     d3, s7, #8
-                adcs    d3, d3, h
-                and     t, t, d3
+        ldp     l, h, [z, #16]
+        extr    d2, s7, s6, #8
+        adcs    d2, d2, l
+        and     t, d1, d2
+        lsr     d3, s7, #8
+        adcs    d3, d3, h
+        and     t, t, d3
 
-                ldp     l, h, [z, #32]
-                lsl     d4, s0, #1
-                adcs    d4, d4, l
-                and     t, t, d4
-                extr    d5, s1, s0, #63
-                adcs    d5, d5, h
-                and     t, t, d5
+        ldp     l, h, [z, #32]
+        lsl     d4, s0, #1
+        adcs    d4, d4, l
+        and     t, t, d4
+        extr    d5, s1, s0, #63
+        adcs    d5, d5, h
+        and     t, t, d5
 
-                ldp     l, h, [z, #48]
-                extr    d6, s2, s1, #63
-                adcs    d6, d6, l
-                and     t, t, d6
-                extr    d7, s3, s2, #63
-                adcs    d7, d7, h
-                and     t, t, d7
+        ldp     l, h, [z, #48]
+        extr    d6, s2, s1, #63
+        adcs    d6, d6, l
+        and     t, t, d6
+        extr    d7, s3, s2, #63
+        adcs    d7, d7, h
+        and     t, t, d7
 
-                ldr     l, [z, #64]
-                extr    d8, s4, s3, #63
-                and     d8, d8, #0x1FF
-                adc     d8, l, d8
+        ldr     l, [z, #64]
+        extr    d8, s4, s3, #63
+        and     d8, d8, #0x1FF
+        adc     d8, l, d8
 
 // Extract the high part h and mask off the low part l = [d8;d7;...;d0]
 // but stuff d8 with 1 bits at the left to ease a comparison below
 
-                lsr     h, d8, #9
-                orr     d8, d8, #~0x1FF
+        lsr     h, d8, #9
+        orr     d8, d8, #~0x1FF
 
 // Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
 // happen if digits d7,...d1 are all 1s, we use the AND of them "t" to
 // condense the carry chain, and since we stuffed 1 bits into d8 we get
 // the result in CF without an additional comparison.
 
-                subs    xzr, xzr, xzr
-                adcs    xzr, d0, h
-                adcs    xzr, t, xzr
-                adcs    xzr, d8, xzr
+        subs    xzr, xzr, xzr
+        adcs    xzr, d0, h
+        adcs    xzr, t, xzr
+        adcs    xzr, d8, xzr
 
 // Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
 // while otherwise we want just h + l. So mask h + l + CF to 521 bits.
 // This masking also gets rid of the stuffing with 1s we did above.
 
-                adcs    d0, d0, h
-                adcs    d1, d1, xzr
-                adcs    d2, d2, xzr
-                adcs    d3, d3, xzr
-                adcs    d4, d4, xzr
-                adcs    d5, d5, xzr
-                adcs    d6, d6, xzr
-                adcs    d7, d7, xzr
-                adc     d8, d8, xzr
-                and     d8, d8, #0x1FF
+        adcs    d0, d0, h
+        adcs    d1, d1, xzr
+        adcs    d2, d2, xzr
+        adcs    d3, d3, xzr
+        adcs    d4, d4, xzr
+        adcs    d5, d5, xzr
+        adcs    d6, d6, xzr
+        adcs    d7, d7, xzr
+        adc     d8, d8, xzr
+        and     d8, d8, #0x1FF
 
 // So far, this has been the same as a pure modular squaring.
 // Now finally the Montgomery ingredient, which is just a 521-bit
 // rotation by 9*64 - 521 = 55 bits right.
 
-                lsl     c, d0, #9
-                extr    d0, d1, d0, #55
-                extr    d1, d2, d1, #55
-                extr    d2, d3, d2, #55
-                extr    d3, d4, d3, #55
-                orr     d8, d8, c
-                extr    d4, d5, d4, #55
-                extr    d5, d6, d5, #55
-                extr    d6, d7, d6, #55
-                extr    d7, d8, d7, #55
-                lsr     d8, d8, #55
+        lsl     c, d0, #9
+        extr    d0, d1, d0, #55
+        extr    d1, d2, d1, #55
+        extr    d2, d3, d2, #55
+        extr    d3, d4, d3, #55
+        orr     d8, d8, c
+        extr    d4, d5, d4, #55
+        extr    d5, d6, d5, #55
+        extr    d6, d7, d6, #55
+        extr    d7, d8, d7, #55
+        lsr     d8, d8, #55
 
 // Store the final result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
 
 // Restore regs and return
 
-                ldp     x23, x24, [sp], #16
-                ldp     x21, x22, [sp], #16
-                ldp     x19, x20, [sp], #16
+        ldp     x23, x24, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
@@ -28,8 +28,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montsqr_p521
-        .globl  _bignum_montsqr_p521
+        .globl bignum_montsqr_p521
+        .private_extern bignum_montsqr_p521
+
+        .globl _bignum_montsqr_p521
+        .private_extern _bignum_montsqr_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
@@ -27,12 +27,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p521
-        .private_extern bignum_montsqr_p521
+        S2N_ASM_HIDDEN(bignum_montsqr_p521)
 
         .globl _bignum_montsqr_p521
-        .private_extern _bignum_montsqr_p521
+        S2N_ASM_HIDDEN(_bignum_montsqr_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
@@ -27,14 +27,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_montsqr_p521_alt
-        S2N_ASM_HIDDEN(bignum_montsqr_p521_alt)
-
-        .globl _bignum_montsqr_p521_alt
-        S2N_ASM_HIDDEN(_bignum_montsqr_p521_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p521_alt)
         .text
         .balign 4
 
@@ -71,330 +67,329 @@
 #define u15 x27
 #define u16 x29
 
-bignum_montsqr_p521_alt:
-_bignum_montsqr_p521_alt:
+S2N_BN_SYMBOL(bignum_montsqr_p521_alt):
 
 // It's convenient to have more registers to play with
 
-                stp     x19, x20, [sp, #-16]!
-                stp     x21, x22, [sp, #-16]!
-                stp     x23, x24, [sp, #-16]!
-                stp     x25, x26, [sp, #-16]!
-                stp     x27, x29, [sp, #-16]!
+        stp     x19, x20, [sp, #-16]!
+        stp     x21, x22, [sp, #-16]!
+        stp     x23, x24, [sp, #-16]!
+        stp     x25, x26, [sp, #-16]!
+        stp     x27, x29, [sp, #-16]!
 
 // Load low 8 elements as [a7;a6;a5;a4;a3;a2;a1;a0], set up an initial
 // window [u8;u7;u6;u5;u4;u3;u2;u1] =  10 + 20 + 30 + 40 + 50 + 60 + 70
 
-                ldp     a0, a1, [x]
+        ldp     a0, a1, [x]
 
-                mul     u1, a0, a1
-                umulh   u2, a0, a1
+        mul     u1, a0, a1
+        umulh   u2, a0, a1
 
-                ldp     a2, a3, [x, #16]
+        ldp     a2, a3, [x, #16]
 
-                mul     l, a0, a2
-                umulh   u3, a0, a2
-                adds    u2, u2, l
+        mul     l, a0, a2
+        umulh   u3, a0, a2
+        adds    u2, u2, l
 
-                ldp     a4, a5, [x, #32]
+        ldp     a4, a5, [x, #32]
 
-                mul     l, a0, a3
-                umulh   u4, a0, a3
-                adcs    u3, u3, l
+        mul     l, a0, a3
+        umulh   u4, a0, a3
+        adcs    u3, u3, l
 
-                ldp     a6, a7, [x, #48]
+        ldp     a6, a7, [x, #48]
 
-                mul     l, a0, a4
-                umulh   u5, a0, a4
-                adcs    u4, u4, l
+        mul     l, a0, a4
+        umulh   u5, a0, a4
+        adcs    u4, u4, l
 
-                mul     l, a0, a5
-                umulh   u6, a0, a5
-                adcs    u5, u5, l
+        mul     l, a0, a5
+        umulh   u6, a0, a5
+        adcs    u5, u5, l
 
-                mul     l, a0, a6
-                umulh   u7, a0, a6
-                adcs    u6, u6, l
+        mul     l, a0, a6
+        umulh   u7, a0, a6
+        adcs    u6, u6, l
 
-                mul     l, a0, a7
-                umulh   u8, a0, a7
-                adcs    u7, u7, l
+        mul     l, a0, a7
+        umulh   u8, a0, a7
+        adcs    u7, u7, l
 
-                adc     u8, u8, xzr
+        adc     u8, u8, xzr
 
 // Add in the next diagonal = 21 + 31 + 41 + 51 + 61 + 71 + 54
 
-                mul     l, a1, a2
-                adds    u3, u3, l
-                mul     l, a1, a3
-                adcs    u4, u4, l
-                mul     l, a1, a4
-                adcs    u5, u5, l
-                mul     l, a1, a5
-                adcs    u6, u6, l
-                mul     l, a1, a6
-                adcs    u7, u7, l
-                mul     l, a1, a7
-                adcs    u8, u8, l
-                cset    u9, cs
+        mul     l, a1, a2
+        adds    u3, u3, l
+        mul     l, a1, a3
+        adcs    u4, u4, l
+        mul     l, a1, a4
+        adcs    u5, u5, l
+        mul     l, a1, a5
+        adcs    u6, u6, l
+        mul     l, a1, a6
+        adcs    u7, u7, l
+        mul     l, a1, a7
+        adcs    u8, u8, l
+        cset    u9, cs
 
-                umulh   l, a1, a2
-                adds    u4, u4, l
-                umulh   l, a1, a3
-                adcs    u5, u5, l
-                umulh   l, a1, a4
-                adcs    u6, u6, l
-                umulh   l, a1, a5
-                adcs    u7, u7, l
-                umulh   l, a1, a6
-                adcs    u8, u8, l
-                umulh   l, a1, a7
-                adc     u9, u9, l
-                mul     l, a4, a5
-                umulh   u10, a4, a5
-                adds    u9, u9, l
-                adc     u10, u10, xzr
+        umulh   l, a1, a2
+        adds    u4, u4, l
+        umulh   l, a1, a3
+        adcs    u5, u5, l
+        umulh   l, a1, a4
+        adcs    u6, u6, l
+        umulh   l, a1, a5
+        adcs    u7, u7, l
+        umulh   l, a1, a6
+        adcs    u8, u8, l
+        umulh   l, a1, a7
+        adc     u9, u9, l
+        mul     l, a4, a5
+        umulh   u10, a4, a5
+        adds    u9, u9, l
+        adc     u10, u10, xzr
 
 // And the next one = 32 + 42 + 52 + 62 + 72 + 64 + 65
 
-                mul     l, a2, a3
-                adds    u5, u5, l
-                mul     l, a2, a4
-                adcs    u6, u6, l
-                mul     l, a2, a5
-                adcs    u7, u7, l
-                mul     l, a2, a6
-                adcs    u8, u8, l
-                mul     l, a2, a7
-                adcs    u9, u9, l
-                mul     l, a4, a6
-                adcs    u10, u10, l
-                cset    u11, cs
+        mul     l, a2, a3
+        adds    u5, u5, l
+        mul     l, a2, a4
+        adcs    u6, u6, l
+        mul     l, a2, a5
+        adcs    u7, u7, l
+        mul     l, a2, a6
+        adcs    u8, u8, l
+        mul     l, a2, a7
+        adcs    u9, u9, l
+        mul     l, a4, a6
+        adcs    u10, u10, l
+        cset    u11, cs
 
-                umulh   l, a2, a3
-                adds    u6, u6, l
-                umulh   l, a2, a4
-                adcs    u7, u7, l
-                umulh   l, a2, a5
-                adcs    u8, u8, l
-                umulh   l, a2, a6
-                adcs    u9, u9, l
-                umulh   l, a2, a7
-                adcs    u10, u10, l
-                umulh   l, a4, a6
-                adc     u11, u11, l
-                mul     l, a5, a6
-                umulh   u12, a5, a6
-                adds    u11, u11, l
-                adc     u12, u12, xzr
+        umulh   l, a2, a3
+        adds    u6, u6, l
+        umulh   l, a2, a4
+        adcs    u7, u7, l
+        umulh   l, a2, a5
+        adcs    u8, u8, l
+        umulh   l, a2, a6
+        adcs    u9, u9, l
+        umulh   l, a2, a7
+        adcs    u10, u10, l
+        umulh   l, a4, a6
+        adc     u11, u11, l
+        mul     l, a5, a6
+        umulh   u12, a5, a6
+        adds    u11, u11, l
+        adc     u12, u12, xzr
 
 // And the final one = 43 + 53 + 63 + 73 + 74 + 75 + 76
 
-                mul     l, a3, a4
-                adds    u7, u7, l
-                mul     l, a3, a5
-                adcs    u8, u8, l
-                mul     l, a3, a6
-                adcs    u9, u9, l
-                mul     l, a3, a7
-                adcs    u10, u10, l
-                mul     l, a4, a7
-                adcs    u11, u11, l
-                mul     l, a5, a7
-                adcs    u12, u12, l
-                cset    u13, cs
+        mul     l, a3, a4
+        adds    u7, u7, l
+        mul     l, a3, a5
+        adcs    u8, u8, l
+        mul     l, a3, a6
+        adcs    u9, u9, l
+        mul     l, a3, a7
+        adcs    u10, u10, l
+        mul     l, a4, a7
+        adcs    u11, u11, l
+        mul     l, a5, a7
+        adcs    u12, u12, l
+        cset    u13, cs
 
-                umulh   l, a3, a4
-                adds    u8, u8, l
-                umulh   l, a3, a5
-                adcs    u9, u9, l
-                umulh   l, a3, a6
-                adcs    u10, u10, l
-                umulh   l, a3, a7
-                adcs    u11, u11, l
-                umulh   l, a4, a7
-                adcs    u12, u12, l
-                umulh   l, a5, a7
-                adc     u13, u13, l
-                mul     l, a6, a7
-                umulh   u14, a6, a7
-                adds    u13, u13, l
-                adc     u14, u14, xzr
+        umulh   l, a3, a4
+        adds    u8, u8, l
+        umulh   l, a3, a5
+        adcs    u9, u9, l
+        umulh   l, a3, a6
+        adcs    u10, u10, l
+        umulh   l, a3, a7
+        adcs    u11, u11, l
+        umulh   l, a4, a7
+        adcs    u12, u12, l
+        umulh   l, a5, a7
+        adc     u13, u13, l
+        mul     l, a6, a7
+        umulh   u14, a6, a7
+        adds    u13, u13, l
+        adc     u14, u14, xzr
 
 // Double that, with u15 holding the top carry
 
-                adds    u1, u1, u1
-                adcs    u2, u2, u2
-                adcs    u3, u3, u3
-                adcs    u4, u4, u4
-                adcs    u5, u5, u5
-                adcs    u6, u6, u6
-                adcs    u7, u7, u7
-                adcs    u8, u8, u8
-                adcs    u9, u9, u9
-                adcs    u10, u10, u10
-                adcs    u11, u11, u11
-                adcs    u12, u12, u12
-                adcs    u13, u13, u13
-                adcs    u14, u14, u14
-                cset    u15, cs
+        adds    u1, u1, u1
+        adcs    u2, u2, u2
+        adcs    u3, u3, u3
+        adcs    u4, u4, u4
+        adcs    u5, u5, u5
+        adcs    u6, u6, u6
+        adcs    u7, u7, u7
+        adcs    u8, u8, u8
+        adcs    u9, u9, u9
+        adcs    u10, u10, u10
+        adcs    u11, u11, u11
+        adcs    u12, u12, u12
+        adcs    u13, u13, u13
+        adcs    u14, u14, u14
+        cset    u15, cs
 
 // Add the homogeneous terms 00 + 11 + 22 + 33 + 44 + 55 + 66 + 77
 
-                umulh   l, a0, a0
-                mul     u0, a0, a0
-                adds    u1, u1, l
+        umulh   l, a0, a0
+        mul     u0, a0, a0
+        adds    u1, u1, l
 
-                mul     l, a1, a1
-                adcs    u2, u2, l
-                umulh   l, a1, a1
-                adcs    u3, u3, l
+        mul     l, a1, a1
+        adcs    u2, u2, l
+        umulh   l, a1, a1
+        adcs    u3, u3, l
 
-                mul     l, a2, a2
-                adcs    u4, u4, l
-                umulh   l, a2, a2
-                adcs    u5, u5, l
+        mul     l, a2, a2
+        adcs    u4, u4, l
+        umulh   l, a2, a2
+        adcs    u5, u5, l
 
-                mul     l, a3, a3
-                adcs    u6, u6, l
-                umulh   l, a3, a3
-                adcs    u7, u7, l
+        mul     l, a3, a3
+        adcs    u6, u6, l
+        umulh   l, a3, a3
+        adcs    u7, u7, l
 
-                mul     l, a4, a4
-                adcs    u8, u8, l
-                umulh   l, a4, a4
-                adcs    u9, u9, l
+        mul     l, a4, a4
+        adcs    u8, u8, l
+        umulh   l, a4, a4
+        adcs    u9, u9, l
 
-                mul     l, a5, a5
-                adcs    u10, u10, l
-                umulh   l, a5, a5
-                adcs    u11, u11, l
+        mul     l, a5, a5
+        adcs    u10, u10, l
+        umulh   l, a5, a5
+        adcs    u11, u11, l
 
-                mul     l, a6, a6
-                adcs    u12, u12, l
-                umulh   l, a6, a6
-                adcs    u13, u13, l
+        mul     l, a6, a6
+        adcs    u12, u12, l
+        umulh   l, a6, a6
+        adcs    u13, u13, l
 
-                mul     l, a7, a7
-                adcs    u14, u14, l
-                umulh   l, a7, a7
-                adc     u15, u15, l
+        mul     l, a7, a7
+        adcs    u14, u14, l
+        umulh   l, a7, a7
+        adc     u15, u15, l
 
 // Now load in the top digit a8, and also set up its double and square
 
-                ldr     a8, [x, #64]
-                mul     u16, a8, a8
-                add     a8, a8, a8
+        ldr     a8, [x, #64]
+        mul     u16, a8, a8
+        add     a8, a8, a8
 
 // Add a8 * [a7;...;a0] into the top of the buffer
 
-                mul     l, a8, a0
-                adds    u8, u8, l
-                mul     l, a8, a1
-                adcs    u9, u9, l
-                mul     l, a8, a2
-                adcs    u10, u10, l
-                mul     l, a8, a3
-                adcs    u11, u11, l
-                mul     l, a8, a4
-                adcs    u12, u12, l
-                mul     l, a8, a5
-                adcs    u13, u13, l
-                mul     l, a8, a6
-                adcs    u14, u14, l
-                mul     l, a8, a7
-                adcs    u15, u15, l
-                adc     u16, u16, xzr
+        mul     l, a8, a0
+        adds    u8, u8, l
+        mul     l, a8, a1
+        adcs    u9, u9, l
+        mul     l, a8, a2
+        adcs    u10, u10, l
+        mul     l, a8, a3
+        adcs    u11, u11, l
+        mul     l, a8, a4
+        adcs    u12, u12, l
+        mul     l, a8, a5
+        adcs    u13, u13, l
+        mul     l, a8, a6
+        adcs    u14, u14, l
+        mul     l, a8, a7
+        adcs    u15, u15, l
+        adc     u16, u16, xzr
 
-                umulh   l, a8, a0
-                adds    u9, u9, l
-                umulh   l, a8, a1
-                adcs    u10, u10, l
-                umulh   l, a8, a2
-                adcs    u11, u11, l
-                umulh   l, a8, a3
-                adcs    u12, u12, l
-                umulh   l, a8, a4
-                adcs    u13, u13, l
-                umulh   l, a8, a5
-                adcs    u14, u14, l
-                umulh   l, a8, a6
-                adcs    u15, u15, l
-                umulh   l, a8, a7
-                adc     u16, u16, l
+        umulh   l, a8, a0
+        adds    u9, u9, l
+        umulh   l, a8, a1
+        adcs    u10, u10, l
+        umulh   l, a8, a2
+        adcs    u11, u11, l
+        umulh   l, a8, a3
+        adcs    u12, u12, l
+        umulh   l, a8, a4
+        adcs    u13, u13, l
+        umulh   l, a8, a5
+        adcs    u14, u14, l
+        umulh   l, a8, a6
+        adcs    u15, u15, l
+        umulh   l, a8, a7
+        adc     u16, u16, l
 
 // Now we have the full product, which we consider as
 // 2^521 * h + l. Form h + l + 1
 
-                subs    xzr, xzr, xzr
-                extr    l, u9, u8, #9
-                adcs    u0, u0, l
-                extr    l, u10, u9, #9
-                adcs    u1, u1, l
-                extr    l, u11, u10, #9
-                adcs    u2, u2, l
-                extr    l, u12, u11, #9
-                adcs    u3, u3, l
-                extr    l, u13, u12, #9
-                adcs    u4, u4, l
-                extr    l, u14, u13, #9
-                adcs    u5, u5, l
-                extr    l, u15, u14, #9
-                adcs    u6, u6, l
-                extr    l, u16, u15, #9
-                adcs    u7, u7, l
-                orr     u8, u8, #~0x1FF
-                lsr     l, u16, #9
-                adcs    u8, u8, l
+        subs    xzr, xzr, xzr
+        extr    l, u9, u8, #9
+        adcs    u0, u0, l
+        extr    l, u10, u9, #9
+        adcs    u1, u1, l
+        extr    l, u11, u10, #9
+        adcs    u2, u2, l
+        extr    l, u12, u11, #9
+        adcs    u3, u3, l
+        extr    l, u13, u12, #9
+        adcs    u4, u4, l
+        extr    l, u14, u13, #9
+        adcs    u5, u5, l
+        extr    l, u15, u14, #9
+        adcs    u6, u6, l
+        extr    l, u16, u15, #9
+        adcs    u7, u7, l
+        orr     u8, u8, #~0x1FF
+        lsr     l, u16, #9
+        adcs    u8, u8, l
 
 // Now CF is set if h + l + 1 >= 2^521, which means it's already
 // the answer, while if ~CF the answer is h + l so we should subtract
 // 1 (all considered in 521 bits). Hence subtract ~CF and mask.
 
-                sbcs    u0, u0, xzr
-                sbcs    u1, u1, xzr
-                sbcs    u2, u2, xzr
-                sbcs    u3, u3, xzr
-                sbcs    u4, u4, xzr
-                sbcs    u5, u5, xzr
-                sbcs    u6, u6, xzr
-                sbcs    u7, u7, xzr
-                sbc     u8, u8, xzr
-                and     u8, u8, #0x1FF
+        sbcs    u0, u0, xzr
+        sbcs    u1, u1, xzr
+        sbcs    u2, u2, xzr
+        sbcs    u3, u3, xzr
+        sbcs    u4, u4, xzr
+        sbcs    u5, u5, xzr
+        sbcs    u6, u6, xzr
+        sbcs    u7, u7, xzr
+        sbc     u8, u8, xzr
+        and     u8, u8, #0x1FF
 
 // So far, this has been the same as a pure modular squaring
 // Now finally the Montgomery ingredient, which is just a 521-bit
 // rotation by 9*64 - 521 = 55 bits right.
 
-                lsl     l, u0, #9
-                extr    u0, u1, u0, #55
-                extr    u1, u2, u1, #55
-                extr    u2, u3, u2, #55
-                extr    u3, u4, u3, #55
-                orr     u8, u8, l
-                extr    u4, u5, u4, #55
-                extr    u5, u6, u5, #55
-                extr    u6, u7, u6, #55
-                extr    u7, u8, u7, #55
-                lsr     u8, u8, #55
+        lsl     l, u0, #9
+        extr    u0, u1, u0, #55
+        extr    u1, u2, u1, #55
+        extr    u2, u3, u2, #55
+        extr    u3, u4, u3, #55
+        orr     u8, u8, l
+        extr    u4, u5, u4, #55
+        extr    u5, u6, u5, #55
+        extr    u6, u7, u6, #55
+        extr    u7, u8, u7, #55
+        lsr     u8, u8, #55
 
 // Store back digits of final result
 
-                stp     u0, u1, [z]
-                stp     u2, u3, [z, #16]
-                stp     u4, u5, [z, #32]
-                stp     u6, u7, [z, #48]
-                str     u8, [z, #64]
+        stp     u0, u1, [z]
+        stp     u2, u3, [z, #16]
+        stp     u4, u5, [z, #32]
+        stp     u6, u7, [z, #48]
+        str     u8, [z, #64]
 
 // Restore registers and return
 
-                ldp     x27, x29, [sp], #16
-                ldp     x25, x26, [sp], #16
-                ldp     x23, x24, [sp], #16
-                ldp     x21, x22, [sp], #16
-                ldp     x19, x20, [sp], #16
+        ldp     x27, x29, [sp], #16
+        ldp     x25, x26, [sp], #16
+        ldp     x23, x24, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
@@ -28,8 +28,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_montsqr_p521_alt
-        .globl  _bignum_montsqr_p521_alt
+        .globl bignum_montsqr_p521_alt
+        .private_extern bignum_montsqr_p521_alt
+
+        .globl _bignum_montsqr_p521_alt
+        .private_extern _bignum_montsqr_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
@@ -27,12 +27,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p521_alt
-        .private_extern bignum_montsqr_p521_alt
+        S2N_ASM_HIDDEN(bignum_montsqr_p521_alt)
 
         .globl _bignum_montsqr_p521_alt
-        .private_extern _bignum_montsqr_p521_alt
+        S2N_ASM_HIDDEN(_bignum_montsqr_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_mul_p521
-        S2N_ASM_HIDDEN(bignum_mul_p521)
-
-        .globl _bignum_mul_p521
-        S2N_ASM_HIDDEN(_bignum_mul_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p521)
         .text
         .balign 4
 
@@ -95,174 +91,173 @@
 
 #define mul4                                                            \
 /*  First accumulate all the "simple" products as [s7,s6,s5,s4,s0] */   \
-                                                                        \
-                mul     s0, a0, b0;                                     \
-                mul     s4, a1, b1;                                     \
-                mul     s5, a2, b2;                                     \
-                mul     s6, a3, b3;                                     \
-                                                                        \
-                umulh   s7, a0, b0;                                     \
-                adds    s4, s4, s7;                                     \
-                umulh   s7, a1, b1;                                     \
-                adcs    s5, s5, s7;                                     \
-                umulh   s7, a2, b2;                                     \
-                adcs    s6, s6, s7;                                     \
-                umulh   s7, a3, b3;                                     \
-                adc     s7, s7, xzr;                                    \
-                                                                        \
+        \
+        mul     s0, a0, b0;                                     \
+        mul     s4, a1, b1;                                     \
+        mul     s5, a2, b2;                                     \
+        mul     s6, a3, b3;                                     \
+        \
+        umulh   s7, a0, b0;                                     \
+        adds    s4, s4, s7;                                     \
+        umulh   s7, a1, b1;                                     \
+        adcs    s5, s5, s7;                                     \
+        umulh   s7, a2, b2;                                     \
+        adcs    s6, s6, s7;                                     \
+        umulh   s7, a3, b3;                                     \
+        adc     s7, s7, xzr;                                    \
+        \
 /*  Multiply by B + 1 to get [s7;s6;s5;s4;s1;s0] */                     \
-                                                                        \
-                adds    s1, s4, s0;                                     \
-                adcs    s4, s5, s4;                                     \
-                adcs    s5, s6, s5;                                     \
-                adcs    s6, s7, s6;                                     \
-                adc     s7, xzr, s7;                                    \
-                                                                        \
+        \
+        adds    s1, s4, s0;                                     \
+        adcs    s4, s5, s4;                                     \
+        adcs    s5, s6, s5;                                     \
+        adcs    s6, s7, s6;                                     \
+        adc     s7, xzr, s7;                                    \
+        \
 /*  Multiply by B^2 + 1 to get [s7;s6;s5;s4;s3;s2;s1;s0] */             \
-                                                                        \
-                adds    s2, s4, s0;                                     \
-                adcs    s3, s5, s1;                                     \
-                adcs    s4, s6, s4;                                     \
-                adcs    s5, s7, s5;                                     \
-                adcs    s6, xzr, s6;                                    \
-                adc     s7, xzr, s7;                                    \
-                                                                        \
+        \
+        adds    s2, s4, s0;                                     \
+        adcs    s3, s5, s1;                                     \
+        adcs    s4, s6, s4;                                     \
+        adcs    s5, s7, s5;                                     \
+        adcs    s6, xzr, s6;                                    \
+        adc     s7, xzr, s7;                                    \
+        \
 /*  Now add in all the "complicated" terms. */                          \
-                                                                        \
-                muldiffnadd(s6,s5, a2,a3, b3,b2);                       \
-                adc     s7, s7, c;                                      \
-                                                                        \
-                muldiffnadd(s2,s1, a0,a1, b1,b0);                       \
-                adcs    s3, s3, c;                                      \
-                adcs    s4, s4, c;                                      \
-                adcs    s5, s5, c;                                      \
-                adcs    s6, s6, c;                                      \
-                adc     s7, s7, c;                                      \
-                                                                        \
-                muldiffnadd(s5,s4, a1,a3, b3,b1);                       \
-                adcs    s6, s6, c;                                      \
-                adc     s7, s7, c;                                      \
-                                                                        \
-                muldiffnadd(s3,s2, a0,a2, b2,b0);                       \
-                adcs    s4, s4, c;                                      \
-                adcs    s5, s5, c;                                      \
-                adcs    s6, s6, c;                                      \
-                adc     s7, s7, c;                                      \
-                                                                        \
-                muldiffnadd(s4,s3, a0,a3, b3,b0);                       \
-                adcs    s5, s5, c;                                      \
-                adcs    s6, s6, c;                                      \
-                adc     s7, s7, c;                                      \
-                muldiffnadd(s4,s3, a1,a2, b2,b1);                       \
-                adcs    s5, s5, c;                                      \
-                adcs    s6, s6, c;                                      \
-                adc     s7, s7, c                                       \
+        \
+        muldiffnadd(s6,s5, a2,a3, b3,b2);                       \
+        adc     s7, s7, c;                                      \
+        \
+        muldiffnadd(s2,s1, a0,a1, b1,b0);                       \
+        adcs    s3, s3, c;                                      \
+        adcs    s4, s4, c;                                      \
+        adcs    s5, s5, c;                                      \
+        adcs    s6, s6, c;                                      \
+        adc     s7, s7, c;                                      \
+        \
+        muldiffnadd(s5,s4, a1,a3, b3,b1);                       \
+        adcs    s6, s6, c;                                      \
+        adc     s7, s7, c;                                      \
+        \
+        muldiffnadd(s3,s2, a0,a2, b2,b0);                       \
+        adcs    s4, s4, c;                                      \
+        adcs    s5, s5, c;                                      \
+        adcs    s6, s6, c;                                      \
+        adc     s7, s7, c;                                      \
+        \
+        muldiffnadd(s4,s3, a0,a3, b3,b0);                       \
+        adcs    s5, s5, c;                                      \
+        adcs    s6, s6, c;                                      \
+        adc     s7, s7, c;                                      \
+        muldiffnadd(s4,s3, a1,a2, b2,b1);                       \
+        adcs    s5, s5, c;                                      \
+        adcs    s6, s6, c;                                      \
+        adc     s7, s7, c                                       \
 
-bignum_mul_p521:
-_bignum_mul_p521:
+S2N_BN_SYMBOL(bignum_mul_p521):
 
 // Save registers and make space for the temporary buffer
 
-                stp     x19, x20, [sp, #-16]!
-                stp     x21, x22, [sp, #-16]!
-                stp     x23, x24, [sp, #-16]!
-                stp     x25, x26, [sp, #-16]!
-                sub     sp, sp, #80
+        stp     x19, x20, [sp, #-16]!
+        stp     x21, x22, [sp, #-16]!
+        stp     x23, x24, [sp, #-16]!
+        stp     x25, x26, [sp, #-16]!
+        sub     sp, sp, #80
 
 // Load 4-digit low parts and multiply them to get L
 
-                ldp     a0, a1, [x]
-                ldp     a2, a3, [x, #16]
-                ldp     b0, b1, [y]
-                ldp     b2, b3, [y, #16]
-                mul4
+        ldp     a0, a1, [x]
+        ldp     a2, a3, [x, #16]
+        ldp     b0, b1, [y]
+        ldp     b2, b3, [y, #16]
+        mul4
 
 // Shift right 256 bits modulo p_521 and stash in temp buffer
 
-                lsl     c, s0, #9
-                extr    s0, s1, s0, #55
-                extr    s1, s2, s1, #55
-                extr    s2, s3, s2, #55
-                lsr     s3, s3, #55
-                stp     s4, s5, [sp]
-                stp     s6, s7, [sp, #16]
-                stp     c, s0, [sp, #32]
-                stp     s1, s2, [sp, #48]
-                str     s3, [sp, #64]
+        lsl     c, s0, #9
+        extr    s0, s1, s0, #55
+        extr    s1, s2, s1, #55
+        extr    s2, s3, s2, #55
+        lsr     s3, s3, #55
+        stp     s4, s5, [sp]
+        stp     s6, s7, [sp, #16]
+        stp     c, s0, [sp, #32]
+        stp     s1, s2, [sp, #48]
+        str     s3, [sp, #64]
 
 // Load 4-digit low parts and multiply them to get H
 
-                ldp     a0, a1, [x, #32]
-                ldp     a2, a3, [x, #48]
-                ldp     b0, b1, [y, #32]
-                ldp     b2, b3, [y, #48]
-                mul4
+        ldp     a0, a1, [x, #32]
+        ldp     a2, a3, [x, #48]
+        ldp     b0, b1, [y, #32]
+        ldp     b2, b3, [y, #48]
+        mul4
 
 // Add to the existing temporary buffer and re-stash.
 // This gives a result HL congruent to (2^256 * H + L) / 2^256 modulo p_521
 
-                ldp     l, h, [sp]
-                adds    s0, s0, l
-                adcs    s1, s1, h
-                stp     s0, s1, [sp]
-                ldp     l, h, [sp, #16]
-                adcs    s2, s2, l
-                adcs    s3, s3, h
-                stp     s2, s3, [sp, #16]
-                ldp     l, h, [sp, #32]
-                adcs    s4, s4, l
-                adcs    s5, s5, h
-                stp     s4, s5, [sp, #32]
-                ldp     l, h, [sp, #48]
-                adcs    s6, s6, l
-                adcs    s7, s7, h
-                stp     s6, s7, [sp, #48]
-                ldr     c, [sp, #64]
-                adc     c, c, xzr
-                str     c, [sp, #64]
+        ldp     l, h, [sp]
+        adds    s0, s0, l
+        adcs    s1, s1, h
+        stp     s0, s1, [sp]
+        ldp     l, h, [sp, #16]
+        adcs    s2, s2, l
+        adcs    s3, s3, h
+        stp     s2, s3, [sp, #16]
+        ldp     l, h, [sp, #32]
+        adcs    s4, s4, l
+        adcs    s5, s5, h
+        stp     s4, s5, [sp, #32]
+        ldp     l, h, [sp, #48]
+        adcs    s6, s6, l
+        adcs    s7, s7, h
+        stp     s6, s7, [sp, #48]
+        ldr     c, [sp, #64]
+        adc     c, c, xzr
+        str     c, [sp, #64]
 
 // Compute t,[a3,a2,a1,a0] = x_hi - x_lo
 // and     s,[b3,b2,b1,b0] = y_lo - y_hi
 // sign-magnitude differences, then XOR overall sign bitmask into s
 
-                ldp     l, h, [x]
-                subs    a0, a0, l
-                sbcs    a1, a1, h
-                ldp     l, h, [x, #16]
-                sbcs    a2, a2, l
-                sbcs    a3, a3, h
-                csetm   t, cc
-                ldp     l, h, [y]
-                subs    b0, l, b0
-                sbcs    b1, h, b1
-                ldp     l, h, [y, #16]
-                sbcs    b2, l, b2
-                sbcs    b3, h, b3
-                csetm   s, cc
+        ldp     l, h, [x]
+        subs    a0, a0, l
+        sbcs    a1, a1, h
+        ldp     l, h, [x, #16]
+        sbcs    a2, a2, l
+        sbcs    a3, a3, h
+        csetm   t, cc
+        ldp     l, h, [y]
+        subs    b0, l, b0
+        sbcs    b1, h, b1
+        ldp     l, h, [y, #16]
+        sbcs    b2, l, b2
+        sbcs    b3, h, b3
+        csetm   s, cc
 
-                eor     a0, a0, t
-                subs    a0, a0, t
-                eor     a1, a1, t
-                sbcs    a1, a1, t
-                eor     a2, a2, t
-                sbcs    a2, a2, t
-                eor     a3, a3, t
-                sbc     a3, a3, t
+        eor     a0, a0, t
+        subs    a0, a0, t
+        eor     a1, a1, t
+        sbcs    a1, a1, t
+        eor     a2, a2, t
+        sbcs    a2, a2, t
+        eor     a3, a3, t
+        sbc     a3, a3, t
 
-                eor     b0, b0, s
-                subs    b0, b0, s
-                eor     b1, b1, s
-                sbcs    b1, b1, s
-                eor     b2, b2, s
-                sbcs    b2, b2, s
-                eor     b3, b3, s
-                sbc     b3, b3, s
+        eor     b0, b0, s
+        subs    b0, b0, s
+        eor     b1, b1, s
+        sbcs    b1, b1, s
+        eor     b2, b2, s
+        sbcs    b2, b2, s
+        eor     b3, b3, s
+        sbc     b3, b3, s
 
-                eor     s, s, t
+        eor     s, s, t
 
 // Now do yet a third 4x4 multiply to get mid-term product M
 
-                mul4
+        mul4
 
 // We now want, at the 256 position, 2^256 * HL + HL + (-1)^s * M
 // To keep things positive we use M' = p_521 - M in place of -M,
@@ -278,48 +273,48 @@ _bignum_mul_p521:
 // small c (s8 + suspended carry) to add at the 256 position here (512
 // overall). This can be added in the next block (to b0 = sum4).
 
-                ldp     a0, a1, [sp]
-                ldp     a2, a3, [sp, #16]
+        ldp     a0, a1, [sp]
+        ldp     a2, a3, [sp, #16]
 
-                eor     s0, s0, s
-                adds    s0, s0, a0
-                eor     s1, s1, s
-                adcs    s1, s1, a1
-                eor     s2, s2, s
-                adcs    s2, s2, a2
-                eor     s3, s3, s
-                adcs    s3, s3, a3
-                eor     s4, s4, s
+        eor     s0, s0, s
+        adds    s0, s0, a0
+        eor     s1, s1, s
+        adcs    s1, s1, a1
+        eor     s2, s2, s
+        adcs    s2, s2, a2
+        eor     s3, s3, s
+        adcs    s3, s3, a3
+        eor     s4, s4, s
 
-                ldp     b0, b1, [sp, #32]
-                ldp     b2, b3, [sp, #48]
-                ldr     s8, [sp, #64]
+        ldp     b0, b1, [sp, #32]
+        ldp     b2, b3, [sp, #48]
+        ldr     s8, [sp, #64]
 
-                adcs    s4, s4, b0
-                eor     s5, s5, s
-                adcs    s5, s5, b1
-                eor     s6, s6, s
-                adcs    s6, s6, b2
-                eor     s7, s7, s
-                adcs    s7, s7, b3
-                adc     c, s8, xzr
+        adcs    s4, s4, b0
+        eor     s5, s5, s
+        adcs    s5, s5, b1
+        eor     s6, s6, s
+        adcs    s6, s6, b2
+        eor     s7, s7, s
+        adcs    s7, s7, b3
+        adc     c, s8, xzr
 
-                adds    s4, s4, a0
-                adcs    s5, s5, a1
-                adcs    s6, s6, a2
-                adcs    s7, s7, a3
-                and     s, s, #0x1FF
-                lsl     t, s0, #9
-                orr     t, t, s
-                adcs    b0, b0, t
-                extr    t, s1, s0, #55
-                adcs    b1, b1, t
-                extr    t, s2, s1, #55
-                adcs    b2, b2, t
-                extr    t, s3, s2, #55
-                adcs    b3, b3, t
-                lsr     t, s3, #55
-                adc     s8, t, s8
+        adds    s4, s4, a0
+        adcs    s5, s5, a1
+        adcs    s6, s6, a2
+        adcs    s7, s7, a3
+        and     s, s, #0x1FF
+        lsl     t, s0, #9
+        orr     t, t, s
+        adcs    b0, b0, t
+        extr    t, s1, s0, #55
+        adcs    b1, b1, t
+        extr    t, s2, s1, #55
+        adcs    b2, b2, t
+        extr    t, s3, s2, #55
+        adcs    b3, b3, t
+        lsr     t, s3, #55
+        adc     s8, t, s8
 
 // Augment the total with the contribution from the top little words
 // w and v. If we write the inputs as 2^512 * w + x and 2^512 * v + y
@@ -366,243 +361,243 @@ _bignum_mul_p521:
 
 // 0 * 52 = 64 * 0 + 0
 
-                ldr     v, [y, #64]
-                ldp     c0, c1, [x]
-                and     l, c0, #0x000fffffffffffff
-                mul     l, v, l
-                ldr     w, [x, #64]
-                ldp     d0, d1, [y]
-                and     t, d0, #0x000fffffffffffff
-                mul     t, w, t
-                add     l, l, t
+        ldr     v, [y, #64]
+        ldp     c0, c1, [x]
+        and     l, c0, #0x000fffffffffffff
+        mul     l, v, l
+        ldr     w, [x, #64]
+        ldp     d0, d1, [y]
+        and     t, d0, #0x000fffffffffffff
+        mul     t, w, t
+        add     l, l, t
 
 // 1 * 52 = 64 * 0 + 52
 
-                extr    t, c1, c0, #52
-                and     t, t, #0x000fffffffffffff
-                mul     h, v, t
-                extr    t, d1, d0, #52
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     h, h, t
-                lsr     t, l, #52
-                add     h, h, t
+        extr    t, c1, c0, #52
+        and     t, t, #0x000fffffffffffff
+        mul     h, v, t
+        extr    t, d1, d0, #52
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     h, h, t
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #12
-                adds    sum0, sum0, t
+        lsl     l, l, #12
+        extr    t, h, l, #12
+        adds    sum0, sum0, t
 
 // 2 * 52 = 64 * 1 + 40
 
-                ldp     c2, c3, [x, #16]
-                ldp     d2, d3, [y, #16]
-                extr    t, c2, c1, #40
-                and     t, t, #0x000fffffffffffff
-                mul     l, v, t
-                extr    t, d2, d1, #40
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     l, l, t
-                lsr     t, h, #52
-                add     l, l, t
+        ldp     c2, c3, [x, #16]
+        ldp     d2, d3, [y, #16]
+        extr    t, c2, c1, #40
+        and     t, t, #0x000fffffffffffff
+        mul     l, v, t
+        extr    t, d2, d1, #40
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     l, l, t
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #24
-                adcs    sum1, sum1, t
+        lsl     h, h, #12
+        extr    t, l, h, #24
+        adcs    sum1, sum1, t
 
 // 3 * 52 = 64 * 2 + 28
 
-                extr    t, c3, c2, #28
-                and     t, t, #0x000fffffffffffff
-                mul     h, v, t
-                extr    t, d3, d2, #28
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     h, h, t
-                lsr     t, l, #52
-                add     h, h, t
+        extr    t, c3, c2, #28
+        and     t, t, #0x000fffffffffffff
+        mul     h, v, t
+        extr    t, d3, d2, #28
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     h, h, t
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #36
-                adcs    sum2, sum2, t
-                and     u, sum1, sum2
+        lsl     l, l, #12
+        extr    t, h, l, #36
+        adcs    sum2, sum2, t
+        and     u, sum1, sum2
 
 // 4 * 52 = 64 * 3 + 16
 // At this point we also fold in the addition of c at the right place.
 // Note that 4 * 64 = 4 * 52 + 48 so we shift c left 48 places to align.
 
-                ldp     c4, c5, [x, #32]
-                ldp     d4, d5, [y, #32]
-                extr    t, c4, c3, #16
-                and     t, t, #0x000fffffffffffff
-                mul     l, v, t
-                extr    t, d4, d3, #16
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     l, l, t
+        ldp     c4, c5, [x, #32]
+        ldp     d4, d5, [y, #32]
+        extr    t, c4, c3, #16
+        and     t, t, #0x000fffffffffffff
+        mul     l, v, t
+        extr    t, d4, d3, #16
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     l, l, t
 
-                lsl     c, c, #48
-                add     l, l, c
+        lsl     c, c, #48
+        add     l, l, c
 
-                lsr     t, h, #52
-                add     l, l, t
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #48
-                adcs    sum3, sum3, t
-                and     u, u, sum3
+        lsl     h, h, #12
+        extr    t, l, h, #48
+        adcs    sum3, sum3, t
+        and     u, u, sum3
 
 // 5 * 52 = 64 * 4 + 4
 
-                lsr     t, c4, #4
-                and     t, t, #0x000fffffffffffff
-                mul     h, v, t
-                lsr     t, d4, #4
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     h, h, t
+        lsr     t, c4, #4
+        and     t, t, #0x000fffffffffffff
+        mul     h, v, t
+        lsr     t, d4, #4
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     h, h, t
 
-                lsr     t, l, #52
-                add     h, h, t
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    s, h, l, #60
+        lsl     l, l, #12
+        extr    s, h, l, #60
 
 // 6 * 52 = 64 * 4 + 56
 
-                extr    t, c5, c4, #56
-                and     t, t, #0x000fffffffffffff
-                mul     l, v, t
-                extr    t, d5, d4, #56
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     l, l, t
+        extr    t, c5, c4, #56
+        and     t, t, #0x000fffffffffffff
+        mul     l, v, t
+        extr    t, d5, d4, #56
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     l, l, t
 
-                lsr     t, h, #52
-                add     l, l, t
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     s, s, #8
-                extr    t, l, s, #8
-                adcs    sum4, sum4, t
-                and     u, u, sum4
+        lsl     s, s, #8
+        extr    t, l, s, #8
+        adcs    sum4, sum4, t
+        and     u, u, sum4
 
 // 7 * 52 = 64 * 5 + 44
 
-                ldp     c6, c7, [x, #48]
-                ldp     d6, d7, [y, #48]
-                extr    t, c6, c5, #44
-                and     t, t, #0x000fffffffffffff
-                mul     h, v, t
-                extr    t, d6, d5, #44
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     h, h, t
+        ldp     c6, c7, [x, #48]
+        ldp     d6, d7, [y, #48]
+        extr    t, c6, c5, #44
+        and     t, t, #0x000fffffffffffff
+        mul     h, v, t
+        extr    t, d6, d5, #44
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     h, h, t
 
-                lsr     t, l, #52
-                add     h, h, t
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #20
-                adcs    sum5, sum5, t
-                and     u, u, sum5
+        lsl     l, l, #12
+        extr    t, h, l, #20
+        adcs    sum5, sum5, t
+        and     u, u, sum5
 
 // 8 * 52 = 64 * 6 + 32
 
-                extr    t, c7, c6, #32
-                and     t, t, #0x000fffffffffffff
-                mul     l, v, t
-                extr    t, d7, d6, #32
-                and     t, t, #0x000fffffffffffff
-                mul     t, w, t
-                add     l, l, t
+        extr    t, c7, c6, #32
+        and     t, t, #0x000fffffffffffff
+        mul     l, v, t
+        extr    t, d7, d6, #32
+        and     t, t, #0x000fffffffffffff
+        mul     t, w, t
+        add     l, l, t
 
-                lsr     t, h, #52
-                add     l, l, t
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #32
-                adcs    sum6, sum6, t
-                and     u, u, sum6
+        lsl     h, h, #12
+        extr    t, l, h, #32
+        adcs    sum6, sum6, t
+        and     u, u, sum6
 
 // 9 * 52 = 64 * 7 + 20
 
-                lsr     t, c7, #20
-                mul     h, v, t
-                lsr     t, d7, #20
-                mul     t, w, t
-                add     h, h, t
+        lsr     t, c7, #20
+        mul     h, v, t
+        lsr     t, d7, #20
+        mul     t, w, t
+        add     h, h, t
 
-                lsr     t, l, #52
-                add     h, h, t
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #44
-                adcs    sum7, sum7, t
-                and     u, u, sum7
+        lsl     l, l, #12
+        extr    t, h, l, #44
+        adcs    sum7, sum7, t
+        and     u, u, sum7
 
 // Top word
 
-                mul     t, v, w
-                lsr     h, h, #44
-                add     t, t, h
-                adc     sum8, sum8, t
+        mul     t, v, w
+        lsr     h, h, #44
+        add     t, t, h
+        adc     sum8, sum8, t
 
 // Extract the high part h and mask off the low part l = [sum8;sum7;...;sum0]
 // but stuff sum8 with 1 bits at the left to ease a comparison below
 
-                lsr     h, sum8, #9
-                orr     sum8, sum8, #~0x1FF
+        lsr     h, sum8, #9
+        orr     sum8, sum8, #~0x1FF
 
 // Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
 // happen if digits sum7,...sum1 are all 1s, we use the AND of them "u" to
 // condense the carry chain, and since we stuffed 1 bits into sum8 we get
 // the result in CF without an additional comparison.
 
-                subs    xzr, xzr, xzr
-                adcs    xzr, sum0, h
-                adcs    xzr, u, xzr
-                adcs    xzr, sum8, xzr
+        subs    xzr, xzr, xzr
+        adcs    xzr, sum0, h
+        adcs    xzr, u, xzr
+        adcs    xzr, sum8, xzr
 
 // Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
 // while otherwise we want just h + l. So mask h + l + CF to 521 bits.
 // We don't need to mask away bits above 521 since they disappear below.
 
-                adcs    sum0, sum0, h
-                adcs    sum1, sum1, xzr
-                adcs    sum2, sum2, xzr
-                adcs    sum3, sum3, xzr
-                adcs    sum4, sum4, xzr
-                adcs    sum5, sum5, xzr
-                adcs    sum6, sum6, xzr
-                adcs    sum7, sum7, xzr
-                adc     sum8, sum8, xzr
+        adcs    sum0, sum0, h
+        adcs    sum1, sum1, xzr
+        adcs    sum2, sum2, xzr
+        adcs    sum3, sum3, xzr
+        adcs    sum4, sum4, xzr
+        adcs    sum5, sum5, xzr
+        adcs    sum6, sum6, xzr
+        adcs    sum7, sum7, xzr
+        adc     sum8, sum8, xzr
 
 // The result is actually 2^512 * [sum8;...;sum0] == 2^-9 * [sum8;...;sum0]
 // so we rotate right by 9 bits
 
-                and     h, sum0, #0x1FF
-                extr    sum0, sum1, sum0, #9
-                extr    sum1, sum2, sum1, #9
-                stp     sum0, sum1, [z]
-                extr    sum2, sum3, sum2, #9
-                extr    sum3, sum4, sum3, #9
-                stp     sum2, sum3, [z, #16]
-                extr    sum4, sum5, sum4, #9
-                extr    sum5, sum6, sum5, #9
-                stp     sum4, sum5, [z, #32]
-                extr    sum6, sum7, sum6, #9
-                extr    sum7, sum8, sum7, #9
-                stp     sum6, sum7, [z, #48]
-                str     h, [z, #64]
+        and     h, sum0, #0x1FF
+        extr    sum0, sum1, sum0, #9
+        extr    sum1, sum2, sum1, #9
+        stp     sum0, sum1, [z]
+        extr    sum2, sum3, sum2, #9
+        extr    sum3, sum4, sum3, #9
+        stp     sum2, sum3, [z, #16]
+        extr    sum4, sum5, sum4, #9
+        extr    sum5, sum6, sum5, #9
+        stp     sum4, sum5, [z, #32]
+        extr    sum6, sum7, sum6, #9
+        extr    sum7, sum8, sum7, #9
+        stp     sum6, sum7, [z, #48]
+        str     h, [z, #64]
 
 // Restore regs and return
 
-                add     sp, sp, #80
-                ldp     x25, x26, [sp], #16
-                ldp     x23, x24, [sp], #16
-                ldp     x21, x22, [sp], #16
-                ldp     x19, x20, [sp], #16
-                ret
+        add     sp, sp, #80
+        ldp     x25, x26, [sp], #16
+        ldp     x23, x24, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mul_p521
-        .private_extern bignum_mul_p521
+        S2N_ASM_HIDDEN(bignum_mul_p521)
 
         .globl _bignum_mul_p521
-        .private_extern _bignum_mul_p521
+        S2N_ASM_HIDDEN(_bignum_mul_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mul_p521
-        .globl  _bignum_mul_p521
+        .globl bignum_mul_p521
+        .private_extern bignum_mul_p521
+
+        .globl _bignum_mul_p521
+        .private_extern _bignum_mul_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_mul_p521_alt
-        S2N_ASM_HIDDEN(bignum_mul_p521_alt)
-
-        .globl _bignum_mul_p521_alt
-        S2N_ASM_HIDDEN(_bignum_mul_p521_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p521_alt)
         .text
         .balign 4
 
@@ -82,467 +78,466 @@
 #define u15 x20
 #define u16 x21
 
-bignum_mul_p521_alt:
-_bignum_mul_p521_alt:
+S2N_BN_SYMBOL(bignum_mul_p521_alt):
 
 // Save more registers and make temporary space on stack
 
-                stp     x19, x20, [sp, #-16]!
-                stp     x21, x22, [sp, #-16]!
-                stp     x23, x24, [sp, #-16]!
-                stp     x25, x26, [sp, #-16]!
-                sub     sp, sp, #64
+        stp     x19, x20, [sp, #-16]!
+        stp     x21, x22, [sp, #-16]!
+        stp     x23, x24, [sp, #-16]!
+        stp     x25, x26, [sp, #-16]!
+        sub     sp, sp, #64
 
 // Load operands and set up row 0 = [u9;...;u0] = a0 * [b8;...;b0]
 
-                ldp     a0, a1, [x]
-                ldp     b0, b1, [y]
+        ldp     a0, a1, [x]
+        ldp     b0, b1, [y]
 
-                mul     u0, a0, b0
-                umulh   u1, a0, b0
-                mul     t, a0, b1
-                umulh   u2, a0, b1
-                adds    u1, u1, t
+        mul     u0, a0, b0
+        umulh   u1, a0, b0
+        mul     t, a0, b1
+        umulh   u2, a0, b1
+        adds    u1, u1, t
 
-                ldp     b2, b3, [y, #16]
+        ldp     b2, b3, [y, #16]
 
-                mul     t, a0, b2
-                umulh   u3, a0, b2
-                adcs    u2, u2, t
+        mul     t, a0, b2
+        umulh   u3, a0, b2
+        adcs    u2, u2, t
 
-                mul     t, a0, b3
-                umulh   u4, a0, b3
-                adcs    u3, u3, t
+        mul     t, a0, b3
+        umulh   u4, a0, b3
+        adcs    u3, u3, t
 
-                ldp     b4, b5, [y, #32]
+        ldp     b4, b5, [y, #32]
 
-                mul     t, a0, b4
-                umulh   u5, a0, b4
-                adcs    u4, u4, t
+        mul     t, a0, b4
+        umulh   u5, a0, b4
+        adcs    u4, u4, t
 
-                mul     t, a0, b5
-                umulh   u6, a0, b5
-                adcs    u5, u5, t
+        mul     t, a0, b5
+        umulh   u6, a0, b5
+        adcs    u5, u5, t
 
-                ldp     b6, b7, [y, #48]
+        ldp     b6, b7, [y, #48]
 
-                mul     t, a0, b6
-                umulh   u7, a0, b6
-                adcs    u6, u6, t
+        mul     t, a0, b6
+        umulh   u7, a0, b6
+        adcs    u6, u6, t
 
-                ldr     b8, [y, #64]
+        ldr     b8, [y, #64]
 
-                mul     t, a0, b7
-                umulh   u8, a0, b7
-                adcs    u7, u7, t
+        mul     t, a0, b7
+        umulh   u8, a0, b7
+        adcs    u7, u7, t
 
-                mul     t, a0, b8
-                umulh   u9, a0, b8
-                adcs    u8, u8, t
+        mul     t, a0, b8
+        umulh   u9, a0, b8
+        adcs    u8, u8, t
 
-                adc     u9, u9, xzr
+        adc     u9, u9, xzr
 
 // Row 1 = [u10;...;u0] = [a1;a0] * [b8;...;b0]
 
-                mul     t, a1, b0
-                adds    u1, u1, t
-                mul     t, a1, b1
-                adcs    u2, u2, t
-                mul     t, a1, b2
-                adcs    u3, u3, t
-                mul     t, a1, b3
-                adcs    u4, u4, t
-                mul     t, a1, b4
-                adcs    u5, u5, t
-                mul     t, a1, b5
-                adcs    u6, u6, t
-                mul     t, a1, b6
-                adcs    u7, u7, t
-                mul     t, a1, b7
-                adcs    u8, u8, t
-                mul     t, a1, b8
-                adcs    u9, u9, t
-                cset    u10, cs
+        mul     t, a1, b0
+        adds    u1, u1, t
+        mul     t, a1, b1
+        adcs    u2, u2, t
+        mul     t, a1, b2
+        adcs    u3, u3, t
+        mul     t, a1, b3
+        adcs    u4, u4, t
+        mul     t, a1, b4
+        adcs    u5, u5, t
+        mul     t, a1, b5
+        adcs    u6, u6, t
+        mul     t, a1, b6
+        adcs    u7, u7, t
+        mul     t, a1, b7
+        adcs    u8, u8, t
+        mul     t, a1, b8
+        adcs    u9, u9, t
+        cset    u10, cs
 
-                umulh   t, a1, b0
-                adds    u2, u2, t
-                umulh   t, a1, b1
-                adcs    u3, u3, t
-                umulh   t, a1, b2
-                adcs    u4, u4, t
-                umulh   t, a1, b3
-                adcs    u5, u5, t
-                umulh   t, a1, b4
-                adcs    u6, u6, t
-                umulh   t, a1, b5
-                adcs    u7, u7, t
-                umulh   t, a1, b6
-                adcs    u8, u8, t
-                umulh   t, a1, b7
-                adcs    u9, u9, t
-                umulh   t, a1, b8
-                adc     u10, u10, t
+        umulh   t, a1, b0
+        adds    u2, u2, t
+        umulh   t, a1, b1
+        adcs    u3, u3, t
+        umulh   t, a1, b2
+        adcs    u4, u4, t
+        umulh   t, a1, b3
+        adcs    u5, u5, t
+        umulh   t, a1, b4
+        adcs    u6, u6, t
+        umulh   t, a1, b5
+        adcs    u7, u7, t
+        umulh   t, a1, b6
+        adcs    u8, u8, t
+        umulh   t, a1, b7
+        adcs    u9, u9, t
+        umulh   t, a1, b8
+        adc     u10, u10, t
 
-                stp     u0, u1, [sp]
+        stp     u0, u1, [sp]
 
 // Row 2 = [u11;...;u0] = [a2;a1;a0] * [b8;...;b0]
 
-                ldp     a2, a3, [x, #16]
+        ldp     a2, a3, [x, #16]
 
-                mul     t, a2, b0
-                adds    u2, u2, t
-                mul     t, a2, b1
-                adcs    u3, u3, t
-                mul     t, a2, b2
-                adcs    u4, u4, t
-                mul     t, a2, b3
-                adcs    u5, u5, t
-                mul     t, a2, b4
-                adcs    u6, u6, t
-                mul     t, a2, b5
-                adcs    u7, u7, t
-                mul     t, a2, b6
-                adcs    u8, u8, t
-                mul     t, a2, b7
-                adcs    u9, u9, t
-                mul     t, a2, b8
-                adcs    u10, u10, t
-                cset    u11, cs
+        mul     t, a2, b0
+        adds    u2, u2, t
+        mul     t, a2, b1
+        adcs    u3, u3, t
+        mul     t, a2, b2
+        adcs    u4, u4, t
+        mul     t, a2, b3
+        adcs    u5, u5, t
+        mul     t, a2, b4
+        adcs    u6, u6, t
+        mul     t, a2, b5
+        adcs    u7, u7, t
+        mul     t, a2, b6
+        adcs    u8, u8, t
+        mul     t, a2, b7
+        adcs    u9, u9, t
+        mul     t, a2, b8
+        adcs    u10, u10, t
+        cset    u11, cs
 
-                umulh   t, a2, b0
-                adds    u3, u3, t
-                umulh   t, a2, b1
-                adcs    u4, u4, t
-                umulh   t, a2, b2
-                adcs    u5, u5, t
-                umulh   t, a2, b3
-                adcs    u6, u6, t
-                umulh   t, a2, b4
-                adcs    u7, u7, t
-                umulh   t, a2, b5
-                adcs    u8, u8, t
-                umulh   t, a2, b6
-                adcs    u9, u9, t
-                umulh   t, a2, b7
-                adcs    u10, u10, t
-                umulh   t, a2, b8
-                adc     u11, u11, t
+        umulh   t, a2, b0
+        adds    u3, u3, t
+        umulh   t, a2, b1
+        adcs    u4, u4, t
+        umulh   t, a2, b2
+        adcs    u5, u5, t
+        umulh   t, a2, b3
+        adcs    u6, u6, t
+        umulh   t, a2, b4
+        adcs    u7, u7, t
+        umulh   t, a2, b5
+        adcs    u8, u8, t
+        umulh   t, a2, b6
+        adcs    u9, u9, t
+        umulh   t, a2, b7
+        adcs    u10, u10, t
+        umulh   t, a2, b8
+        adc     u11, u11, t
 
 // Row 3 = [u12;...;u0] = [a3;a2;a1;a0] * [b8;...;b0]
 
-                mul     t, a3, b0
-                adds    u3, u3, t
-                mul     t, a3, b1
-                adcs    u4, u4, t
-                mul     t, a3, b2
-                adcs    u5, u5, t
-                mul     t, a3, b3
-                adcs    u6, u6, t
-                mul     t, a3, b4
-                adcs    u7, u7, t
-                mul     t, a3, b5
-                adcs    u8, u8, t
-                mul     t, a3, b6
-                adcs    u9, u9, t
-                mul     t, a3, b7
-                adcs    u10, u10, t
-                mul     t, a3, b8
-                adcs    u11, u11, t
-                cset    u12, cs
+        mul     t, a3, b0
+        adds    u3, u3, t
+        mul     t, a3, b1
+        adcs    u4, u4, t
+        mul     t, a3, b2
+        adcs    u5, u5, t
+        mul     t, a3, b3
+        adcs    u6, u6, t
+        mul     t, a3, b4
+        adcs    u7, u7, t
+        mul     t, a3, b5
+        adcs    u8, u8, t
+        mul     t, a3, b6
+        adcs    u9, u9, t
+        mul     t, a3, b7
+        adcs    u10, u10, t
+        mul     t, a3, b8
+        adcs    u11, u11, t
+        cset    u12, cs
 
-                umulh   t, a3, b0
-                adds    u4, u4, t
-                umulh   t, a3, b1
-                adcs    u5, u5, t
-                umulh   t, a3, b2
-                adcs    u6, u6, t
-                umulh   t, a3, b3
-                adcs    u7, u7, t
-                umulh   t, a3, b4
-                adcs    u8, u8, t
-                umulh   t, a3, b5
-                adcs    u9, u9, t
-                umulh   t, a3, b6
-                adcs    u10, u10, t
-                umulh   t, a3, b7
-                adcs    u11, u11, t
-                umulh   t, a3, b8
-                adc     u12, u12, t
+        umulh   t, a3, b0
+        adds    u4, u4, t
+        umulh   t, a3, b1
+        adcs    u5, u5, t
+        umulh   t, a3, b2
+        adcs    u6, u6, t
+        umulh   t, a3, b3
+        adcs    u7, u7, t
+        umulh   t, a3, b4
+        adcs    u8, u8, t
+        umulh   t, a3, b5
+        adcs    u9, u9, t
+        umulh   t, a3, b6
+        adcs    u10, u10, t
+        umulh   t, a3, b7
+        adcs    u11, u11, t
+        umulh   t, a3, b8
+        adc     u12, u12, t
 
-                stp     u2, u3, [sp, #16]
+        stp     u2, u3, [sp, #16]
 
 // Row 4 = [u13;...;u0] = [a4;a3;a2;a1;a0] * [b8;...;b0]
 
-                ldp     a4, a5, [x, #32]
+        ldp     a4, a5, [x, #32]
 
-                mul     t, a4, b0
-                adds    u4, u4, t
-                mul     t, a4, b1
-                adcs    u5, u5, t
-                mul     t, a4, b2
-                adcs    u6, u6, t
-                mul     t, a4, b3
-                adcs    u7, u7, t
-                mul     t, a4, b4
-                adcs    u8, u8, t
-                mul     t, a4, b5
-                adcs    u9, u9, t
-                mul     t, a4, b6
-                adcs    u10, u10, t
-                mul     t, a4, b7
-                adcs    u11, u11, t
-                mul     t, a4, b8
-                adcs    u12, u12, t
-                cset    u13, cs
+        mul     t, a4, b0
+        adds    u4, u4, t
+        mul     t, a4, b1
+        adcs    u5, u5, t
+        mul     t, a4, b2
+        adcs    u6, u6, t
+        mul     t, a4, b3
+        adcs    u7, u7, t
+        mul     t, a4, b4
+        adcs    u8, u8, t
+        mul     t, a4, b5
+        adcs    u9, u9, t
+        mul     t, a4, b6
+        adcs    u10, u10, t
+        mul     t, a4, b7
+        adcs    u11, u11, t
+        mul     t, a4, b8
+        adcs    u12, u12, t
+        cset    u13, cs
 
-                umulh   t, a4, b0
-                adds    u5, u5, t
-                umulh   t, a4, b1
-                adcs    u6, u6, t
-                umulh   t, a4, b2
-                adcs    u7, u7, t
-                umulh   t, a4, b3
-                adcs    u8, u8, t
-                umulh   t, a4, b4
-                adcs    u9, u9, t
-                umulh   t, a4, b5
-                adcs    u10, u10, t
-                umulh   t, a4, b6
-                adcs    u11, u11, t
-                umulh   t, a4, b7
-                adcs    u12, u12, t
-                umulh   t, a4, b8
-                adc     u13, u13, t
+        umulh   t, a4, b0
+        adds    u5, u5, t
+        umulh   t, a4, b1
+        adcs    u6, u6, t
+        umulh   t, a4, b2
+        adcs    u7, u7, t
+        umulh   t, a4, b3
+        adcs    u8, u8, t
+        umulh   t, a4, b4
+        adcs    u9, u9, t
+        umulh   t, a4, b5
+        adcs    u10, u10, t
+        umulh   t, a4, b6
+        adcs    u11, u11, t
+        umulh   t, a4, b7
+        adcs    u12, u12, t
+        umulh   t, a4, b8
+        adc     u13, u13, t
 
 // Row 5 = [u14;...;u0] = [a5;a4;a3;a2;a1;a0] * [b8;...;b0]
 
-                mul     t, a5, b0
-                adds    u5, u5, t
-                mul     t, a5, b1
-                adcs    u6, u6, t
-                mul     t, a5, b2
-                adcs    u7, u7, t
-                mul     t, a5, b3
-                adcs    u8, u8, t
-                mul     t, a5, b4
-                adcs    u9, u9, t
-                mul     t, a5, b5
-                adcs    u10, u10, t
-                mul     t, a5, b6
-                adcs    u11, u11, t
-                mul     t, a5, b7
-                adcs    u12, u12, t
-                mul     t, a5, b8
-                adcs    u13, u13, t
-                cset    u14, cs
+        mul     t, a5, b0
+        adds    u5, u5, t
+        mul     t, a5, b1
+        adcs    u6, u6, t
+        mul     t, a5, b2
+        adcs    u7, u7, t
+        mul     t, a5, b3
+        adcs    u8, u8, t
+        mul     t, a5, b4
+        adcs    u9, u9, t
+        mul     t, a5, b5
+        adcs    u10, u10, t
+        mul     t, a5, b6
+        adcs    u11, u11, t
+        mul     t, a5, b7
+        adcs    u12, u12, t
+        mul     t, a5, b8
+        adcs    u13, u13, t
+        cset    u14, cs
 
-                umulh   t, a5, b0
-                adds    u6, u6, t
-                umulh   t, a5, b1
-                adcs    u7, u7, t
-                umulh   t, a5, b2
-                adcs    u8, u8, t
-                umulh   t, a5, b3
-                adcs    u9, u9, t
-                umulh   t, a5, b4
-                adcs    u10, u10, t
-                umulh   t, a5, b5
-                adcs    u11, u11, t
-                umulh   t, a5, b6
-                adcs    u12, u12, t
-                umulh   t, a5, b7
-                adcs    u13, u13, t
-                umulh   t, a5, b8
-                adc     u14, u14, t
+        umulh   t, a5, b0
+        adds    u6, u6, t
+        umulh   t, a5, b1
+        adcs    u7, u7, t
+        umulh   t, a5, b2
+        adcs    u8, u8, t
+        umulh   t, a5, b3
+        adcs    u9, u9, t
+        umulh   t, a5, b4
+        adcs    u10, u10, t
+        umulh   t, a5, b5
+        adcs    u11, u11, t
+        umulh   t, a5, b6
+        adcs    u12, u12, t
+        umulh   t, a5, b7
+        adcs    u13, u13, t
+        umulh   t, a5, b8
+        adc     u14, u14, t
 
-                stp     u4, u5, [sp, #32]
+        stp     u4, u5, [sp, #32]
 
 // Row 6 = [u15;...;u0] = [a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
 
-                ldp     a6, a7, [x, #48]
+        ldp     a6, a7, [x, #48]
 
-                mul     t, a6, b0
-                adds    u6, u6, t
-                mul     t, a6, b1
-                adcs    u7, u7, t
-                mul     t, a6, b2
-                adcs    u8, u8, t
-                mul     t, a6, b3
-                adcs    u9, u9, t
-                mul     t, a6, b4
-                adcs    u10, u10, t
-                mul     t, a6, b5
-                adcs    u11, u11, t
-                mul     t, a6, b6
-                adcs    u12, u12, t
-                mul     t, a6, b7
-                adcs    u13, u13, t
-                mul     t, a6, b8
-                adcs    u14, u14, t
-                cset    u15, cs
+        mul     t, a6, b0
+        adds    u6, u6, t
+        mul     t, a6, b1
+        adcs    u7, u7, t
+        mul     t, a6, b2
+        adcs    u8, u8, t
+        mul     t, a6, b3
+        adcs    u9, u9, t
+        mul     t, a6, b4
+        adcs    u10, u10, t
+        mul     t, a6, b5
+        adcs    u11, u11, t
+        mul     t, a6, b6
+        adcs    u12, u12, t
+        mul     t, a6, b7
+        adcs    u13, u13, t
+        mul     t, a6, b8
+        adcs    u14, u14, t
+        cset    u15, cs
 
-                umulh   t, a6, b0
-                adds    u7, u7, t
-                umulh   t, a6, b1
-                adcs    u8, u8, t
-                umulh   t, a6, b2
-                adcs    u9, u9, t
-                umulh   t, a6, b3
-                adcs    u10, u10, t
-                umulh   t, a6, b4
-                adcs    u11, u11, t
-                umulh   t, a6, b5
-                adcs    u12, u12, t
-                umulh   t, a6, b6
-                adcs    u13, u13, t
-                umulh   t, a6, b7
-                adcs    u14, u14, t
-                umulh   t, a6, b8
-                adc     u15, u15, t
+        umulh   t, a6, b0
+        adds    u7, u7, t
+        umulh   t, a6, b1
+        adcs    u8, u8, t
+        umulh   t, a6, b2
+        adcs    u9, u9, t
+        umulh   t, a6, b3
+        adcs    u10, u10, t
+        umulh   t, a6, b4
+        adcs    u11, u11, t
+        umulh   t, a6, b5
+        adcs    u12, u12, t
+        umulh   t, a6, b6
+        adcs    u13, u13, t
+        umulh   t, a6, b7
+        adcs    u14, u14, t
+        umulh   t, a6, b8
+        adc     u15, u15, t
 
 // Row 7 = [u16;...;u0] = [a7;a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
 
-                mul     t, a7, b0
-                adds    u7, u7, t
-                mul     t, a7, b1
-                adcs    u8, u8, t
-                mul     t, a7, b2
-                adcs    u9, u9, t
-                mul     t, a7, b3
-                adcs    u10, u10, t
-                mul     t, a7, b4
-                adcs    u11, u11, t
-                mul     t, a7, b5
-                adcs    u12, u12, t
-                mul     t, a7, b6
-                adcs    u13, u13, t
-                mul     t, a7, b7
-                adcs    u14, u14, t
-                mul     t, a7, b8
-                adcs    u15, u15, t
-                cset    u16, cs
+        mul     t, a7, b0
+        adds    u7, u7, t
+        mul     t, a7, b1
+        adcs    u8, u8, t
+        mul     t, a7, b2
+        adcs    u9, u9, t
+        mul     t, a7, b3
+        adcs    u10, u10, t
+        mul     t, a7, b4
+        adcs    u11, u11, t
+        mul     t, a7, b5
+        adcs    u12, u12, t
+        mul     t, a7, b6
+        adcs    u13, u13, t
+        mul     t, a7, b7
+        adcs    u14, u14, t
+        mul     t, a7, b8
+        adcs    u15, u15, t
+        cset    u16, cs
 
-                umulh   t, a7, b0
-                adds    u8, u8, t
-                umulh   t, a7, b1
-                adcs    u9, u9, t
-                umulh   t, a7, b2
-                adcs    u10, u10, t
-                umulh   t, a7, b3
-                adcs    u11, u11, t
-                umulh   t, a7, b4
-                adcs    u12, u12, t
-                umulh   t, a7, b5
-                adcs    u13, u13, t
-                umulh   t, a7, b6
-                adcs    u14, u14, t
-                umulh   t, a7, b7
-                adcs    u15, u15, t
-                umulh   t, a7, b8
-                adc     u16, u16, t
+        umulh   t, a7, b0
+        adds    u8, u8, t
+        umulh   t, a7, b1
+        adcs    u9, u9, t
+        umulh   t, a7, b2
+        adcs    u10, u10, t
+        umulh   t, a7, b3
+        adcs    u11, u11, t
+        umulh   t, a7, b4
+        adcs    u12, u12, t
+        umulh   t, a7, b5
+        adcs    u13, u13, t
+        umulh   t, a7, b6
+        adcs    u14, u14, t
+        umulh   t, a7, b7
+        adcs    u15, u15, t
+        umulh   t, a7, b8
+        adc     u16, u16, t
 
-                stp     u6, u7, [sp, #48]
+        stp     u6, u7, [sp, #48]
 
 // Row 8 = [u16;...;u0] = [a8;a7;a6;a5;a4;a3;a2;a1;a0] * [b8;...;b0]
 
-                ldr     a8, [x, #64]
+        ldr     a8, [x, #64]
 
-                mul     t, a8, b0
-                adds    u8, u8, t
-                mul     t, a8, b1
-                adcs    u9, u9, t
-                mul     t, a8, b2
-                adcs    u10, u10, t
-                mul     t, a8, b3
-                adcs    u11, u11, t
-                mul     t, a8, b4
-                adcs    u12, u12, t
-                mul     t, a8, b5
-                adcs    u13, u13, t
-                mul     t, a8, b6
-                adcs    u14, u14, t
-                mul     t, a8, b7
-                adcs    u15, u15, t
-                mul     t, a8, b8
-                adc     u16, u16, t
+        mul     t, a8, b0
+        adds    u8, u8, t
+        mul     t, a8, b1
+        adcs    u9, u9, t
+        mul     t, a8, b2
+        adcs    u10, u10, t
+        mul     t, a8, b3
+        adcs    u11, u11, t
+        mul     t, a8, b4
+        adcs    u12, u12, t
+        mul     t, a8, b5
+        adcs    u13, u13, t
+        mul     t, a8, b6
+        adcs    u14, u14, t
+        mul     t, a8, b7
+        adcs    u15, u15, t
+        mul     t, a8, b8
+        adc     u16, u16, t
 
-                umulh   t, a8, b0
-                adds    u9, u9, t
-                umulh   t, a8, b1
-                adcs    u10, u10, t
-                umulh   t, a8, b2
-                adcs    u11, u11, t
-                umulh   t, a8, b3
-                adcs    u12, u12, t
-                umulh   t, a8, b4
-                adcs    u13, u13, t
-                umulh   t, a8, b5
-                adcs    u14, u14, t
-                umulh   t, a8, b6
-                adcs    u15, u15, t
-                umulh   t, a8, b7
-                adc     u16, u16, t
+        umulh   t, a8, b0
+        adds    u9, u9, t
+        umulh   t, a8, b1
+        adcs    u10, u10, t
+        umulh   t, a8, b2
+        adcs    u11, u11, t
+        umulh   t, a8, b3
+        adcs    u12, u12, t
+        umulh   t, a8, b4
+        adcs    u13, u13, t
+        umulh   t, a8, b5
+        adcs    u14, u14, t
+        umulh   t, a8, b6
+        adcs    u15, u15, t
+        umulh   t, a8, b7
+        adc     u16, u16, t
 
 // Now we have the full product, which we consider as
 // 2^521 * h + l. Form h + l + 1
 
-                subs    xzr, xzr, xzr
-                ldp     b0, b1, [sp]
-                extr    t, u9, u8, #9
-                adcs    b0, b0, t
-                extr    t, u10, u9, #9
-                adcs    b1, b1, t
-                ldp     b2, b3, [sp, #16]
-                extr    t, u11, u10, #9
-                adcs    b2, b2, t
-                extr    t, u12, u11, #9
-                adcs    b3, b3, t
-                ldp     b4, b5, [sp, #32]
-                extr    t, u13, u12, #9
-                adcs    b4, b4, t
-                extr    t, u14, u13, #9
-                adcs    b5, b5, t
-                ldp     b6, b7, [sp, #48]
-                extr    t, u15, u14, #9
-                adcs    b6, b6, t
-                extr    t, u16, u15, #9
-                adcs    b7, b7, t
-                orr     b8, u8, #~0x1FF
-                lsr     t, u16, #9
-                adcs    b8, b8, t
+        subs    xzr, xzr, xzr
+        ldp     b0, b1, [sp]
+        extr    t, u9, u8, #9
+        adcs    b0, b0, t
+        extr    t, u10, u9, #9
+        adcs    b1, b1, t
+        ldp     b2, b3, [sp, #16]
+        extr    t, u11, u10, #9
+        adcs    b2, b2, t
+        extr    t, u12, u11, #9
+        adcs    b3, b3, t
+        ldp     b4, b5, [sp, #32]
+        extr    t, u13, u12, #9
+        adcs    b4, b4, t
+        extr    t, u14, u13, #9
+        adcs    b5, b5, t
+        ldp     b6, b7, [sp, #48]
+        extr    t, u15, u14, #9
+        adcs    b6, b6, t
+        extr    t, u16, u15, #9
+        adcs    b7, b7, t
+        orr     b8, u8, #~0x1FF
+        lsr     t, u16, #9
+        adcs    b8, b8, t
 
 // Now CF is set if h + l + 1 >= 2^521, which means it's already
 // the answer, while if ~CF the answer is h + l so we should subtract
 // 1 (all considered in 521 bits). Hence subtract ~CF and mask.
 
-                sbcs    b0, b0, xzr
-                sbcs    b1, b1, xzr
-                sbcs    b2, b2, xzr
-                sbcs    b3, b3, xzr
-                sbcs    b4, b4, xzr
-                sbcs    b5, b5, xzr
-                sbcs    b6, b6, xzr
-                sbcs    b7, b7, xzr
-                sbc     b8, b8, xzr
-                and     b8, b8, #0x1FF
+        sbcs    b0, b0, xzr
+        sbcs    b1, b1, xzr
+        sbcs    b2, b2, xzr
+        sbcs    b3, b3, xzr
+        sbcs    b4, b4, xzr
+        sbcs    b5, b5, xzr
+        sbcs    b6, b6, xzr
+        sbcs    b7, b7, xzr
+        sbc     b8, b8, xzr
+        and     b8, b8, #0x1FF
 
 // Store back digits of final result
 
-                stp     b0, b1, [z]
-                stp     b2, b3, [z, #16]
-                stp     b4, b5, [z, #32]
-                stp     b6, b7, [z, #48]
-                str     b8, [z, #64]
+        stp     b0, b1, [z]
+        stp     b2, b3, [z, #16]
+        stp     b4, b5, [z, #32]
+        stp     b6, b7, [z, #48]
+        str     b8, [z, #64]
 
 // Restore registers
 
-                add     sp, sp, #64
-                ldp     x25, x26, [sp], #16
-                ldp     x23, x24, [sp], #16
-                ldp     x21, x22, [sp], #16
-                ldp     x19, x20, [sp], #16
+        add     sp, sp, #64
+        ldp     x25, x26, [sp], #16
+        ldp     x23, x24, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_mul_p521_alt
-        .globl  _bignum_mul_p521_alt
+        .globl bignum_mul_p521_alt
+        .private_extern bignum_mul_p521_alt
+
+        .globl _bignum_mul_p521_alt
+        .private_extern _bignum_mul_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mul_p521_alt
-        .private_extern bignum_mul_p521_alt
+        S2N_ASM_HIDDEN(bignum_mul_p521_alt)
 
         .globl _bignum_mul_p521_alt
-        .private_extern _bignum_mul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_mul_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
@@ -21,14 +21,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_neg_p521
-        S2N_ASM_HIDDEN(bignum_neg_p521)
-
-        .globl _bignum_neg_p521
-        S2N_ASM_HIDDEN(_bignum_neg_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p521)
         .text
         .balign 4
 
@@ -47,53 +43,52 @@
 #define d7 x10
 #define d8 x11
 
-bignum_neg_p521:
-_bignum_neg_p521:
+S2N_BN_SYMBOL(bignum_neg_p521):
 
 // Load the 9 digits of x and generate p = the OR of them all
 
-                ldp     d0, d1, [x]
-                orr     d6, d0, d1
-                ldp     d2, d3, [x, #16]
-                orr     d7, d2, d3
-                orr     p, d6, d7
-                ldp     d4, d5, [x, #32]
-                orr     d8, d4, d5
-                orr     p, p, d8
-                ldp     d6, d7, [x, #48]
-                orr     d8, d6, d7
-                orr     p, p, d8
-                ldr     d8, [x, #64]
-                orr     p, p, d8
+        ldp     d0, d1, [x]
+        orr     d6, d0, d1
+        ldp     d2, d3, [x, #16]
+        orr     d7, d2, d3
+        orr     p, d6, d7
+        ldp     d4, d5, [x, #32]
+        orr     d8, d4, d5
+        orr     p, p, d8
+        ldp     d6, d7, [x, #48]
+        orr     d8, d6, d7
+        orr     p, p, d8
+        ldr     d8, [x, #64]
+        orr     p, p, d8
 
 // Turn p into a bitmask for "input is nonzero", so that we avoid doing
 // -0 = p_521 and hence maintain strict modular reduction
 
-                cmp     p, #0
-                csetm   p, ne
+        cmp     p, #0
+        csetm   p, ne
 
 // Since p_521 is all 1s, the subtraction is just an exclusive-or with p
 // to give an optional inversion, with a slight fiddle for the top digit.
 
-                eor     d0, d0, p
-                eor     d1, d1, p
-                eor     d2, d2, p
-                eor     d3, d3, p
-                eor     d4, d4, p
-                eor     d5, d5, p
-                eor     d6, d6, p
-                eor     d7, d7, p
-                and     p, p, #0x1FF
-                eor     d8, d8, p
+        eor     d0, d0, p
+        eor     d1, d1, p
+        eor     d2, d2, p
+        eor     d3, d3, p
+        eor     d4, d4, p
+        eor     d5, d5, p
+        eor     d6, d6, p
+        eor     d7, d7, p
+        and     p, p, #0x1FF
+        eor     d8, d8, p
 
 // Write back the result and return
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
-                ret
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
@@ -21,12 +21,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_neg_p521
-        .private_extern bignum_neg_p521
+        S2N_ASM_HIDDEN(bignum_neg_p521)
 
         .globl _bignum_neg_p521
-        .private_extern _bignum_neg_p521
+        S2N_ASM_HIDDEN(_bignum_neg_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
@@ -22,8 +22,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_neg_p521
-        .globl  _bignum_neg_p521
+        .globl bignum_neg_p521
+        .private_extern bignum_neg_p521
+
+        .globl _bignum_neg_p521
+        .private_extern _bignum_neg_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
@@ -23,12 +23,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_optneg_p521
-        .private_extern bignum_optneg_p521
+        S2N_ASM_HIDDEN(bignum_optneg_p521)
 
         .globl _bignum_optneg_p521
-        .private_extern _bignum_optneg_p521
+        S2N_ASM_HIDDEN(_bignum_optneg_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
@@ -24,8 +24,12 @@
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_optneg_p521
-        .globl  _bignum_optneg_p521
+        .globl bignum_optneg_p521
+        .private_extern bignum_optneg_p521
+
+        .globl _bignum_optneg_p521
+        .private_extern _bignum_optneg_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
@@ -23,14 +23,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_optneg_p521
-        S2N_ASM_HIDDEN(bignum_optneg_p521)
-
-        .globl _bignum_optneg_p521
-        S2N_ASM_HIDDEN(_bignum_optneg_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p521)
         .text
         .balign 4
 
@@ -49,55 +45,54 @@
 #define d7 x11
 #define d8 x12
 
-bignum_optneg_p521:
-_bignum_optneg_p521:
+S2N_BN_SYMBOL(bignum_optneg_p521):
 
 // Load the 9 digits of x and generate q = the OR of them all
 
-                ldp     d0, d1, [x]
-                orr     d6, d0, d1
-                ldp     d2, d3, [x, #16]
-                orr     d7, d2, d3
-                orr     q, d6, d7
-                ldp     d4, d5, [x, #32]
-                orr     d8, d4, d5
-                orr     q, q, d8
-                ldp     d6, d7, [x, #48]
-                orr     d8, d6, d7
-                orr     q, q, d8
-                ldr     d8, [x, #64]
-                orr     q, q, d8
+        ldp     d0, d1, [x]
+        orr     d6, d0, d1
+        ldp     d2, d3, [x, #16]
+        orr     d7, d2, d3
+        orr     q, d6, d7
+        ldp     d4, d5, [x, #32]
+        orr     d8, d4, d5
+        orr     q, q, d8
+        ldp     d6, d7, [x, #48]
+        orr     d8, d6, d7
+        orr     q, q, d8
+        ldr     d8, [x, #64]
+        orr     q, q, d8
 
 // Turn q into a bitmask for "input is nonzero and p is nonzero", so that
 // we avoid doing -0 = p_521 and hence maintain strict modular reduction
 
-                cmp     q, #0
-                csetm   q, ne
-                cmp     p, #0
-                csel    q, xzr, q, eq
+        cmp     q, #0
+        csetm   q, ne
+        cmp     p, #0
+        csel    q, xzr, q, eq
 
 // Since p_521 is all 1s, the subtraction is just an exclusive-or with q
 // to give an optional inversion, with a slight fiddle for the top digit.
 
-                eor     d0, d0, q
-                eor     d1, d1, q
-                eor     d2, d2, q
-                eor     d3, d3, q
-                eor     d4, d4, q
-                eor     d5, d5, q
-                eor     d6, d6, q
-                eor     d7, d7, q
-                and     q, q, #0x1FF
-                eor     d8, d8, q
+        eor     d0, d0, q
+        eor     d1, d1, q
+        eor     d2, d2, q
+        eor     d3, d3, q
+        eor     d4, d4, q
+        eor     d5, d5, q
+        eor     d6, d6, q
+        eor     d7, d7, q
+        and     q, q, #0x1FF
+        eor     d8, d8, q
 
 // Write back the result and return
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
-                ret
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
@@ -21,14 +21,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_sqr_p521
-        S2N_ASM_HIDDEN(bignum_sqr_p521)
-
-        .globl _bignum_sqr_p521
-        S2N_ASM_HIDDEN(_bignum_sqr_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p521)
         .text
         .balign 4
 
@@ -72,87 +68,86 @@
 #define d7 x9
 #define d8 x10
 
-bignum_sqr_p521:
-_bignum_sqr_p521:
+S2N_BN_SYMBOL(bignum_sqr_p521):
 
 // Save registers
 
-                stp     x19, x20, [sp, #-16]!
-                stp     x21, x22, [sp, #-16]!
-                stp     x23, x24, [sp, #-16]!
+        stp     x19, x20, [sp, #-16]!
+        stp     x21, x22, [sp, #-16]!
+        stp     x23, x24, [sp, #-16]!
 
 // Load all the inputs first
 
-                ldp     a0, a1, [x]
-                ldp     a2, a3, [x, #16]
-                ldp     b0, b1, [x, #32]
-                ldp     b2, b3, [x, #48]
+        ldp     a0, a1, [x]
+        ldp     a2, a3, [x, #16]
+        ldp     b0, b1, [x, #32]
+        ldp     b2, b3, [x, #48]
 
 // Square the upper half with a register-renamed variant of bignum_sqr_4_8
 
-                mul     s2, b0, b2
-                mul     s7, b1, b3
-                umulh   t, b0, b2
-                subs    u, b0, b1
-                cneg    u, u, cc
-                csetm   s1, cc
-                subs    s0, b3, b2
-                cneg    s0, s0, cc
-                mul     s6, u, s0
-                umulh   s0, u, s0
-                cinv    s1, s1, cc
-                eor     s6, s6, s1
-                eor     s0, s0, s1
-                adds    s3, s2, t
-                adc     t, t, xzr
-                umulh   u, b1, b3
-                adds    s3, s3, s7
-                adcs    t, t, u
-                adc     u, u, xzr
-                adds    t, t, s7
-                adc     u, u, xzr
-                cmn     s1, #0x1
-                adcs    s3, s3, s6
-                adcs    t, t, s0
-                adc     u, u, s1
-                adds    s2, s2, s2
-                adcs    s3, s3, s3
-                adcs    t, t, t
-                adcs    u, u, u
-                adc     c, xzr, xzr
-                mul     s0, b0, b0
-                mul     s6, b1, b1
-                mul     l, b0, b1
-                umulh   s1, b0, b0
-                umulh   s7, b1, b1
-                umulh   h, b0, b1
-                adds    s1, s1, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s1, s1, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s2, s2, s6
-                adcs    s3, s3, s7
-                adcs    t, t, xzr
-                adcs    u, u, xzr
-                adc     c, c, xzr
-                mul     s4, b2, b2
-                mul     s6, b3, b3
-                mul     l, b2, b3
-                umulh   s5, b2, b2
-                umulh   s7, b3, b3
-                umulh   h, b2, b3
-                adds    s5, s5, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s5, s5, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s4, s4, t
-                adcs    s5, s5, u
-                adcs    s6, s6, c
-                adc     s7, s7, xzr
+        mul     s2, b0, b2
+        mul     s7, b1, b3
+        umulh   t, b0, b2
+        subs    u, b0, b1
+        cneg    u, u, cc
+        csetm   s1, cc
+        subs    s0, b3, b2
+        cneg    s0, s0, cc
+        mul     s6, u, s0
+        umulh   s0, u, s0
+        cinv    s1, s1, cc
+        eor     s6, s6, s1
+        eor     s0, s0, s1
+        adds    s3, s2, t
+        adc     t, t, xzr
+        umulh   u, b1, b3
+        adds    s3, s3, s7
+        adcs    t, t, u
+        adc     u, u, xzr
+        adds    t, t, s7
+        adc     u, u, xzr
+        cmn     s1, #0x1
+        adcs    s3, s3, s6
+        adcs    t, t, s0
+        adc     u, u, s1
+        adds    s2, s2, s2
+        adcs    s3, s3, s3
+        adcs    t, t, t
+        adcs    u, u, u
+        adc     c, xzr, xzr
+        mul     s0, b0, b0
+        mul     s6, b1, b1
+        mul     l, b0, b1
+        umulh   s1, b0, b0
+        umulh   s7, b1, b1
+        umulh   h, b0, b1
+        adds    s1, s1, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s1, s1, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s2, s2, s6
+        adcs    s3, s3, s7
+        adcs    t, t, xzr
+        adcs    u, u, xzr
+        adc     c, c, xzr
+        mul     s4, b2, b2
+        mul     s6, b3, b3
+        mul     l, b2, b3
+        umulh   s5, b2, b2
+        umulh   s7, b3, b3
+        umulh   h, b2, b3
+        adds    s5, s5, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s5, s5, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s4, s4, t
+        adcs    s5, s5, u
+        adcs    s6, s6, c
+        adc     s7, s7, xzr
 
 // Augment the high part with the contribution from the top little word C.
 // If we write the input as 2^512 * C + x then we are otherwise just doing
@@ -167,364 +162,364 @@ _bignum_sqr_p521:
 // equally well use 53 or 54 since they are still <= 64 - 10, but below
 // 52 we would end up using more multiplications.
 
-                ldr     c, [x, #64]
-                add     u, c, c
-                mul     c, c, c
+        ldr     c, [x, #64]
+        add     u, c, c
+        mul     c, c, c
 
 // 0 * 52 = 64 * 0 + 0
 
-                and     l, a0, #0x000fffffffffffff
-                mul     l, u, l
+        and     l, a0, #0x000fffffffffffff
+        mul     l, u, l
 
 // 1 * 52 = 64 * 0 + 52
 
-                extr    h, a1, a0, #52
-                and     h, h, #0x000fffffffffffff
-                mul     h, u, h
-                lsr     t, l, #52
-                add     h, h, t
+        extr    h, a1, a0, #52
+        and     h, h, #0x000fffffffffffff
+        mul     h, u, h
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #12
-                adds    s0, s0, t
+        lsl     l, l, #12
+        extr    t, h, l, #12
+        adds    s0, s0, t
 
 // 2 * 52 = 64 * 1 + 40
 
-                extr    l, a2, a1, #40
-                and     l, l, #0x000fffffffffffff
-                mul     l, u, l
-                lsr     t, h, #52
-                add     l, l, t
+        extr    l, a2, a1, #40
+        and     l, l, #0x000fffffffffffff
+        mul     l, u, l
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #24
-                adcs    s1, s1, t
+        lsl     h, h, #12
+        extr    t, l, h, #24
+        adcs    s1, s1, t
 
 // 3 * 52 = 64 * 2 + 28
 
-                extr    h, a3, a2, #28
-                and     h, h, #0x000fffffffffffff
-                mul     h, u, h
-                lsr     t, l, #52
-                add     h, h, t
+        extr    h, a3, a2, #28
+        and     h, h, #0x000fffffffffffff
+        mul     h, u, h
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #36
-                adcs    s2, s2, t
+        lsl     l, l, #12
+        extr    t, h, l, #36
+        adcs    s2, s2, t
 
 // 4 * 52 = 64 * 3 + 16
 
-                extr    l, b0, a3, #16
-                and     l, l, #0x000fffffffffffff
-                mul     l, u, l
-                lsr     t, h, #52
-                add     l, l, t
+        extr    l, b0, a3, #16
+        and     l, l, #0x000fffffffffffff
+        mul     l, u, l
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #48
-                adcs    s3, s3, t
+        lsl     h, h, #12
+        extr    t, l, h, #48
+        adcs    s3, s3, t
 
 // 5 * 52 = 64 * 4 + 4
 
-                lsr     h, b0, #4
-                and     h, h, #0x000fffffffffffff
-                mul     h, u, h
-                lsr     t, l, #52
-                add     h, h, t
+        lsr     h, b0, #4
+        and     h, h, #0x000fffffffffffff
+        mul     h, u, h
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    v, h, l, #60
+        lsl     l, l, #12
+        extr    v, h, l, #60
 
 // 6 * 52 = 64 * 4 + 56
 
-                extr    l, b1, b0, #56
-                and     l, l, #0x000fffffffffffff
-                mul     l, u, l
-                lsr     t, h, #52
-                add     l, l, t
+        extr    l, b1, b0, #56
+        and     l, l, #0x000fffffffffffff
+        mul     l, u, l
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     v, v, #8
-                extr    t, l, v, #8
-                adcs    s4, s4, t
+        lsl     v, v, #8
+        extr    t, l, v, #8
+        adcs    s4, s4, t
 
 // 7 * 52 = 64 * 5 + 44
 
-                extr    h, b2, b1, #44
-                and     h, h, #0x000fffffffffffff
-                mul     h, u, h
-                lsr     t, l, #52
-                add     h, h, t
+        extr    h, b2, b1, #44
+        and     h, h, #0x000fffffffffffff
+        mul     h, u, h
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #20
-                adcs    s5, s5, t
+        lsl     l, l, #12
+        extr    t, h, l, #20
+        adcs    s5, s5, t
 
 // 8 * 52 = 64 * 6 + 32
 
-                extr    l, b3, b2, #32
-                and     l, l, #0x000fffffffffffff
-                mul     l, u, l
-                lsr     t, h, #52
-                add     l, l, t
+        extr    l, b3, b2, #32
+        and     l, l, #0x000fffffffffffff
+        mul     l, u, l
+        lsr     t, h, #52
+        add     l, l, t
 
-                lsl     h, h, #12
-                extr    t, l, h, #32
-                adcs    s6, s6, t
+        lsl     h, h, #12
+        extr    t, l, h, #32
+        adcs    s6, s6, t
 
 // 9 * 52 = 64 * 7 + 20
 
-                lsr     h, b3, #20
-                mul     h, u, h
-                lsr     t, l, #52
-                add     h, h, t
+        lsr     h, b3, #20
+        mul     h, u, h
+        lsr     t, l, #52
+        add     h, h, t
 
-                lsl     l, l, #12
-                extr    t, h, l, #44
-                adcs    s7, s7, t
+        lsl     l, l, #12
+        extr    t, h, l, #44
+        adcs    s7, s7, t
 
 // Top word
 
-                lsr     h, h, #44
-                adc     c, c, h
+        lsr     h, h, #44
+        adc     c, c, h
 
 // Rotate [c;s7;...;s0] before storing in the buffer.
 // We want to add 2^512 * H', which splitting H' at bit 9 is
 // 2^521 * H_top + 2^512 * H_bot == 2^512 * H_bot + H_top (mod p_521)
 
-                extr    l, s1, s0, #9
-                extr    h, s2, s1, #9
-                stp     l, h, [z]
+        extr    l, s1, s0, #9
+        extr    h, s2, s1, #9
+        stp     l, h, [z]
 
-                extr    l, s3, s2, #9
-                extr    h, s4, s3, #9
-                stp     l, h, [z, #16]
+        extr    l, s3, s2, #9
+        extr    h, s4, s3, #9
+        stp     l, h, [z, #16]
 
-                extr    l, s5, s4, #9
-                extr    h, s6, s5, #9
-                stp     l, h, [z, #32]
+        extr    l, s5, s4, #9
+        extr    h, s6, s5, #9
+        stp     l, h, [z, #32]
 
-                extr    l, s7, s6, #9
-                extr    h, c, s7, #9
-                stp     l, h, [z, #48]
+        extr    l, s7, s6, #9
+        extr    h, c, s7, #9
+        stp     l, h, [z, #48]
 
-                and     t, s0, #0x1FF
-                lsr     c, c, #9
-                add     t, t, c
-                str     t, [z, #64]
+        and     t, s0, #0x1FF
+        lsr     c, c, #9
+        add     t, t, c
+        str     t, [z, #64]
 
 // Square the lower half with an analogous variant of bignum_sqr_4_8
 
-                mul     s2, a0, a2
-                mul     s7, a1, a3
-                umulh   t, a0, a2
-                subs    u, a0, a1
-                cneg    u, u, cc
-                csetm   s1, cc
-                subs    s0, a3, a2
-                cneg    s0, s0, cc
-                mul     s6, u, s0
-                umulh   s0, u, s0
-                cinv    s1, s1, cc
-                eor     s6, s6, s1
-                eor     s0, s0, s1
-                adds    s3, s2, t
-                adc     t, t, xzr
-                umulh   u, a1, a3
-                adds    s3, s3, s7
-                adcs    t, t, u
-                adc     u, u, xzr
-                adds    t, t, s7
-                adc     u, u, xzr
-                cmn     s1, #0x1
-                adcs    s3, s3, s6
-                adcs    t, t, s0
-                adc     u, u, s1
-                adds    s2, s2, s2
-                adcs    s3, s3, s3
-                adcs    t, t, t
-                adcs    u, u, u
-                adc     c, xzr, xzr
-                mul     s0, a0, a0
-                mul     s6, a1, a1
-                mul     l, a0, a1
-                umulh   s1, a0, a0
-                umulh   s7, a1, a1
-                umulh   h, a0, a1
-                adds    s1, s1, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s1, s1, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s2, s2, s6
-                adcs    s3, s3, s7
-                adcs    t, t, xzr
-                adcs    u, u, xzr
-                adc     c, c, xzr
-                mul     s4, a2, a2
-                mul     s6, a3, a3
-                mul     l, a2, a3
-                umulh   s5, a2, a2
-                umulh   s7, a3, a3
-                umulh   h, a2, a3
-                adds    s5, s5, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s5, s5, l
-                adcs    s6, s6, h
-                adc     s7, s7, xzr
-                adds    s4, s4, t
-                adcs    s5, s5, u
-                adcs    s6, s6, c
-                adc     s7, s7, xzr
+        mul     s2, a0, a2
+        mul     s7, a1, a3
+        umulh   t, a0, a2
+        subs    u, a0, a1
+        cneg    u, u, cc
+        csetm   s1, cc
+        subs    s0, a3, a2
+        cneg    s0, s0, cc
+        mul     s6, u, s0
+        umulh   s0, u, s0
+        cinv    s1, s1, cc
+        eor     s6, s6, s1
+        eor     s0, s0, s1
+        adds    s3, s2, t
+        adc     t, t, xzr
+        umulh   u, a1, a3
+        adds    s3, s3, s7
+        adcs    t, t, u
+        adc     u, u, xzr
+        adds    t, t, s7
+        adc     u, u, xzr
+        cmn     s1, #0x1
+        adcs    s3, s3, s6
+        adcs    t, t, s0
+        adc     u, u, s1
+        adds    s2, s2, s2
+        adcs    s3, s3, s3
+        adcs    t, t, t
+        adcs    u, u, u
+        adc     c, xzr, xzr
+        mul     s0, a0, a0
+        mul     s6, a1, a1
+        mul     l, a0, a1
+        umulh   s1, a0, a0
+        umulh   s7, a1, a1
+        umulh   h, a0, a1
+        adds    s1, s1, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s1, s1, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s2, s2, s6
+        adcs    s3, s3, s7
+        adcs    t, t, xzr
+        adcs    u, u, xzr
+        adc     c, c, xzr
+        mul     s4, a2, a2
+        mul     s6, a3, a3
+        mul     l, a2, a3
+        umulh   s5, a2, a2
+        umulh   s7, a3, a3
+        umulh   h, a2, a3
+        adds    s5, s5, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s5, s5, l
+        adcs    s6, s6, h
+        adc     s7, s7, xzr
+        adds    s4, s4, t
+        adcs    s5, s5, u
+        adcs    s6, s6, c
+        adc     s7, s7, xzr
 
 // Add it directly to the existing buffer
 
-                ldp     l, h, [z]
-                adds    l, l, s0
-                adcs    h, h, s1
-                stp     l, h, [z]
+        ldp     l, h, [z]
+        adds    l, l, s0
+        adcs    h, h, s1
+        stp     l, h, [z]
 
-                ldp     l, h, [z, #16]
-                adcs    l, l, s2
-                adcs    h, h, s3
-                stp     l, h, [z, #16]
+        ldp     l, h, [z, #16]
+        adcs    l, l, s2
+        adcs    h, h, s3
+        stp     l, h, [z, #16]
 
-                ldp     l, h, [z, #32]
-                adcs    l, l, s4
-                adcs    h, h, s5
-                stp     l, h, [z, #32]
+        ldp     l, h, [z, #32]
+        adcs    l, l, s4
+        adcs    h, h, s5
+        stp     l, h, [z, #32]
 
-                ldp     l, h, [z, #48]
-                adcs    l, l, s6
-                adcs    h, h, s7
-                stp     l, h, [z, #48]
+        ldp     l, h, [z, #48]
+        adcs    l, l, s6
+        adcs    h, h, s7
+        stp     l, h, [z, #48]
 
-                ldr     t, [z, #64]
-                adc     t, t, xzr
-                str     t, [z, #64]
+        ldr     t, [z, #64]
+        adc     t, t, xzr
+        str     t, [z, #64]
 
 // Now get the cross-product in [s7,...,s0] with variant of bignum_mul_4_8
 
-                mul     s0, a0, b0
-                mul     s4, a1, b1
-                mul     s5, a2, b2
-                mul     s6, a3, b3
-                umulh   s7, a0, b0
-                adds    s4, s4, s7
-                umulh   s7, a1, b1
-                adcs    s5, s5, s7
-                umulh   s7, a2, b2
-                adcs    s6, s6, s7
-                umulh   s7, a3, b3
-                adc     s7, s7, xzr
-                adds    s1, s4, s0
-                adcs    s4, s5, s4
-                adcs    s5, s6, s5
-                adcs    s6, s7, s6
-                adc     s7, xzr, s7
-                adds    s2, s4, s0
-                adcs    s3, s5, s1
-                adcs    s4, s6, s4
-                adcs    s5, s7, s5
-                adcs    s6, xzr, s6
-                adc     s7, xzr, s7
-                subs    t, a2, a3
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b3, b2
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s5, s5, l
-                eor     h, h, c
-                adcs    s6, s6, h
-                adc     s7, s7, c
-                subs    t, a0, a1
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b1, b0
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s1, s1, l
-                eor     h, h, c
-                adcs    s2, s2, h
-                adcs    s3, s3, c
-                adcs    s4, s4, c
-                adcs    s5, s5, c
-                adcs    s6, s6, c
-                adc     s7, s7, c
-                subs    t, a1, a3
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b3, b1
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s4, s4, l
-                eor     h, h, c
-                adcs    s5, s5, h
-                adcs    s6, s6, c
-                adc     s7, s7, c
-                subs    t, a0, a2
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b2, b0
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s2, s2, l
-                eor     h, h, c
-                adcs    s3, s3, h
-                adcs    s4, s4, c
-                adcs    s5, s5, c
-                adcs    s6, s6, c
-                adc     s7, s7, c
-                subs    t, a0, a3
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b3, b0
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s3, s3, l
-                eor     h, h, c
-                adcs    s4, s4, h
-                adcs    s5, s5, c
-                adcs    s6, s6, c
-                adc     s7, s7, c
-                subs    t, a1, a2
-                cneg    t, t, cc
-                csetm   c, cc
-                subs    h, b2, b1
-                cneg    h, h, cc
-                mul     l, t, h
-                umulh   h, t, h
-                cinv    c, c, cc
-                cmn     c, #0x1
-                eor     l, l, c
-                adcs    s3, s3, l
-                eor     h, h, c
-                adcs    s4, s4, h
-                adcs    s5, s5, c
-                adcs    s6, s6, c
-                adc     s7, s7, c
+        mul     s0, a0, b0
+        mul     s4, a1, b1
+        mul     s5, a2, b2
+        mul     s6, a3, b3
+        umulh   s7, a0, b0
+        adds    s4, s4, s7
+        umulh   s7, a1, b1
+        adcs    s5, s5, s7
+        umulh   s7, a2, b2
+        adcs    s6, s6, s7
+        umulh   s7, a3, b3
+        adc     s7, s7, xzr
+        adds    s1, s4, s0
+        adcs    s4, s5, s4
+        adcs    s5, s6, s5
+        adcs    s6, s7, s6
+        adc     s7, xzr, s7
+        adds    s2, s4, s0
+        adcs    s3, s5, s1
+        adcs    s4, s6, s4
+        adcs    s5, s7, s5
+        adcs    s6, xzr, s6
+        adc     s7, xzr, s7
+        subs    t, a2, a3
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b3, b2
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s5, s5, l
+        eor     h, h, c
+        adcs    s6, s6, h
+        adc     s7, s7, c
+        subs    t, a0, a1
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b1, b0
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s1, s1, l
+        eor     h, h, c
+        adcs    s2, s2, h
+        adcs    s3, s3, c
+        adcs    s4, s4, c
+        adcs    s5, s5, c
+        adcs    s6, s6, c
+        adc     s7, s7, c
+        subs    t, a1, a3
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b3, b1
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s4, s4, l
+        eor     h, h, c
+        adcs    s5, s5, h
+        adcs    s6, s6, c
+        adc     s7, s7, c
+        subs    t, a0, a2
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b2, b0
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s2, s2, l
+        eor     h, h, c
+        adcs    s3, s3, h
+        adcs    s4, s4, c
+        adcs    s5, s5, c
+        adcs    s6, s6, c
+        adc     s7, s7, c
+        subs    t, a0, a3
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b3, b0
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s3, s3, l
+        eor     h, h, c
+        adcs    s4, s4, h
+        adcs    s5, s5, c
+        adcs    s6, s6, c
+        adc     s7, s7, c
+        subs    t, a1, a2
+        cneg    t, t, cc
+        csetm   c, cc
+        subs    h, b2, b1
+        cneg    h, h, cc
+        mul     l, t, h
+        umulh   h, t, h
+        cinv    c, c, cc
+        cmn     c, #0x1
+        eor     l, l, c
+        adcs    s3, s3, l
+        eor     h, h, c
+        adcs    s4, s4, h
+        adcs    s5, s5, c
+        adcs    s6, s6, c
+        adc     s7, s7, c
 
 // Let the cross product be M. We want to add 2^256 * 2 * M to the buffer
 // Split M into M_top (248 bits) and M_bot (264 bits), so we add
@@ -533,87 +528,87 @@ _bignum_sqr_p521:
 // As this sum is built, accumulate t = AND of words d7...d1 to help
 // in condensing the carry chain in the comparison that comes next
 
-                ldp     l, h, [z]
-                extr    d0, s5, s4, #8
-                adds    d0, d0, l
-                extr    d1, s6, s5, #8
-                adcs    d1, d1, h
+        ldp     l, h, [z]
+        extr    d0, s5, s4, #8
+        adds    d0, d0, l
+        extr    d1, s6, s5, #8
+        adcs    d1, d1, h
 
-                ldp     l, h, [z, #16]
-                extr    d2, s7, s6, #8
-                adcs    d2, d2, l
-                and     t, d1, d2
-                lsr     d3, s7, #8
-                adcs    d3, d3, h
-                and     t, t, d3
+        ldp     l, h, [z, #16]
+        extr    d2, s7, s6, #8
+        adcs    d2, d2, l
+        and     t, d1, d2
+        lsr     d3, s7, #8
+        adcs    d3, d3, h
+        and     t, t, d3
 
-                ldp     l, h, [z, #32]
-                lsl     d4, s0, #1
-                adcs    d4, d4, l
-                and     t, t, d4
-                extr    d5, s1, s0, #63
-                adcs    d5, d5, h
-                and     t, t, d5
+        ldp     l, h, [z, #32]
+        lsl     d4, s0, #1
+        adcs    d4, d4, l
+        and     t, t, d4
+        extr    d5, s1, s0, #63
+        adcs    d5, d5, h
+        and     t, t, d5
 
-                ldp     l, h, [z, #48]
-                extr    d6, s2, s1, #63
-                adcs    d6, d6, l
-                and     t, t, d6
-                extr    d7, s3, s2, #63
-                adcs    d7, d7, h
-                and     t, t, d7
+        ldp     l, h, [z, #48]
+        extr    d6, s2, s1, #63
+        adcs    d6, d6, l
+        and     t, t, d6
+        extr    d7, s3, s2, #63
+        adcs    d7, d7, h
+        and     t, t, d7
 
-                ldr     l, [z, #64]
-                extr    d8, s4, s3, #63
-                and     d8, d8, #0x1FF
-                adc     d8, l, d8
+        ldr     l, [z, #64]
+        extr    d8, s4, s3, #63
+        and     d8, d8, #0x1FF
+        adc     d8, l, d8
 
 // Extract the high part h and mask off the low part l = [d8;d7;...;d0]
 // but stuff d8 with 1 bits at the left to ease a comparison below
 
-                lsr     h, d8, #9
-                orr     d8, d8, #~0x1FF
+        lsr     h, d8, #9
+        orr     d8, d8, #~0x1FF
 
 // Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
 // happen if digits d7,...d1 are all 1s, we use the AND of them "t" to
 // condense the carry chain, and since we stuffed 1 bits into d8 we get
 // the result in CF without an additional comparison.
 
-                subs    xzr, xzr, xzr
-                adcs    xzr, d0, h
-                adcs    xzr, t, xzr
-                adcs    xzr, d8, xzr
+        subs    xzr, xzr, xzr
+        adcs    xzr, d0, h
+        adcs    xzr, t, xzr
+        adcs    xzr, d8, xzr
 
 // Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
 // while otherwise we want just h + l. So mask h + l + CF to 521 bits.
 // This masking also gets rid of the stuffing with 1s we did above.
 
-                adcs    d0, d0, h
-                adcs    d1, d1, xzr
-                adcs    d2, d2, xzr
-                adcs    d3, d3, xzr
-                adcs    d4, d4, xzr
-                adcs    d5, d5, xzr
-                adcs    d6, d6, xzr
-                adcs    d7, d7, xzr
-                adc     d8, d8, xzr
-                and     d8, d8, #0x1FF
+        adcs    d0, d0, h
+        adcs    d1, d1, xzr
+        adcs    d2, d2, xzr
+        adcs    d3, d3, xzr
+        adcs    d4, d4, xzr
+        adcs    d5, d5, xzr
+        adcs    d6, d6, xzr
+        adcs    d7, d7, xzr
+        adc     d8, d8, xzr
+        and     d8, d8, #0x1FF
 
 // Store the final result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
 
 // Restore regs and return
 
-                ldp     x23, x24, [sp], #16
-                ldp     x21, x22, [sp], #16
-                ldp     x19, x20, [sp], #16
+        ldp     x23, x24, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
@@ -21,12 +21,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sqr_p521
-        .private_extern bignum_sqr_p521
+        S2N_ASM_HIDDEN(bignum_sqr_p521)
 
         .globl _bignum_sqr_p521
-        .private_extern _bignum_sqr_p521
+        S2N_ASM_HIDDEN(_bignum_sqr_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
@@ -22,8 +22,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_sqr_p521
-        .globl  _bignum_sqr_p521
+        .globl bignum_sqr_p521
+        .private_extern bignum_sqr_p521
+
+        .globl _bignum_sqr_p521
+        .private_extern _bignum_sqr_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
@@ -21,14 +21,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_sqr_p521_alt
-        S2N_ASM_HIDDEN(bignum_sqr_p521_alt)
-
-        .globl _bignum_sqr_p521_alt
-        S2N_ASM_HIDDEN(_bignum_sqr_p521_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p521_alt)
         .text
         .balign 4
 
@@ -65,314 +61,313 @@
 #define u15 x27
 #define u16 x29
 
-bignum_sqr_p521_alt:
-_bignum_sqr_p521_alt:
+S2N_BN_SYMBOL(bignum_sqr_p521_alt):
 
 // It's convenient to have more registers to play with
 
-                stp     x19, x20, [sp, #-16]!
-                stp     x21, x22, [sp, #-16]!
-                stp     x23, x24, [sp, #-16]!
-                stp     x25, x26, [sp, #-16]!
-                stp     x27, x29, [sp, #-16]!
+        stp     x19, x20, [sp, #-16]!
+        stp     x21, x22, [sp, #-16]!
+        stp     x23, x24, [sp, #-16]!
+        stp     x25, x26, [sp, #-16]!
+        stp     x27, x29, [sp, #-16]!
 
 // Load low 8 elements as [a7;a6;a5;a4;a3;a2;a1;a0], set up an initial
 // window [u8;u7;u6;u5;u4;u3;u2;u1] =  10 + 20 + 30 + 40 + 50 + 60 + 70
 
-                ldp     a0, a1, [x]
+        ldp     a0, a1, [x]
 
-                mul     u1, a0, a1
-                umulh   u2, a0, a1
+        mul     u1, a0, a1
+        umulh   u2, a0, a1
 
-                ldp     a2, a3, [x, #16]
+        ldp     a2, a3, [x, #16]
 
-                mul     l, a0, a2
-                umulh   u3, a0, a2
-                adds    u2, u2, l
+        mul     l, a0, a2
+        umulh   u3, a0, a2
+        adds    u2, u2, l
 
-                ldp     a4, a5, [x, #32]
+        ldp     a4, a5, [x, #32]
 
-                mul     l, a0, a3
-                umulh   u4, a0, a3
-                adcs    u3, u3, l
+        mul     l, a0, a3
+        umulh   u4, a0, a3
+        adcs    u3, u3, l
 
-                ldp     a6, a7, [x, #48]
+        ldp     a6, a7, [x, #48]
 
-                mul     l, a0, a4
-                umulh   u5, a0, a4
-                adcs    u4, u4, l
+        mul     l, a0, a4
+        umulh   u5, a0, a4
+        adcs    u4, u4, l
 
-                mul     l, a0, a5
-                umulh   u6, a0, a5
-                adcs    u5, u5, l
+        mul     l, a0, a5
+        umulh   u6, a0, a5
+        adcs    u5, u5, l
 
-                mul     l, a0, a6
-                umulh   u7, a0, a6
-                adcs    u6, u6, l
+        mul     l, a0, a6
+        umulh   u7, a0, a6
+        adcs    u6, u6, l
 
-                mul     l, a0, a7
-                umulh   u8, a0, a7
-                adcs    u7, u7, l
+        mul     l, a0, a7
+        umulh   u8, a0, a7
+        adcs    u7, u7, l
 
-                adc     u8, u8, xzr
+        adc     u8, u8, xzr
 
 // Add in the next diagonal = 21 + 31 + 41 + 51 + 61 + 71 + 54
 
-                mul     l, a1, a2
-                adds    u3, u3, l
-                mul     l, a1, a3
-                adcs    u4, u4, l
-                mul     l, a1, a4
-                adcs    u5, u5, l
-                mul     l, a1, a5
-                adcs    u6, u6, l
-                mul     l, a1, a6
-                adcs    u7, u7, l
-                mul     l, a1, a7
-                adcs    u8, u8, l
-                cset    u9, cs
+        mul     l, a1, a2
+        adds    u3, u3, l
+        mul     l, a1, a3
+        adcs    u4, u4, l
+        mul     l, a1, a4
+        adcs    u5, u5, l
+        mul     l, a1, a5
+        adcs    u6, u6, l
+        mul     l, a1, a6
+        adcs    u7, u7, l
+        mul     l, a1, a7
+        adcs    u8, u8, l
+        cset    u9, cs
 
-                umulh   l, a1, a2
-                adds    u4, u4, l
-                umulh   l, a1, a3
-                adcs    u5, u5, l
-                umulh   l, a1, a4
-                adcs    u6, u6, l
-                umulh   l, a1, a5
-                adcs    u7, u7, l
-                umulh   l, a1, a6
-                adcs    u8, u8, l
-                umulh   l, a1, a7
-                adc     u9, u9, l
-                mul     l, a4, a5
-                umulh   u10, a4, a5
-                adds    u9, u9, l
-                adc     u10, u10, xzr
+        umulh   l, a1, a2
+        adds    u4, u4, l
+        umulh   l, a1, a3
+        adcs    u5, u5, l
+        umulh   l, a1, a4
+        adcs    u6, u6, l
+        umulh   l, a1, a5
+        adcs    u7, u7, l
+        umulh   l, a1, a6
+        adcs    u8, u8, l
+        umulh   l, a1, a7
+        adc     u9, u9, l
+        mul     l, a4, a5
+        umulh   u10, a4, a5
+        adds    u9, u9, l
+        adc     u10, u10, xzr
 
 // And the next one = 32 + 42 + 52 + 62 + 72 + 64 + 65
 
-                mul     l, a2, a3
-                adds    u5, u5, l
-                mul     l, a2, a4
-                adcs    u6, u6, l
-                mul     l, a2, a5
-                adcs    u7, u7, l
-                mul     l, a2, a6
-                adcs    u8, u8, l
-                mul     l, a2, a7
-                adcs    u9, u9, l
-                mul     l, a4, a6
-                adcs    u10, u10, l
-                cset    u11, cs
+        mul     l, a2, a3
+        adds    u5, u5, l
+        mul     l, a2, a4
+        adcs    u6, u6, l
+        mul     l, a2, a5
+        adcs    u7, u7, l
+        mul     l, a2, a6
+        adcs    u8, u8, l
+        mul     l, a2, a7
+        adcs    u9, u9, l
+        mul     l, a4, a6
+        adcs    u10, u10, l
+        cset    u11, cs
 
-                umulh   l, a2, a3
-                adds    u6, u6, l
-                umulh   l, a2, a4
-                adcs    u7, u7, l
-                umulh   l, a2, a5
-                adcs    u8, u8, l
-                umulh   l, a2, a6
-                adcs    u9, u9, l
-                umulh   l, a2, a7
-                adcs    u10, u10, l
-                umulh   l, a4, a6
-                adc     u11, u11, l
-                mul     l, a5, a6
-                umulh   u12, a5, a6
-                adds    u11, u11, l
-                adc     u12, u12, xzr
+        umulh   l, a2, a3
+        adds    u6, u6, l
+        umulh   l, a2, a4
+        adcs    u7, u7, l
+        umulh   l, a2, a5
+        adcs    u8, u8, l
+        umulh   l, a2, a6
+        adcs    u9, u9, l
+        umulh   l, a2, a7
+        adcs    u10, u10, l
+        umulh   l, a4, a6
+        adc     u11, u11, l
+        mul     l, a5, a6
+        umulh   u12, a5, a6
+        adds    u11, u11, l
+        adc     u12, u12, xzr
 
 // And the final one = 43 + 53 + 63 + 73 + 74 + 75 + 76
 
-                mul     l, a3, a4
-                adds    u7, u7, l
-                mul     l, a3, a5
-                adcs    u8, u8, l
-                mul     l, a3, a6
-                adcs    u9, u9, l
-                mul     l, a3, a7
-                adcs    u10, u10, l
-                mul     l, a4, a7
-                adcs    u11, u11, l
-                mul     l, a5, a7
-                adcs    u12, u12, l
-                cset    u13, cs
+        mul     l, a3, a4
+        adds    u7, u7, l
+        mul     l, a3, a5
+        adcs    u8, u8, l
+        mul     l, a3, a6
+        adcs    u9, u9, l
+        mul     l, a3, a7
+        adcs    u10, u10, l
+        mul     l, a4, a7
+        adcs    u11, u11, l
+        mul     l, a5, a7
+        adcs    u12, u12, l
+        cset    u13, cs
 
-                umulh   l, a3, a4
-                adds    u8, u8, l
-                umulh   l, a3, a5
-                adcs    u9, u9, l
-                umulh   l, a3, a6
-                adcs    u10, u10, l
-                umulh   l, a3, a7
-                adcs    u11, u11, l
-                umulh   l, a4, a7
-                adcs    u12, u12, l
-                umulh   l, a5, a7
-                adc     u13, u13, l
-                mul     l, a6, a7
-                umulh   u14, a6, a7
-                adds    u13, u13, l
-                adc     u14, u14, xzr
+        umulh   l, a3, a4
+        adds    u8, u8, l
+        umulh   l, a3, a5
+        adcs    u9, u9, l
+        umulh   l, a3, a6
+        adcs    u10, u10, l
+        umulh   l, a3, a7
+        adcs    u11, u11, l
+        umulh   l, a4, a7
+        adcs    u12, u12, l
+        umulh   l, a5, a7
+        adc     u13, u13, l
+        mul     l, a6, a7
+        umulh   u14, a6, a7
+        adds    u13, u13, l
+        adc     u14, u14, xzr
 
 // Double that, with u15 holding the top carry
 
-                adds    u1, u1, u1
-                adcs    u2, u2, u2
-                adcs    u3, u3, u3
-                adcs    u4, u4, u4
-                adcs    u5, u5, u5
-                adcs    u6, u6, u6
-                adcs    u7, u7, u7
-                adcs    u8, u8, u8
-                adcs    u9, u9, u9
-                adcs    u10, u10, u10
-                adcs    u11, u11, u11
-                adcs    u12, u12, u12
-                adcs    u13, u13, u13
-                adcs    u14, u14, u14
-                cset    u15, cs
+        adds    u1, u1, u1
+        adcs    u2, u2, u2
+        adcs    u3, u3, u3
+        adcs    u4, u4, u4
+        adcs    u5, u5, u5
+        adcs    u6, u6, u6
+        adcs    u7, u7, u7
+        adcs    u8, u8, u8
+        adcs    u9, u9, u9
+        adcs    u10, u10, u10
+        adcs    u11, u11, u11
+        adcs    u12, u12, u12
+        adcs    u13, u13, u13
+        adcs    u14, u14, u14
+        cset    u15, cs
 
 // Add the homogeneous terms 00 + 11 + 22 + 33 + 44 + 55 + 66 + 77
 
-                umulh   l, a0, a0
-                mul     u0, a0, a0
-                adds    u1, u1, l
+        umulh   l, a0, a0
+        mul     u0, a0, a0
+        adds    u1, u1, l
 
-                mul     l, a1, a1
-                adcs    u2, u2, l
-                umulh   l, a1, a1
-                adcs    u3, u3, l
+        mul     l, a1, a1
+        adcs    u2, u2, l
+        umulh   l, a1, a1
+        adcs    u3, u3, l
 
-                mul     l, a2, a2
-                adcs    u4, u4, l
-                umulh   l, a2, a2
-                adcs    u5, u5, l
+        mul     l, a2, a2
+        adcs    u4, u4, l
+        umulh   l, a2, a2
+        adcs    u5, u5, l
 
-                mul     l, a3, a3
-                adcs    u6, u6, l
-                umulh   l, a3, a3
-                adcs    u7, u7, l
+        mul     l, a3, a3
+        adcs    u6, u6, l
+        umulh   l, a3, a3
+        adcs    u7, u7, l
 
-                mul     l, a4, a4
-                adcs    u8, u8, l
-                umulh   l, a4, a4
-                adcs    u9, u9, l
+        mul     l, a4, a4
+        adcs    u8, u8, l
+        umulh   l, a4, a4
+        adcs    u9, u9, l
 
-                mul     l, a5, a5
-                adcs    u10, u10, l
-                umulh   l, a5, a5
-                adcs    u11, u11, l
+        mul     l, a5, a5
+        adcs    u10, u10, l
+        umulh   l, a5, a5
+        adcs    u11, u11, l
 
-                mul     l, a6, a6
-                adcs    u12, u12, l
-                umulh   l, a6, a6
-                adcs    u13, u13, l
+        mul     l, a6, a6
+        adcs    u12, u12, l
+        umulh   l, a6, a6
+        adcs    u13, u13, l
 
-                mul     l, a7, a7
-                adcs    u14, u14, l
-                umulh   l, a7, a7
-                adc     u15, u15, l
+        mul     l, a7, a7
+        adcs    u14, u14, l
+        umulh   l, a7, a7
+        adc     u15, u15, l
 
 // Now load in the top digit a8, and also set up its double and square
 
-                ldr     a8, [x, #64]
-                mul     u16, a8, a8
-                add     a8, a8, a8
+        ldr     a8, [x, #64]
+        mul     u16, a8, a8
+        add     a8, a8, a8
 
 // Add a8 * [a7;...;a0] into the top of the buffer
 
-                mul     l, a8, a0
-                adds    u8, u8, l
-                mul     l, a8, a1
-                adcs    u9, u9, l
-                mul     l, a8, a2
-                adcs    u10, u10, l
-                mul     l, a8, a3
-                adcs    u11, u11, l
-                mul     l, a8, a4
-                adcs    u12, u12, l
-                mul     l, a8, a5
-                adcs    u13, u13, l
-                mul     l, a8, a6
-                adcs    u14, u14, l
-                mul     l, a8, a7
-                adcs    u15, u15, l
-                adc     u16, u16, xzr
+        mul     l, a8, a0
+        adds    u8, u8, l
+        mul     l, a8, a1
+        adcs    u9, u9, l
+        mul     l, a8, a2
+        adcs    u10, u10, l
+        mul     l, a8, a3
+        adcs    u11, u11, l
+        mul     l, a8, a4
+        adcs    u12, u12, l
+        mul     l, a8, a5
+        adcs    u13, u13, l
+        mul     l, a8, a6
+        adcs    u14, u14, l
+        mul     l, a8, a7
+        adcs    u15, u15, l
+        adc     u16, u16, xzr
 
-                umulh   l, a8, a0
-                adds    u9, u9, l
-                umulh   l, a8, a1
-                adcs    u10, u10, l
-                umulh   l, a8, a2
-                adcs    u11, u11, l
-                umulh   l, a8, a3
-                adcs    u12, u12, l
-                umulh   l, a8, a4
-                adcs    u13, u13, l
-                umulh   l, a8, a5
-                adcs    u14, u14, l
-                umulh   l, a8, a6
-                adcs    u15, u15, l
-                umulh   l, a8, a7
-                adc     u16, u16, l
+        umulh   l, a8, a0
+        adds    u9, u9, l
+        umulh   l, a8, a1
+        adcs    u10, u10, l
+        umulh   l, a8, a2
+        adcs    u11, u11, l
+        umulh   l, a8, a3
+        adcs    u12, u12, l
+        umulh   l, a8, a4
+        adcs    u13, u13, l
+        umulh   l, a8, a5
+        adcs    u14, u14, l
+        umulh   l, a8, a6
+        adcs    u15, u15, l
+        umulh   l, a8, a7
+        adc     u16, u16, l
 
 // Now we have the full product, which we consider as
 // 2^521 * h + l. Form h + l + 1
 
-                subs    xzr, xzr, xzr
-                extr    l, u9, u8, #9
-                adcs    u0, u0, l
-                extr    l, u10, u9, #9
-                adcs    u1, u1, l
-                extr    l, u11, u10, #9
-                adcs    u2, u2, l
-                extr    l, u12, u11, #9
-                adcs    u3, u3, l
-                extr    l, u13, u12, #9
-                adcs    u4, u4, l
-                extr    l, u14, u13, #9
-                adcs    u5, u5, l
-                extr    l, u15, u14, #9
-                adcs    u6, u6, l
-                extr    l, u16, u15, #9
-                adcs    u7, u7, l
-                orr     u8, u8, #~0x1FF
-                lsr     l, u16, #9
-                adcs    u8, u8, l
+        subs    xzr, xzr, xzr
+        extr    l, u9, u8, #9
+        adcs    u0, u0, l
+        extr    l, u10, u9, #9
+        adcs    u1, u1, l
+        extr    l, u11, u10, #9
+        adcs    u2, u2, l
+        extr    l, u12, u11, #9
+        adcs    u3, u3, l
+        extr    l, u13, u12, #9
+        adcs    u4, u4, l
+        extr    l, u14, u13, #9
+        adcs    u5, u5, l
+        extr    l, u15, u14, #9
+        adcs    u6, u6, l
+        extr    l, u16, u15, #9
+        adcs    u7, u7, l
+        orr     u8, u8, #~0x1FF
+        lsr     l, u16, #9
+        adcs    u8, u8, l
 
 // Now CF is set if h + l + 1 >= 2^521, which means it's already
 // the answer, while if ~CF the answer is h + l so we should subtract
 // 1 (all considered in 521 bits). Hence subtract ~CF and mask.
 
-                sbcs    u0, u0, xzr
-                sbcs    u1, u1, xzr
-                sbcs    u2, u2, xzr
-                sbcs    u3, u3, xzr
-                sbcs    u4, u4, xzr
-                sbcs    u5, u5, xzr
-                sbcs    u6, u6, xzr
-                sbcs    u7, u7, xzr
-                sbc     u8, u8, xzr
-                and     u8, u8, #0x1FF
+        sbcs    u0, u0, xzr
+        sbcs    u1, u1, xzr
+        sbcs    u2, u2, xzr
+        sbcs    u3, u3, xzr
+        sbcs    u4, u4, xzr
+        sbcs    u5, u5, xzr
+        sbcs    u6, u6, xzr
+        sbcs    u7, u7, xzr
+        sbc     u8, u8, xzr
+        and     u8, u8, #0x1FF
 
 // Store back digits of final result
 
-                stp     u0, u1, [z]
-                stp     u2, u3, [z, #16]
-                stp     u4, u5, [z, #32]
-                stp     u6, u7, [z, #48]
-                str     u8, [z, #64]
+        stp     u0, u1, [z]
+        stp     u2, u3, [z, #16]
+        stp     u4, u5, [z, #32]
+        stp     u6, u7, [z, #48]
+        str     u8, [z, #64]
 
 // Restore registers and return
 
-                ldp     x27, x29, [sp], #16
-                ldp     x25, x26, [sp], #16
-                ldp     x23, x24, [sp], #16
-                ldp     x21, x22, [sp], #16
-                ldp     x19, x20, [sp], #16
+        ldp     x27, x29, [sp], #16
+        ldp     x25, x26, [sp], #16
+        ldp     x23, x24, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
@@ -22,8 +22,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_sqr_p521_alt
-        .globl  _bignum_sqr_p521_alt
+        .globl bignum_sqr_p521_alt
+        .private_extern bignum_sqr_p521_alt
+
+        .globl _bignum_sqr_p521_alt
+        .private_extern _bignum_sqr_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
@@ -21,12 +21,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sqr_p521_alt
-        .private_extern bignum_sqr_p521_alt
+        S2N_ASM_HIDDEN(bignum_sqr_p521_alt)
 
         .globl _bignum_sqr_p521_alt
-        .private_extern _bignum_sqr_p521_alt
+        S2N_ASM_HIDDEN(_bignum_sqr_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_sub_p521
-        .globl  _bignum_sub_p521
+        .globl bignum_sub_p521
+        .private_extern bignum_sub_p521
+
+        .globl _bignum_sub_p521
+        .private_extern _bignum_sub_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sub_p521
-        .private_extern bignum_sub_p521
+        S2N_ASM_HIDDEN(bignum_sub_p521)
 
         .globl _bignum_sub_p521
-        .private_extern _bignum_sub_p521
+        S2N_ASM_HIDDEN(_bignum_sub_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_sub_p521
-        S2N_ASM_HIDDEN(bignum_sub_p521)
-
-        .globl _bignum_sub_p521
-        S2N_ASM_HIDDEN(_bignum_sub_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p521)
         .text
         .balign 4
 
@@ -49,55 +45,54 @@
 #define d8 x13
 
 
-bignum_sub_p521:
-_bignum_sub_p521:
+S2N_BN_SYMBOL(bignum_sub_p521):
 
 // First just subtract the numbers as [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x - y
 
-                ldp     d0, d1, [x]
-                ldp     l, h, [y]
-                subs    d0, d0, l
-                sbcs    d1, d1, h
-                ldp     d2, d3, [x, #16]
-                ldp     l, h, [y, #16]
-                sbcs    d2, d2, l
-                sbcs    d3, d3, h
-                ldp     d4, d5, [x, #32]
-                ldp     l, h, [y, #32]
-                sbcs    d4, d4, l
-                sbcs    d5, d5, h
-                ldp     d6, d7, [x, #48]
-                ldp     l, h, [y, #48]
-                sbcs    d6, d6, l
-                sbcs    d7, d7, h
-                ldr     d8, [x, #64]
-                ldr     l, [y, #64]
-                sbcs    d8, d8, l
+        ldp     d0, d1, [x]
+        ldp     l, h, [y]
+        subs    d0, d0, l
+        sbcs    d1, d1, h
+        ldp     d2, d3, [x, #16]
+        ldp     l, h, [y, #16]
+        sbcs    d2, d2, l
+        sbcs    d3, d3, h
+        ldp     d4, d5, [x, #32]
+        ldp     l, h, [y, #32]
+        sbcs    d4, d4, l
+        sbcs    d5, d5, h
+        ldp     d6, d7, [x, #48]
+        ldp     l, h, [y, #48]
+        sbcs    d6, d6, l
+        sbcs    d7, d7, h
+        ldr     d8, [x, #64]
+        ldr     l, [y, #64]
+        sbcs    d8, d8, l
 
 // Now if x < y we want (x - y) + p_521 == (x - y) - 1 (mod 2^521)
 // Otherwise we just want the existing x - y result. So subtract
 // 1 iff the initial subtraction carried, then mask to 521 bits.
 
-                sbcs    d0, d0, xzr
-                sbcs    d1, d1, xzr
-                sbcs    d2, d2, xzr
-                sbcs    d3, d3, xzr
-                sbcs    d4, d4, xzr
-                sbcs    d5, d5, xzr
-                sbcs    d6, d6, xzr
-                sbcs    d7, d7, xzr
-                sbcs    d8, d8, xzr
-                and     d8, d8, #0x1FF
+        sbcs    d0, d0, xzr
+        sbcs    d1, d1, xzr
+        sbcs    d2, d2, xzr
+        sbcs    d3, d3, xzr
+        sbcs    d4, d4, xzr
+        sbcs    d5, d5, xzr
+        sbcs    d6, d6, xzr
+        sbcs    d7, d7, xzr
+        sbcs    d8, d8, xzr
+        and     d8, d8, #0x1FF
 
 // Store the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
@@ -24,12 +24,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tolebytes_p521
-        .private_extern bignum_tolebytes_p521
+        S2N_ASM_HIDDEN(bignum_tolebytes_p521)
 
         .globl _bignum_tolebytes_p521
-        .private_extern _bignum_tolebytes_p521
+        S2N_ASM_HIDDEN(_bignum_tolebytes_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
@@ -24,14 +24,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_tolebytes_p521
-        S2N_ASM_HIDDEN(bignum_tolebytes_p521)
-
-        .globl _bignum_tolebytes_p521
-        S2N_ASM_HIDDEN(_bignum_tolebytes_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tolebytes_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tolebytes_p521)
         .text
         .balign 4
 
@@ -41,169 +37,168 @@
 #define d x2
 #define dshort w2
 
-bignum_tolebytes_p521:
-_bignum_tolebytes_p521:
+S2N_BN_SYMBOL(bignum_tolebytes_p521):
 
 // word 0
 
-                ldr     d, [x]
-                strb    dshort, [z]
-                lsr     d, d, #8
-                strb    dshort, [z, #1]
-                lsr     d, d, #8
-                strb    dshort, [z, #2]
-                lsr     d, d, #8
-                strb    dshort, [z, #3]
-                lsr     d, d, #8
-                strb    dshort, [z, #4]
-                lsr     d, d, #8
-                strb    dshort, [z, #5]
-                lsr     d, d, #8
-                strb    dshort, [z, #6]
-                lsr     d, d, #8
-                strb    dshort, [z, #7]
+        ldr     d, [x]
+        strb    dshort, [z]
+        lsr     d, d, #8
+        strb    dshort, [z, #1]
+        lsr     d, d, #8
+        strb    dshort, [z, #2]
+        lsr     d, d, #8
+        strb    dshort, [z, #3]
+        lsr     d, d, #8
+        strb    dshort, [z, #4]
+        lsr     d, d, #8
+        strb    dshort, [z, #5]
+        lsr     d, d, #8
+        strb    dshort, [z, #6]
+        lsr     d, d, #8
+        strb    dshort, [z, #7]
 
 // word 1
 
-                ldr     d, [x, #8]
-                strb    dshort, [z, #8]
-                lsr     d, d, #8
-                strb    dshort, [z, #9]
-                lsr     d, d, #8
-                strb    dshort, [z, #10]
-                lsr     d, d, #8
-                strb    dshort, [z, #11]
-                lsr     d, d, #8
-                strb    dshort, [z, #12]
-                lsr     d, d, #8
-                strb    dshort, [z, #13]
-                lsr     d, d, #8
-                strb    dshort, [z, #14]
-                lsr     d, d, #8
-                strb    dshort, [z, #15]
+        ldr     d, [x, #8]
+        strb    dshort, [z, #8]
+        lsr     d, d, #8
+        strb    dshort, [z, #9]
+        lsr     d, d, #8
+        strb    dshort, [z, #10]
+        lsr     d, d, #8
+        strb    dshort, [z, #11]
+        lsr     d, d, #8
+        strb    dshort, [z, #12]
+        lsr     d, d, #8
+        strb    dshort, [z, #13]
+        lsr     d, d, #8
+        strb    dshort, [z, #14]
+        lsr     d, d, #8
+        strb    dshort, [z, #15]
 
 // word 2
 
-                ldr     d, [x, #16]
-                strb    dshort, [z, #16]
-                lsr     d, d, #8
-                strb    dshort, [z, #17]
-                lsr     d, d, #8
-                strb    dshort, [z, #18]
-                lsr     d, d, #8
-                strb    dshort, [z, #19]
-                lsr     d, d, #8
-                strb    dshort, [z, #20]
-                lsr     d, d, #8
-                strb    dshort, [z, #21]
-                lsr     d, d, #8
-                strb    dshort, [z, #22]
-                lsr     d, d, #8
-                strb    dshort, [z, #23]
+        ldr     d, [x, #16]
+        strb    dshort, [z, #16]
+        lsr     d, d, #8
+        strb    dshort, [z, #17]
+        lsr     d, d, #8
+        strb    dshort, [z, #18]
+        lsr     d, d, #8
+        strb    dshort, [z, #19]
+        lsr     d, d, #8
+        strb    dshort, [z, #20]
+        lsr     d, d, #8
+        strb    dshort, [z, #21]
+        lsr     d, d, #8
+        strb    dshort, [z, #22]
+        lsr     d, d, #8
+        strb    dshort, [z, #23]
 
 // word 3
 
-                ldr     d, [x, #24]
-                strb    dshort, [z, #24]
-                lsr     d, d, #8
-                strb    dshort, [z, #25]
-                lsr     d, d, #8
-                strb    dshort, [z, #26]
-                lsr     d, d, #8
-                strb    dshort, [z, #27]
-                lsr     d, d, #8
-                strb    dshort, [z, #28]
-                lsr     d, d, #8
-                strb    dshort, [z, #29]
-                lsr     d, d, #8
-                strb    dshort, [z, #30]
-                lsr     d, d, #8
-                strb    dshort, [z, #31]
+        ldr     d, [x, #24]
+        strb    dshort, [z, #24]
+        lsr     d, d, #8
+        strb    dshort, [z, #25]
+        lsr     d, d, #8
+        strb    dshort, [z, #26]
+        lsr     d, d, #8
+        strb    dshort, [z, #27]
+        lsr     d, d, #8
+        strb    dshort, [z, #28]
+        lsr     d, d, #8
+        strb    dshort, [z, #29]
+        lsr     d, d, #8
+        strb    dshort, [z, #30]
+        lsr     d, d, #8
+        strb    dshort, [z, #31]
 
 // word 4
 
-                ldr     d, [x, #32]
-                strb    dshort, [z, #32]
-                lsr     d, d, #8
-                strb    dshort, [z, #33]
-                lsr     d, d, #8
-                strb    dshort, [z, #34]
-                lsr     d, d, #8
-                strb    dshort, [z, #35]
-                lsr     d, d, #8
-                strb    dshort, [z, #36]
-                lsr     d, d, #8
-                strb    dshort, [z, #37]
-                lsr     d, d, #8
-                strb    dshort, [z, #38]
-                lsr     d, d, #8
-                strb    dshort, [z, #39]
+        ldr     d, [x, #32]
+        strb    dshort, [z, #32]
+        lsr     d, d, #8
+        strb    dshort, [z, #33]
+        lsr     d, d, #8
+        strb    dshort, [z, #34]
+        lsr     d, d, #8
+        strb    dshort, [z, #35]
+        lsr     d, d, #8
+        strb    dshort, [z, #36]
+        lsr     d, d, #8
+        strb    dshort, [z, #37]
+        lsr     d, d, #8
+        strb    dshort, [z, #38]
+        lsr     d, d, #8
+        strb    dshort, [z, #39]
 
 // word 5
 
-                ldr     d, [x, #40]
-                strb    dshort, [z, #40]
-                lsr     d, d, #8
-                strb    dshort, [z, #41]
-                lsr     d, d, #8
-                strb    dshort, [z, #42]
-                lsr     d, d, #8
-                strb    dshort, [z, #43]
-                lsr     d, d, #8
-                strb    dshort, [z, #44]
-                lsr     d, d, #8
-                strb    dshort, [z, #45]
-                lsr     d, d, #8
-                strb    dshort, [z, #46]
-                lsr     d, d, #8
-                strb    dshort, [z, #47]
+        ldr     d, [x, #40]
+        strb    dshort, [z, #40]
+        lsr     d, d, #8
+        strb    dshort, [z, #41]
+        lsr     d, d, #8
+        strb    dshort, [z, #42]
+        lsr     d, d, #8
+        strb    dshort, [z, #43]
+        lsr     d, d, #8
+        strb    dshort, [z, #44]
+        lsr     d, d, #8
+        strb    dshort, [z, #45]
+        lsr     d, d, #8
+        strb    dshort, [z, #46]
+        lsr     d, d, #8
+        strb    dshort, [z, #47]
 
 // word 6
 
-                ldr     d, [x, #48]
-                strb    dshort, [z, #48]
-                lsr     d, d, #8
-                strb    dshort, [z, #49]
-                lsr     d, d, #8
-                strb    dshort, [z, #50]
-                lsr     d, d, #8
-                strb    dshort, [z, #51]
-                lsr     d, d, #8
-                strb    dshort, [z, #52]
-                lsr     d, d, #8
-                strb    dshort, [z, #53]
-                lsr     d, d, #8
-                strb    dshort, [z, #54]
-                lsr     d, d, #8
-                strb    dshort, [z, #55]
+        ldr     d, [x, #48]
+        strb    dshort, [z, #48]
+        lsr     d, d, #8
+        strb    dshort, [z, #49]
+        lsr     d, d, #8
+        strb    dshort, [z, #50]
+        lsr     d, d, #8
+        strb    dshort, [z, #51]
+        lsr     d, d, #8
+        strb    dshort, [z, #52]
+        lsr     d, d, #8
+        strb    dshort, [z, #53]
+        lsr     d, d, #8
+        strb    dshort, [z, #54]
+        lsr     d, d, #8
+        strb    dshort, [z, #55]
 
 // word 7
 
-                ldr     d, [x, #56]
-                strb    dshort, [z, #56]
-                lsr     d, d, #8
-                strb    dshort, [z, #57]
-                lsr     d, d, #8
-                strb    dshort, [z, #58]
-                lsr     d, d, #8
-                strb    dshort, [z, #59]
-                lsr     d, d, #8
-                strb    dshort, [z, #60]
-                lsr     d, d, #8
-                strb    dshort, [z, #61]
-                lsr     d, d, #8
-                strb    dshort, [z, #62]
-                lsr     d, d, #8
-                strb    dshort, [z, #63]
+        ldr     d, [x, #56]
+        strb    dshort, [z, #56]
+        lsr     d, d, #8
+        strb    dshort, [z, #57]
+        lsr     d, d, #8
+        strb    dshort, [z, #58]
+        lsr     d, d, #8
+        strb    dshort, [z, #59]
+        lsr     d, d, #8
+        strb    dshort, [z, #60]
+        lsr     d, d, #8
+        strb    dshort, [z, #61]
+        lsr     d, d, #8
+        strb    dshort, [z, #62]
+        lsr     d, d, #8
+        strb    dshort, [z, #63]
 
 // word 8
 
-                ldr     d, [x, #64]
-                strb    dshort, [z, #64]
-                lsr     d, d, #8
-                strb    dshort, [z, #65]
+        ldr     d, [x, #64]
+        strb    dshort, [z, #64]
+        lsr     d, d, #8
+        strb    dshort, [z, #65]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
@@ -25,8 +25,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_tolebytes_p521
-        .globl  _bignum_tolebytes_p521
+        .globl bignum_tolebytes_p521
+        .private_extern bignum_tolebytes_p521
+
+        .globl _bignum_tolebytes_p521
+        .private_extern _bignum_tolebytes_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
@@ -22,14 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_tomont_p521
-        S2N_ASM_HIDDEN(bignum_tomont_p521)
-
-        .globl _bignum_tomont_p521
-        S2N_ASM_HIDDEN(_bignum_tomont_p521)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p521)
         .text
         .balign 4
 
@@ -48,15 +44,14 @@
 #define d7 x11
 #define d8 x12
 
-bignum_tomont_p521:
-_bignum_tomont_p521:
+S2N_BN_SYMBOL(bignum_tomont_p521):
 
 // Load top digit first and get its upper bits in h so that we
 // separate out x = 2^521 * H + L with h = H. Now x mod p_521 =
 // (H + L) mod p_521 = if H + L >= p_521 then H + L - p_521 else H + L.
 
-                ldr     d8, [x, #64]
-                lsr     h, d8, #9
+        ldr     d8, [x, #64]
+        lsr     h, d8, #9
 
 // Load in the other digits and decide whether H + L >= p_521. This is
 // equivalent to H + L + 1 >= 2^521, and since this can only happen if
@@ -65,35 +60,35 @@ _bignum_tomont_p521:
 // This condenses only three pairs; the payoff beyond that seems limited.
 // By stuffing in 1 bits from 521 position upwards, get CF directly
 
-                subs    xzr, xzr, xzr
-                ldp     d0, d1, [x]
-                adcs    xzr, d0, h
-                adcs    xzr, d1, xzr
-                ldp     d2, d3, [x, #16]
-                and     t, d2, d3
-                adcs    xzr, t, xzr
-                ldp     d4, d5, [x, #32]
-                and     t, d4, d5
-                adcs    xzr, t, xzr
-                ldp     d6, d7, [x, #48]
-                and     t, d6, d7
-                adcs    xzr, t, xzr
-                orr     t, d8, #~0x1FF
-                adcs    t, t, xzr
+        subs    xzr, xzr, xzr
+        ldp     d0, d1, [x]
+        adcs    xzr, d0, h
+        adcs    xzr, d1, xzr
+        ldp     d2, d3, [x, #16]
+        and     t, d2, d3
+        adcs    xzr, t, xzr
+        ldp     d4, d5, [x, #32]
+        and     t, d4, d5
+        adcs    xzr, t, xzr
+        ldp     d6, d7, [x, #48]
+        and     t, d6, d7
+        adcs    xzr, t, xzr
+        orr     t, d8, #~0x1FF
+        adcs    t, t, xzr
 
 // Now H + L >= p_521 <=> H + L + 1 >= 2^521 <=> CF from this comparison.
 // So if CF is set we want (H + L) - p_521 = (H + L + 1) - 2^521
 // while otherwise we want just H + L. So mask H + L + CF to 521 bits.
 
-                adcs    d0, d0, h
-                adcs    d1, d1, xzr
-                adcs    d2, d2, xzr
-                adcs    d3, d3, xzr
-                adcs    d4, d4, xzr
-                adcs    d5, d5, xzr
-                adcs    d6, d6, xzr
-                adcs    d7, d7, xzr
-                adc     d8, d8, xzr
+        adcs    d0, d0, h
+        adcs    d1, d1, xzr
+        adcs    d2, d2, xzr
+        adcs    d3, d3, xzr
+        adcs    d4, d4, xzr
+        adcs    d5, d5, xzr
+        adcs    d6, d6, xzr
+        adcs    d7, d7, xzr
+        adc     d8, d8, xzr
 
 // So far, this is just a modular reduction as in bignum_mod_p521_9,
 // except that the final masking of d8 is skipped since that comes out
@@ -103,27 +98,27 @@ _bignum_tomont_p521:
 // right-to-left fashion, which might blend better with the carry
 // chain above, the digit register indices themselves get shuffled up.
 
-                lsl     t, d0, #55
-                extr    d0, d1, d0, #9
-                extr    d1, d2, d1, #9
-                extr    d2, d3, d2, #9
-                extr    d3, d4, d3, #9
-                extr    d4, d5, d4, #9
-                extr    d5, d6, d5, #9
-                extr    d6, d7, d6, #9
-                extr    d7, d8, d7, #9
-                lsr     d8, d7, #9
-                orr     t, t, d8
-                and     d7, d7, #0x1FF
+        lsl     t, d0, #55
+        extr    d0, d1, d0, #9
+        extr    d1, d2, d1, #9
+        extr    d2, d3, d2, #9
+        extr    d3, d4, d3, #9
+        extr    d4, d5, d4, #9
+        extr    d5, d6, d5, #9
+        extr    d6, d7, d6, #9
+        extr    d7, d8, d7, #9
+        lsr     d8, d7, #9
+        orr     t, t, d8
+        and     d7, d7, #0x1FF
 
 // Store the result from the shuffled registers [d7;d6;...;d1;d0;t]
 
-                stp     t, d0, [z]
-                stp     d1, d2, [z, #16]
-                stp     d3, d4, [z, #32]
-                stp     d5, d6, [z, #48]
-                str     d7, [z, #64]
-                ret
+        stp     t, d0, [z]
+        stp     d1, d2, [z, #16]
+        stp     d3, d4, [z, #32]
+        stp     d5, d6, [z, #48]
+        str     d7, [z, #64]
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
@@ -22,12 +22,13 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tomont_p521
-        .private_extern bignum_tomont_p521
+        S2N_ASM_HIDDEN(bignum_tomont_p521)
 
         .globl _bignum_tomont_p521
-        .private_extern _bignum_tomont_p521
+        S2N_ASM_HIDDEN(_bignum_tomont_p521)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
@@ -23,8 +23,12 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_tomont_p521
-        .globl  _bignum_tomont_p521
+        .globl bignum_tomont_p521
+        .private_extern bignum_tomont_p521
+
+        .globl _bignum_tomont_p521
+        .private_extern _bignum_tomont_p521
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
@@ -22,20 +22,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl bignum_triple_p521
-        S2N_ASM_HIDDEN(bignum_triple_p521)
-
-        .globl _bignum_triple_p521
-        S2N_ASM_HIDDEN(_bignum_triple_p521)
-
-        .globl bignum_triple_p521_alt
-        S2N_ASM_HIDDEN(bignum_triple_p521_alt)
-
-        .globl _bignum_triple_p521_alt
-        S2N_ASM_HIDDEN(_bignum_triple_p521_alt)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p521_alt)
         .text
         .balign 4
 
@@ -56,80 +48,79 @@
 #define d8 x12
 
 
-bignum_triple_p521:
-_bignum_triple_p521:
-bignum_triple_p521_alt:
-_bignum_triple_p521_alt:
+S2N_BN_SYMBOL(bignum_triple_p521):
+
+S2N_BN_SYMBOL(bignum_triple_p521_alt):
 
 // Pick out top bit to wrap to the zero position in the doubling step
 
-                ldr     d8, [x, #64]
-                lsl     l, d8, #55
+        ldr     d8, [x, #64]
+        lsl     l, d8, #55
 
 // Rotate left to get x' == 2 * x (mod p_521) and add to x + 1 (carryin) to get
 // s = [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x + x' + 1 == 3 * x + 1 (mod p_521)
 
-                subs    xzr, xzr, xzr
+        subs    xzr, xzr, xzr
 
-                ldp     d0, d1, [x]
-                extr    l, d0, l, #63
-                extr    h, d1, d0, #63
-                adcs    d0, d0, l
+        ldp     d0, d1, [x]
+        extr    l, d0, l, #63
+        extr    h, d1, d0, #63
+        adcs    d0, d0, l
 
-                ldp     d2, d3, [x, #16]
-                extr    l, d2, d1, #63
-                adcs    d1, d1, h
-                extr    h, d3, d2, #63
-                adcs    d2, d2, l
+        ldp     d2, d3, [x, #16]
+        extr    l, d2, d1, #63
+        adcs    d1, d1, h
+        extr    h, d3, d2, #63
+        adcs    d2, d2, l
 
-                ldp     d4, d5, [x, #32]
-                extr    l, d4, d3, #63
-                adcs    d3, d3, h
-                extr    h, d5, d4, #63
-                adcs    d4, d4, l
+        ldp     d4, d5, [x, #32]
+        extr    l, d4, d3, #63
+        adcs    d3, d3, h
+        extr    h, d5, d4, #63
+        adcs    d4, d4, l
 
-                ldp     d6, d7, [x, #48]
-                extr    l, d6, d5, #63
-                adcs    d5, d5, h
-                extr    h, d7, d6, #63
-                adcs    d6, d6, l
+        ldp     d6, d7, [x, #48]
+        extr    l, d6, d5, #63
+        adcs    d5, d5, h
+        extr    h, d7, d6, #63
+        adcs    d6, d6, l
 
-                extr    l, d8, d7, #63
-                adcs    d7, d7, h
-                and     l, l, #0x1FF
-                adcs    d8, d8, l
+        extr    l, d8, d7, #63
+        adcs    d7, d7, h
+        and     l, l, #0x1FF
+        adcs    d8, d8, l
 
 // We know x, x' < p_521 (they are the same bits except for the positions)
 // so x + x' + 1 <= 2 * (p_521 - 1) + 1 < 2 * p_521.
 // Note that x + x' >= p_521 <=> s = x + x' + 1 >= 2^521
 // Set CF <=> s = x + x' + 1 >= 2^521 and make it a mask in l as well
 
-                subs    l, d8, #512
-                csetm   l, cs
+        subs    l, d8, #512
+        csetm   l, cs
 
 // Now if CF is set (and l is all 1s), we want (x + x') - p_521 = s - 2^521
 // while otherwise we want x + x' = s - 1 (from existing CF, which is nice)
 
-                sbcs    d0, d0, xzr
-                and     l, l, #512
-                sbcs    d1, d1, xzr
-                sbcs    d2, d2, xzr
-                sbcs    d3, d3, xzr
-                sbcs    d4, d4, xzr
-                sbcs    d5, d5, xzr
-                sbcs    d6, d6, xzr
-                sbcs    d7, d7, xzr
-                sbc     d8, d8, l
+        sbcs    d0, d0, xzr
+        and     l, l, #512
+        sbcs    d1, d1, xzr
+        sbcs    d2, d2, xzr
+        sbcs    d3, d3, xzr
+        sbcs    d4, d4, xzr
+        sbcs    d5, d5, xzr
+        sbcs    d6, d6, xzr
+        sbcs    d7, d7, xzr
+        sbc     d8, d8, l
 
 // Store the result
 
-                stp     d0, d1, [z]
-                stp     d2, d3, [z, #16]
-                stp     d4, d5, [z, #32]
-                stp     d6, d7, [z, #48]
-                str     d8, [z, #64]
+        stp     d0, d1, [z]
+        stp     d2, d3, [z, #16]
+        stp     d4, d5, [z, #32]
+        stp     d6, d7, [z, #48]
+        str     d8, [z, #64]
 
-                ret
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
@@ -23,10 +23,18 @@
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
 
-        .globl  bignum_triple_p521
-        .globl  _bignum_triple_p521
-        .globl  bignum_triple_p521_alt
-        .globl  _bignum_triple_p521_alt
+        .globl bignum_triple_p521
+        .private_extern bignum_triple_p521
+
+        .globl _bignum_triple_p521
+        .private_extern _bignum_triple_p521
+
+        .globl bignum_triple_p521_alt
+        .private_extern bignum_triple_p521_alt
+
+        .globl _bignum_triple_p521_alt
+        .private_extern _bignum_triple_p521_alt
+
         .text
         .balign 4
 

--- a/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
@@ -22,18 +22,19 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p521
-        .private_extern bignum_triple_p521
+        S2N_ASM_HIDDEN(bignum_triple_p521)
 
         .globl _bignum_triple_p521
-        .private_extern _bignum_triple_p521
+        S2N_ASM_HIDDEN(_bignum_triple_p521)
 
         .globl bignum_triple_p521_alt
-        .private_extern bignum_triple_p521_alt
+        S2N_ASM_HIDDEN(bignum_triple_p521_alt)
 
         .globl _bignum_triple_p521_alt
-        .private_extern _bignum_triple_p521_alt
+        S2N_ASM_HIDDEN(_bignum_triple_p521_alt)
 
         .text
         .balign 4

--- a/third_party/s2n-bignum/include/_internal_s2n_bignum.h
+++ b/third_party/s2n-bignum/include/_internal_s2n_bignum.h
@@ -1,0 +1,18 @@
+
+#ifdef __APPLE__
+#define S2N_BN_SYM_VISIBILITY_DIRECTIVE(name) .globl _##name
+#ifdef S2N_BN_HIDE_SYMBOLS
+#define S2N_BN_SYM_PRIVACY_DIRECTIVE(name) .private_extern _##name
+#else
+#define S2N_BN_SYM_PRIVACY_DIRECTIVE(name)  /* NO-OP: S2N_BN_SYM_PRIVACY_DIRECTIVE */
+#endif
+#define S2N_BN_SYMBOL(name) _##name
+#else
+#define S2N_BN_SYM_VISIBILITY_DIRECTIVE(name) .globl name
+#ifdef S2N_BN_HIDE_SYMBOLS
+#define S2N_BN_SYM_PRIVACY_DIRECTIVE(name) .hidden name
+#else
+#define S2N_BN_SYM_PRIVACY_DIRECTIVE(name)  /* NO-OP: S2N_BN_SYM_PRIVACY_DIRECTIVE */
+#endif
+#define S2N_BN_SYMBOL(name) name
+#endif

--- a/third_party/s2n-bignum/include/_internal_s2n_bignum.h
+++ b/third_party/s2n-bignum/include/_internal_s2n_bignum.h
@@ -1,18 +1,19 @@
 
 #ifdef __APPLE__
-#define S2N_BN_SYM_VISIBILITY_DIRECTIVE(name) .globl _##name
-#ifdef S2N_BN_HIDE_SYMBOLS
-#define S2N_BN_SYM_PRIVACY_DIRECTIVE(name) .private_extern _##name
+#   define S2N_BN_SYM_VISIBILITY_DIRECTIVE(name) .globl _##name
+#   ifdef S2N_BN_HIDE_SYMBOLS
+#      define S2N_BN_SYM_PRIVACY_DIRECTIVE(name) .private_extern _##name
+#   else
+#      define S2N_BN_SYM_PRIVACY_DIRECTIVE(name)  /* NO-OP: S2N_BN_SYM_PRIVACY_DIRECTIVE */
+#   endif
+#   define S2N_BN_SYMBOL(name) _##name
 #else
-#define S2N_BN_SYM_PRIVACY_DIRECTIVE(name)  /* NO-OP: S2N_BN_SYM_PRIVACY_DIRECTIVE */
+#   define S2N_BN_SYM_VISIBILITY_DIRECTIVE(name) .globl name
+#   ifdef S2N_BN_HIDE_SYMBOLS
+#      define S2N_BN_SYM_PRIVACY_DIRECTIVE(name) .hidden name
+#   else
+#      define S2N_BN_SYM_PRIVACY_DIRECTIVE(name)  /* NO-OP: S2N_BN_SYM_PRIVACY_DIRECTIVE */
+#   endif
+#   define S2N_BN_SYMBOL(name) name
 #endif
-#define S2N_BN_SYMBOL(name) _##name
-#else
-#define S2N_BN_SYM_VISIBILITY_DIRECTIVE(name) .globl name
-#ifdef S2N_BN_HIDE_SYMBOLS
-#define S2N_BN_SYM_PRIVACY_DIRECTIVE(name) .hidden name
-#else
-#define S2N_BN_SYM_PRIVACY_DIRECTIVE(name)  /* NO-OP: S2N_BN_SYM_PRIVACY_DIRECTIVE */
-#endif
-#define S2N_BN_SYMBOL(name) name
-#endif
+

--- a/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
@@ -21,18 +21,13 @@
 //     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_add_p384
-        S2N_ASM_HIDDEN(bignum_add_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        S2N_ASM_HIDDEN(bignum_add_p384)
-        .globl _bignum_add_p384
-        S2N_ASM_HIDDEN(_bignum_add_p384)
-
-        S2N_ASM_HIDDEN(_bignum_add_p384)
-        .text
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p384)
 
 #define z %rdi
 #define x %rsi
@@ -55,8 +50,15 @@
 
 
 
-bignum_add_p384:
-_bignum_add_p384:
+S2N_BN_SYMBOL(bignum_add_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Add the inputs as 2^384 * c + [d5;d4;d3;d2;d1;d0] = x + y
 // This could be combined with the next block using ADCX and ADOX.
@@ -125,6 +127,10 @@ _bignum_add_p384:
         sbbq    $0, d5
         movq    d5, 40(z)
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
@@ -22,16 +22,16 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_add_p384
-        .private_extern bignum_add_p384
+        S2N_ASM_HIDDEN(bignum_add_p384)
 
-        .private_extern  bignum_add_p384
+        S2N_ASM_HIDDEN(bignum_add_p384)
         .globl _bignum_add_p384
-        .private_extern _bignum_add_p384
+        S2N_ASM_HIDDEN(_bignum_add_p384)
 
-        .private_extern  _bignum_add_p384
+        S2N_ASM_HIDDEN(_bignum_add_p384)
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
@@ -24,8 +24,14 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_add_p384
-        .globl  _bignum_add_p384
+        .globl bignum_add_p384
+        .private_extern bignum_add_p384
+
+        .private_extern  bignum_add_p384
+        .globl _bignum_add_p384
+        .private_extern _bignum_add_p384
+
+        .private_extern  _bignum_add_p384
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
@@ -36,12 +36,24 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_bigendian_6
-        .globl  _bignum_bigendian_6
-        .globl  bignum_frombebytes_6
-        .globl  _bignum_frombebytes_6
-        .globl  bignum_tobebytes_6
-        .globl  _bignum_tobebytes_6
+        .globl bignum_bigendian_6
+        .private_extern bignum_bigendian_6
+
+        .globl _bignum_bigendian_6
+        .private_extern _bignum_bigendian_6
+
+        .globl bignum_frombebytes_6
+        .private_extern bignum_frombebytes_6
+
+        .globl _bignum_frombebytes_6
+        .private_extern _bignum_frombebytes_6
+
+        .globl bignum_tobebytes_6
+        .private_extern bignum_tobebytes_6
+
+        .globl _bignum_tobebytes_6
+        .private_extern _bignum_tobebytes_6
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
@@ -33,26 +33,17 @@
 // word order, this is simply byte reversal and is implemented as such.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_bigendian_6
-        S2N_ASM_HIDDEN(bignum_bigendian_6)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_bigendian_6
-        S2N_ASM_HIDDEN(_bignum_bigendian_6)
-
-        .globl bignum_frombebytes_6
-        S2N_ASM_HIDDEN(bignum_frombebytes_6)
-
-        .globl _bignum_frombebytes_6
-        S2N_ASM_HIDDEN(_bignum_frombebytes_6)
-
-        .globl bignum_tobebytes_6
-        S2N_ASM_HIDDEN(bignum_tobebytes_6)
-
-        .globl _bignum_tobebytes_6
-        S2N_ASM_HIDDEN(_bignum_tobebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_bigendian_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_bigendian_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_frombebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_frombebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tobebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tobebytes_6)
 
         .text
 
@@ -67,41 +58,49 @@
 // pairs (0-5, 1-4, 2-3) to allow x and z to point to the same buffer
 // without using more intermediate registers.
 
-bignum_bigendian_6:
-_bignum_bigendian_6:
-bignum_frombebytes_6:
-_bignum_frombebytes_6:
-bignum_tobebytes_6:
-_bignum_tobebytes_6:
+S2N_BN_SYMBOL(bignum_bigendian_6):
+S2N_BN_SYMBOL(bignum_frombebytes_6):
+S2N_BN_SYMBOL(bignum_tobebytes_6):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // 0 and 5 words
 
-                movq    (x), a
-                movq    40(x), b
-                bswapq  a
-                bswapq  b
-                movq    a, 40(z)
-                movq    b, (z)
+        movq    (x), a
+        movq    40(x), b
+        bswapq  a
+        bswapq  b
+        movq    a, 40(z)
+        movq    b, (z)
 
 // 1 and 4 words
 
-                movq    8(x), a
-                movq    32(x), b
-                bswapq  a
-                bswapq  b
-                movq    a, 32(z)
-                movq    b, 8(z)
+        movq    8(x), a
+        movq    32(x), b
+        bswapq  a
+        bswapq  b
+        movq    a, 32(z)
+        movq    b, 8(z)
 
 // 2 and 3 words
 
-                movq    16(x), a
-                movq    24(x), b
-                bswapq  a
-                bswapq  b
-                movq    a, 24(z)
-                movq    b, 16(z)
+        movq    16(x), a
+        movq    24(x), b
+        bswapq  a
+        bswapq  b
+        movq    a, 24(z)
+        movq    b, 16(z)
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
@@ -34,25 +34,25 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_bigendian_6
-        .private_extern bignum_bigendian_6
+        S2N_ASM_HIDDEN(bignum_bigendian_6)
 
         .globl _bignum_bigendian_6
-        .private_extern _bignum_bigendian_6
+        S2N_ASM_HIDDEN(_bignum_bigendian_6)
 
         .globl bignum_frombebytes_6
-        .private_extern bignum_frombebytes_6
+        S2N_ASM_HIDDEN(bignum_frombebytes_6)
 
         .globl _bignum_frombebytes_6
-        .private_extern _bignum_frombebytes_6
+        S2N_ASM_HIDDEN(_bignum_frombebytes_6)
 
         .globl bignum_tobebytes_6
-        .private_extern bignum_tobebytes_6
+        S2N_ASM_HIDDEN(bignum_tobebytes_6)
 
         .globl _bignum_tobebytes_6
-        .private_extern _bignum_tobebytes_6
+        S2N_ASM_HIDDEN(_bignum_tobebytes_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
@@ -22,15 +22,13 @@
 //     (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
+// Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_cmul_p384
-        S2N_ASM_HIDDEN(bignum_cmul_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_cmul_p384
-        S2N_ASM_HIDDEN(_bignum_cmul_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384)
         .text
 
 #define z %rdi
@@ -57,17 +55,24 @@
 #define qshort %edx
 
 
-bignum_cmul_p384:
-_bignum_cmul_p384:
+S2N_BN_SYMBOL(bignum_cmul_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // We seem to need (just!) one extra register, which we need to save and restore
 
-                pushq   %r12
+        pushq   %r12
 
 // Shuffle inputs (since we want multiplier in %rdx)
 
-                movq    %rdx, x
-                movq    %rsi, m
+        movq    %rdx, x
+        movq    %rsi, m
 
 // Multiply, accumulating the result as 2^384 * h + [d5;d4;d3;d2;d1;d0]
 // but actually immediately producing q = h + 1, our quotient approximation,
@@ -75,18 +80,18 @@ _bignum_cmul_p384:
 // product is <= (2^64 - 1) * (p_384 - 1) and hence  h <= 2^64 - 2, meaning
 // there is no danger this addition of 1 could wrap.
 
-                mulxq   (x), d0, d1
-                mulxq   8(x), a, d2
-                addq    a, d1
-                mulxq   16(x), a, d3
-                adcq    a, d2
-                mulxq   24(x), a, d4
-                adcq    a, d3
-                mulxq   32(x), a, d5
-                adcq    a, d4
-                mulxq   40(x), a, q
-                adcq    a, d5
-                adcq    $1, q
+        mulxq   (x), d0, d1
+        mulxq   8(x), a, d2
+        addq    a, d1
+        mulxq   16(x), a, d3
+        adcq    a, d2
+        mulxq   24(x), a, d4
+        adcq    a, d3
+        mulxq   32(x), a, d5
+        adcq    a, d4
+        mulxq   40(x), a, q
+        adcq    a, d5
+        adcq    $1, q
 
 // It's easy to see -p_384 <= z - q * p_384 < p_384, so we just need to
 // subtract q * p_384 and then correct if that is negative by adding p_384.
@@ -98,24 +103,24 @@ _bignum_cmul_p384:
 //       = 2^384 * (h - q) + (l + q * r)
 //       = 2^384 * (-1) + (l + q * r)
 
-                xorq    c, c
-                movq    $0xffffffff00000001, a
-                mulxq   a, a, c
-                adcxq   a, d0
-                adoxq   c, d1
-                movl    $0x00000000ffffffff, ashort
-                mulxq   a, a, c
-                adcxq   a, d1
-                adoxq   c, d2
-                adcxq   q, d2
-                movl    $0, ashort
-                movl    $0, cshort
-                adoxq   a, a
-                adcq    a, d3
-                adcq    c, d4
-                adcq    c, d5
-                adcq    c, c
-                subq    $1, c
+        xorq    c, c
+        movq    $0xffffffff00000001, a
+        mulxq   a, a, c
+        adcxq   a, d0
+        adoxq   c, d1
+        movl    $0x00000000ffffffff, ashort
+        mulxq   a, a, c
+        adcxq   a, d1
+        adoxq   c, d2
+        adcxq   q, d2
+        movl    $0, ashort
+        movl    $0, cshort
+        adoxq   a, a
+        adcq    a, d3
+        adcq    c, d4
+        adcq    c, d5
+        adcq    c, c
+        subq    $1, c
 
 // The net c value is now the top word of the 7-word answer, hence will
 // be -1 if we need a corrective addition, 0 otherwise, usable as a mask.
@@ -123,29 +128,33 @@ _bignum_cmul_p384:
 // fact done by a masked subtraction of 2^384 - p_384, so that we only
 // have three nonzero digits and so can avoid using another register.
 
-                movl    $0x00000000ffffffff, qshort
-                xorq    a, a
-                andq    c, q
-                subq    q, a
-                andq    $1, c
+        movl    $0x00000000ffffffff, qshort
+        xorq    a, a
+        andq    c, q
+        subq    q, a
+        andq    $1, c
 
-                subq    a, d0
-                movq    d0, (z)
-                sbbq    q, d1
-                movq    d1, 8(z)
-                sbbq    c, d2
-                movq    d2, 16(z)
-                sbbq    $0, d3
-                movq    d3, 24(z)
-                sbbq    $0, d4
-                movq    d4, 32(z)
-                sbbq    $0, d5
-                movq    d5, 40(z)
+        subq    a, d0
+        movq    d0, (z)
+        sbbq    q, d1
+        movq    d1, 8(z)
+        sbbq    c, d2
+        movq    d2, 16(z)
+        sbbq    $0, d3
+        movq    d3, 24(z)
+        sbbq    $0, d4
+        movq    d4, 32(z)
+        sbbq    $0, d5
+        movq    d5, 40(z)
 
 // Return
 
-                popq    %r12
-                ret
+        popq    %r12
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_cmul_p384
-        .globl  _bignum_cmul_p384
+        .globl bignum_cmul_p384
+        .private_extern bignum_cmul_p384
+
+        .globl _bignum_cmul_p384
+        .private_extern _bignum_cmul_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p384
-        .private_extern bignum_cmul_p384
+        S2N_ASM_HIDDEN(bignum_cmul_p384)
 
         .globl _bignum_cmul_p384
-        .private_extern _bignum_cmul_p384
+        S2N_ASM_HIDDEN(_bignum_cmul_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p384_alt
-        .private_extern bignum_cmul_p384_alt
+        S2N_ASM_HIDDEN(bignum_cmul_p384_alt)
 
         .globl _bignum_cmul_p384_alt
-        .private_extern _bignum_cmul_p384_alt
+        S2N_ASM_HIDDEN(_bignum_cmul_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_cmul_p384_alt
-        .globl  _bignum_cmul_p384_alt
+        .globl bignum_cmul_p384_alt
+        .private_extern bignum_cmul_p384_alt
+
+        .globl _bignum_cmul_p384_alt
+        .private_extern _bignum_cmul_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
@@ -22,16 +22,13 @@
 //     (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
+// Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_cmul_p384_alt
-        S2N_ASM_HIDDEN(bignum_cmul_p384_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_cmul_p384_alt
-        S2N_ASM_HIDDEN(_bignum_cmul_p384_alt)
-
-        .text
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384_alt)
 
 #define z %rdi
 
@@ -61,16 +58,23 @@
 #define cshort %ecx
 #define qshort %ecx
 
-bignum_cmul_p384_alt:
-_bignum_cmul_p384_alt:
+S2N_BN_SYMBOL(bignum_cmul_p384_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // We seem to need (just!) one extra register, which we need to save and restore
 
-                pushq   %r12
+        pushq   %r12
 
 // Shuffle inputs (since we want %rdx for the high parts of products)
 
-                movq    %rdx, x
+        movq    %rdx, x
 
 // Multiply, accumulating the result as 2^384 * h + [d5;d4;d3;d2;d1;d0]
 // but actually immediately producing q = h + 1, our quotient approximation,
@@ -78,41 +82,41 @@ _bignum_cmul_p384_alt:
 // product is <= (2^64 - 1) * (p_384 - 1) and hence  h <= 2^64 - 2, meaning
 // there is no danger this addition of 1 could wrap.
 
-                movq    (x), a
-                mulq    m
-                movq    a, d0
-                movq    d, d1
+        movq    (x), a
+        mulq    m
+        movq    a, d0
+        movq    d, d1
 
-                movq    8(x), a
-                mulq    m
-                xorq    d2, d2
-                addq    a, d1
-                adcq    d, d2
+        movq    8(x), a
+        mulq    m
+        xorq    d2, d2
+        addq    a, d1
+        adcq    d, d2
 
-                movq    16(x), a
-                mulq    m
-                xorq    d3, d3
-                addq    a, d2
-                adcq    d, d3
+        movq    16(x), a
+        mulq    m
+        xorq    d3, d3
+        addq    a, d2
+        adcq    d, d3
 
-                movq    24(x), a
-                mulq    m
-                xorq    d4, d4
-                addq    a, d3
-                adcq    d, d4
+        movq    24(x), a
+        mulq    m
+        xorq    d4, d4
+        addq    a, d3
+        adcq    d, d4
 
-                movq    32(x), a
-                mulq    m
-                addq    a, d4
-                adcq    $0, d
+        movq    32(x), a
+        mulq    m
+        addq    a, d4
+        adcq    $0, d
 
-                movq    m, a
-                movq    d, d5
-                mulq     40(x)
-                movl    $1, qshort
+        movq    m, a
+        movq    d, d5
+        mulq     40(x)
+        movl    $1, qshort
 
-                addq    a, d5
-                adcq    d, q
+        addq    a, d5
+        adcq    d, q
 
 // It's easy to see -p_384 <= z - q * p_384 < p_384, so we just need to
 // subtract q * p_384 and then correct if that is negative by adding p_384.
@@ -124,23 +128,23 @@ _bignum_cmul_p384_alt:
 //       = 2^384 * (h - q) + (l + q * r)
 //       = 2^384 * (-1) + (l + q * r)
 
-                movq    $0xffffffff00000001, a
-                mulq    q
-                addq    a, d0
-                adcq    d, d1
-                adcq    q, d2
-                movq    q, a
-                sbbq    c, c
-                movl    $0x00000000ffffffff, dshort
-                negq    c
-                mulq    d
-                addq    a, d1
-                adcq    d, d2
-                adcq    c, d3
-                adcq    $0, d4
-                adcq    $0, d5
-                sbbq    c, c
-                notq    c
+        movq    $0xffffffff00000001, a
+        mulq    q
+        addq    a, d0
+        adcq    d, d1
+        adcq    q, d2
+        movq    q, a
+        sbbq    c, c
+        movl    $0x00000000ffffffff, dshort
+        negq    c
+        mulq    d
+        addq    a, d1
+        adcq    d, d2
+        adcq    c, d3
+        adcq    $0, d4
+        adcq    $0, d5
+        sbbq    c, c
+        notq    c
 
 // The net c value is now the top word of the 7-word answer, hence will
 // be -1 if we need a corrective addition, 0 otherwise, usable as a mask.
@@ -148,29 +152,33 @@ _bignum_cmul_p384_alt:
 // fact done by a masked subtraction of 2^384 - p_384, so that we only
 // have three nonzero digits and so can avoid using another register.
 
-                movl    $0x00000000ffffffff, dshort
-                xorq    a, a
-                andq    c, d
-                subq    d, a
-                andq    $1, c
+        movl    $0x00000000ffffffff, dshort
+        xorq    a, a
+        andq    c, d
+        subq    d, a
+        andq    $1, c
 
-                subq    a, d0
-                movq    d0, (z)
-                sbbq    d, d1
-                movq    d1, 8(z)
-                sbbq    c, d2
-                movq    d2, 16(z)
-                sbbq    $0, d3
-                movq    d3, 24(z)
-                sbbq    $0, d4
-                movq    d4, 32(z)
-                sbbq    $0, d5
-                movq    d5, 40(z)
+        subq    a, d0
+        movq    d0, (z)
+        sbbq    d, d1
+        movq    d1, 8(z)
+        sbbq    c, d2
+        movq    d2, 16(z)
+        sbbq    $0, d3
+        movq    d3, 24(z)
+        sbbq    $0, d4
+        movq    d4, 32(z)
+        sbbq    $0, d5
+        movq    d5, 40(z)
 
 // Return
 
-                popq    %r12
-                ret
+        popq    %r12
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
@@ -24,17 +24,13 @@
 // "almost" meaning any 6-digit input will work, with no range restriction.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_deamont_p384
-        S2N_ASM_HIDDEN(bignum_deamont_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_deamont_p384
-        S2N_ASM_HIDDEN(_bignum_deamont_p384)
-
-        .text
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384)
 #define z %rdi
 #define x %rsi
 
@@ -60,31 +56,37 @@
 
 #define montreds(d6,d5,d4,d3,d2,d1,d0)                                  \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
-                movq    d0, %rdx ;                                        \
-                shlq    $32, %rdx ;                                        \
-                addq    d0, %rdx ;                                        \
+        movq    d0, %rdx ;                                        \
+        shlq    $32, %rdx ;                                        \
+        addq    d0, %rdx ;                                        \
 /* Construct [%rsi;%rcx;%rax;-] = (2^384 - p_384) * w           */         \
 /* We know the lowest word will cancel so we can re-use d0   */         \
 /* as a temp.                                                */         \
-                xorq    %rsi, %rsi ;                                       \
-                movq    $0xffffffff00000001, %rax ;                        \
-                mulxq   %rax, %rcx, %rax ;                                  \
-                movl    $0x00000000ffffffff, %ecx ;                        \
-                mulxq   %rcx, d0, %rcx ;                                   \
-                adcq    d0, %rax ;                                        \
-                adcq    %rdx, %rcx ;                                       \
-                adcq    $0, %rsi ;                                         \
+        xorq    %rsi, %rsi ;                                       \
+        movq    $0xffffffff00000001, %rax ;                        \
+        mulxq   %rax, %rcx, %rax ;                                  \
+        movl    $0x00000000ffffffff, %ecx ;                        \
+        mulxq   %rcx, d0, %rcx ;                                   \
+        adcq    d0, %rax ;                                        \
+        adcq    %rdx, %rcx ;                                       \
+        adcq    $0, %rsi ;                                         \
 /* Now subtract that and add 2^384 * w                       */         \
-                subq    %rax, d1 ;                                        \
-                sbbq    %rcx, d2 ;                                        \
-                sbbq    %rsi, d3 ;                                        \
-                sbbq    $0, d4 ;                                          \
-                sbbq    $0, d5 ;                                          \
-                movq    %rdx, d6 ;                                        \
-                sbbq    $0, d6
+        subq    %rax, d1 ;                                        \
+        sbbq    %rcx, d2 ;                                        \
+        sbbq    %rsi, d3 ;                                        \
+        sbbq    $0, d4 ;                                          \
+        sbbq    $0, d5 ;                                          \
+        movq    %rdx, d6 ;                                        \
+        sbbq    $0, d6
 
-bignum_deamont_p384:
-_bignum_deamont_p384:
+S2N_BN_SYMBOL(bignum_deamont_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save more registers to play with
 
@@ -175,6 +177,10 @@ _bignum_deamont_p384:
         popq    %r13
         popq    %r12
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_deamont_p384
-        .private_extern bignum_deamont_p384
+        S2N_ASM_HIDDEN(bignum_deamont_p384)
 
         .globl _bignum_deamont_p384
-        .private_extern _bignum_deamont_p384
+        S2N_ASM_HIDDEN(_bignum_deamont_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_deamont_p384
-        .globl  _bignum_deamont_p384
+        .globl bignum_deamont_p384
+        .private_extern bignum_deamont_p384
+
+        .globl _bignum_deamont_p384
+        .private_extern _bignum_deamont_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_deamont_p384_alt
-        .private_extern bignum_deamont_p384_alt
+        S2N_ASM_HIDDEN(bignum_deamont_p384_alt)
 
         .globl _bignum_deamont_p384_alt
-        .private_extern _bignum_deamont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_deamont_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_deamont_p384_alt
-        .globl  _bignum_deamont_p384_alt
+        .globl bignum_deamont_p384_alt
+        .private_extern bignum_deamont_p384_alt
+
+        .globl _bignum_deamont_p384_alt
+        .private_extern _bignum_deamont_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
@@ -24,16 +24,13 @@
 // "almost" meaning any 6-digit input will work, with no range restriction.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_deamont_p384_alt
-        S2N_ASM_HIDDEN(bignum_deamont_p384_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_deamont_p384_alt
-        S2N_ASM_HIDDEN(_bignum_deamont_p384_alt)
-
-        .text
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384_alt)
 
 #define z %rdi
 #define x %rsi
@@ -59,32 +56,38 @@
 
 #define montreds(d6,d5,d4,d3,d2,d1,d0)                                  \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
-                movq    d0, %rcx ;                                        \
-                shlq    $32, %rcx ;                                        \
-                addq    d0, %rcx ;                                        \
+        movq    d0, %rcx ;                                        \
+        shlq    $32, %rcx ;                                        \
+        addq    d0, %rcx ;                                        \
 /* Construct [%rax;%rdx;d0;-] = (2^384 - p_384) * w            */         \
 /* We know the lowest word will cancel so we can re-use d0   */         \
 /* and %rcx as temps.                                         */         \
-                movq    $0xffffffff00000001, %rax ;                        \
-                mulq    %rcx;                                            \
-                movq    %rdx, d0 ;                                        \
-                movq    $0x00000000ffffffff, %rax ;                        \
-                mulq    %rcx;                                            \
-                addq    %rax, d0 ;                                        \
-                movl    $0, %eax ;                                         \
-                adcq    %rcx, %rdx ;                                       \
-                adcl    %eax, %eax ;                                       \
+        movq    $0xffffffff00000001, %rax ;                        \
+        mulq    %rcx;                                            \
+        movq    %rdx, d0 ;                                        \
+        movq    $0x00000000ffffffff, %rax ;                        \
+        mulq    %rcx;                                            \
+        addq    %rax, d0 ;                                        \
+        movl    $0, %eax ;                                         \
+        adcq    %rcx, %rdx ;                                       \
+        adcl    %eax, %eax ;                                       \
 /* Now subtract that and add 2^384 * w                       */         \
-                subq    d0, d1 ;                                         \
-                sbbq    %rdx, d2 ;                                        \
-                sbbq    %rax, d3 ;                                        \
-                sbbq    $0, d4 ;                                          \
-                sbbq    $0, d5 ;                                          \
-                movq    %rcx, d6 ;                                        \
-                sbbq    $0, d6
+        subq    d0, d1 ;                                         \
+        sbbq    %rdx, d2 ;                                        \
+        sbbq    %rax, d3 ;                                        \
+        sbbq    $0, d4 ;                                          \
+        sbbq    $0, d5 ;                                          \
+        movq    %rcx, d6 ;                                        \
+        sbbq    $0, d6
 
-bignum_deamont_p384_alt:
-_bignum_deamont_p384_alt:
+S2N_BN_SYMBOL(bignum_deamont_p384_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save more registers to play with
 
@@ -175,6 +178,10 @@ _bignum_deamont_p384_alt:
         popq    %r13
         popq    %r12
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_demont_p384
-        .private_extern bignum_demont_p384
+        S2N_ASM_HIDDEN(bignum_demont_p384)
 
         .globl _bignum_demont_p384
-        .private_extern _bignum_demont_p384
+        S2N_ASM_HIDDEN(_bignum_demont_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
@@ -24,16 +24,13 @@
 // use the variant "bignum_deamont_p384" instead.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_demont_p384
-        S2N_ASM_HIDDEN(bignum_demont_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_demont_p384
-        S2N_ASM_HIDDEN(_bignum_demont_p384)
-
-        .text
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384)
 
 #define z %rdi
 #define x %rsi
@@ -52,31 +49,37 @@
 
 #define montreds(d6,d5,d4,d3,d2,d1,d0)                                  \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
-                movq    d0, %rdx ;                                        \
-                shlq    $32, %rdx ;                                        \
-                addq    d0, %rdx ;                                        \
+        movq    d0, %rdx ;                                        \
+        shlq    $32, %rdx ;                                        \
+        addq    d0, %rdx ;                                        \
 /* Construct [%rsi;%rcx;%rax;-] = (2^384 - p_384) * w           */         \
 /* We know the lowest word will cancel so we can re-use d0   */         \
 /* as a temp.                                                */         \
-                xorq    %rsi, %rsi ;                                       \
-                movq    $0xffffffff00000001, %rax ;                        \
-                mulxq   %rax, %rcx, %rax ;                                  \
-                movl    $0x00000000ffffffff, %ecx ;                        \
-                mulxq   %rcx, d0, %rcx ;                                   \
-                adcq    d0, %rax ;                                        \
-                adcq    %rdx, %rcx ;                                       \
-                adcq    $0, %rsi ;                                         \
+        xorq    %rsi, %rsi ;                                       \
+        movq    $0xffffffff00000001, %rax ;                        \
+        mulxq   %rax, %rcx, %rax ;                                  \
+        movl    $0x00000000ffffffff, %ecx ;                        \
+        mulxq   %rcx, d0, %rcx ;                                   \
+        adcq    d0, %rax ;                                        \
+        adcq    %rdx, %rcx ;                                       \
+        adcq    $0, %rsi ;                                         \
 /* Now subtract that and add 2^384 * w                       */         \
-                subq    %rax, d1 ;                                        \
-                sbbq    %rcx, d2 ;                                        \
-                sbbq    %rsi, d3 ;                                        \
-                sbbq    $0, d4 ;                                          \
-                sbbq    $0, d5 ;                                          \
-                movq    %rdx, d6 ;                                        \
-                sbbq    $0, d6
+        subq    %rax, d1 ;                                        \
+        sbbq    %rcx, d2 ;                                        \
+        sbbq    %rsi, d3 ;                                        \
+        sbbq    $0, d4 ;                                          \
+        sbbq    $0, d5 ;                                          \
+        movq    %rdx, d6 ;                                        \
+        sbbq    $0, d6
 
-bignum_demont_p384:
-_bignum_demont_p384:
+S2N_BN_SYMBOL(bignum_demont_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save more registers to play with
 
@@ -130,6 +133,10 @@ _bignum_demont_p384:
         popq    %r13
         popq    %r12
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_demont_p384
-        .globl  _bignum_demont_p384
+        .globl bignum_demont_p384
+        .private_extern bignum_demont_p384
+
+        .globl _bignum_demont_p384
+        .private_extern _bignum_demont_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
@@ -24,16 +24,13 @@
 // use the variant "bignum_deamont_p384" instead.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_demont_p384_alt
-        S2N_ASM_HIDDEN(bignum_demont_p384_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_demont_p384_alt
-        S2N_ASM_HIDDEN(_bignum_demont_p384_alt)
-
-        .text
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384_alt)
 
 #define z %rdi
 #define x %rsi
@@ -51,32 +48,38 @@
 
 #define montreds(d6,d5,d4,d3,d2,d1,d0)                                  \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
-                movq    d0, %rcx ;                                        \
-                shlq    $32, %rcx ;                                        \
-                addq    d0, %rcx ;                                        \
+        movq    d0, %rcx ;                                        \
+        shlq    $32, %rcx ;                                        \
+        addq    d0, %rcx ;                                        \
 /* Construct [%rax;%rdx;d0;-] = (2^384 - p_384) * w            */         \
 /* We know the lowest word will cancel so we can re-use d0   */         \
 /* and %rcx as temps.                                         */         \
-                movq    $0xffffffff00000001, %rax ;                        \
-                mulq    %rcx;                                            \
-                movq    %rdx, d0 ;                                        \
-                movq    $0x00000000ffffffff, %rax ;                        \
-                mulq    %rcx;                                            \
-                addq    %rax, d0 ;                                        \
-                movl    $0, %eax ;                                         \
-                adcq    %rcx, %rdx ;                                       \
-                adcl    %eax, %eax ;                                       \
+        movq    $0xffffffff00000001, %rax ;                        \
+        mulq    %rcx;                                            \
+        movq    %rdx, d0 ;                                        \
+        movq    $0x00000000ffffffff, %rax ;                        \
+        mulq    %rcx;                                            \
+        addq    %rax, d0 ;                                        \
+        movl    $0, %eax ;                                         \
+        adcq    %rcx, %rdx ;                                       \
+        adcl    %eax, %eax ;                                       \
 /* Now subtract that and add 2^384 * w                       */         \
-                subq    d0, d1 ;                                         \
-                sbbq    %rdx, d2 ;                                        \
-                sbbq    %rax, d3 ;                                        \
-                sbbq    $0, d4 ;                                          \
-                sbbq    $0, d5 ;                                          \
-                movq    %rcx, d6 ;                                        \
-                sbbq    $0, d6
+        subq    d0, d1 ;                                         \
+        sbbq    %rdx, d2 ;                                        \
+        sbbq    %rax, d3 ;                                        \
+        sbbq    $0, d4 ;                                          \
+        sbbq    $0, d5 ;                                          \
+        movq    %rcx, d6 ;                                        \
+        sbbq    $0, d6
 
-bignum_demont_p384_alt:
-_bignum_demont_p384_alt:
+S2N_BN_SYMBOL(bignum_demont_p384_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save more registers to play with
 
@@ -130,6 +133,10 @@ _bignum_demont_p384_alt:
         popq    %r13
         popq    %r12
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_demont_p384_alt
-        .globl  _bignum_demont_p384_alt
+        .globl bignum_demont_p384_alt
+        .private_extern bignum_demont_p384_alt
+
+        .globl _bignum_demont_p384_alt
+        .private_extern _bignum_demont_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_demont_p384_alt
-        .private_extern bignum_demont_p384_alt
+        S2N_ASM_HIDDEN(bignum_demont_p384_alt)
 
         .globl _bignum_demont_p384_alt
-        .private_extern _bignum_demont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_demont_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_double_p384
-        .private_extern bignum_double_p384
+        S2N_ASM_HIDDEN(bignum_double_p384)
 
         .globl _bignum_double_p384
-        .private_extern _bignum_double_p384
+        S2N_ASM_HIDDEN(_bignum_double_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_double_p384
-        .globl  _bignum_double_p384
+        .globl bignum_double_p384
+        .private_extern bignum_double_p384
+
+        .globl _bignum_double_p384
+        .private_extern _bignum_double_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
@@ -21,15 +21,13 @@
 //     (uint64_t z[static 6], uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_double_p384
-        S2N_ASM_HIDDEN(bignum_double_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_double_p384
-        S2N_ASM_HIDDEN(_bignum_double_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p384)
         .text
 
 #define z %rdi
@@ -51,8 +49,14 @@
 
 
 
-bignum_double_p384:
-_bignum_double_p384:
+S2N_BN_SYMBOL(bignum_double_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Load the input and double it so that 2^384 * c + [d5;d4;d3;d2;d1;d0] = 2 * x
 // Could also consider using shld to decouple carries *or* combining this
@@ -122,6 +126,10 @@ _bignum_double_p384:
         sbbq    $0, d5
         movq    d5, 40(z)
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
@@ -21,15 +21,13 @@
 //     (uint64_t z[static 6], uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_half_p384
-        S2N_ASM_HIDDEN(bignum_half_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_half_p384
-        S2N_ASM_HIDDEN(_bignum_half_p384)
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p384)
         .text
 
 #define z %rdi
@@ -48,57 +46,67 @@
 
 
 
-bignum_half_p384:
-_bignum_half_p384:
+S2N_BN_SYMBOL(bignum_half_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Load lowest digit and get a mask for its lowest bit in d3
 
-                movq    (x), a
-                movl    $1, d3short
-                andq    a, d3
-                negq    d3
+        movq    (x), a
+        movl    $1, d3short
+        andq    a, d3
+        negq    d3
 
 // Create a masked version of p_384 (top 3 words = the mask itself)
 
-                movl    $0x00000000ffffffff, d0short
-                andq    d3, d0
-                movq    d0, d1
-                xorq    d3, d1
-                movq    d3, d2
-                addq    d2, d2
-                andq    d3, d2
-                movq    d3, d4
-                movq    d3, d5
+        movl    $0x00000000ffffffff, d0short
+        andq    d3, d0
+        movq    d0, d1
+        xorq    d3, d1
+        movq    d3, d2
+        addq    d2, d2
+        andq    d3, d2
+        movq    d3, d4
+        movq    d3, d5
 
 // Perform addition with masked p_384. Catch the carry in a, as a bitmask
 // for convenience though we only use its LSB below with SHRD
 
-                addq    a, d0
-                adcq    8(x), d1
-                adcq    16(x), d2
-                adcq    24(x), d3
-                adcq    32(x), d4
-                adcq    40(x), d5
-                sbbq    a, a
+        addq    a, d0
+        adcq    8(x), d1
+        adcq    16(x), d2
+        adcq    24(x), d3
+        adcq    32(x), d4
+        adcq    40(x), d5
+        sbbq    a, a
 
 // Shift right, pushing the carry back down, and store back
 
-                shrdq   $1, d1, d0
-                movq    d0, (z)
-                shrdq   $1, d2, d1
-                movq    d1, 8(z)
-                shrdq   $1, d3, d2
-                movq    d2, 16(z)
-                shrdq   $1, d4, d3
-                movq    d3, 24(z)
-                shrdq   $1, d5, d4
-                movq    d4, 32(z)
-                shrdq   $1, a, d5
-                movq    d5, 40(z)
+        shrdq   $1, d1, d0
+        movq    d0, (z)
+        shrdq   $1, d2, d1
+        movq    d1, 8(z)
+        shrdq   $1, d3, d2
+        movq    d2, 16(z)
+        shrdq   $1, d4, d3
+        movq    d3, 24(z)
+        shrdq   $1, d5, d4
+        movq    d4, 32(z)
+        shrdq   $1, a, d5
+        movq    d5, 40(z)
 
 // Return
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_half_p384
-        .globl  _bignum_half_p384
+        .globl bignum_half_p384
+        .private_extern bignum_half_p384
+
+        .globl _bignum_half_p384
+        .private_extern _bignum_half_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_half_p384
-        .private_extern bignum_half_p384
+        S2N_ASM_HIDDEN(bignum_half_p384)
 
         .globl _bignum_half_p384
-        .private_extern _bignum_half_p384
+        S2N_ASM_HIDDEN(_bignum_half_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
@@ -35,12 +35,24 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_littleendian_6
-        .globl  _bignum_littleendian_6
-        .globl  bignum_fromlebytes_6
-        .globl  _bignum_fromlebytes_6
-        .globl  bignum_tolebytes_6
-        .globl  _bignum_tolebytes_6
+        .globl bignum_littleendian_6
+        .private_extern bignum_littleendian_6
+
+        .globl _bignum_littleendian_6
+        .private_extern _bignum_littleendian_6
+
+        .globl bignum_fromlebytes_6
+        .private_extern bignum_fromlebytes_6
+
+        .globl _bignum_fromlebytes_6
+        .private_extern _bignum_fromlebytes_6
+
+        .globl bignum_tolebytes_6
+        .private_extern bignum_tolebytes_6
+
+        .globl _bignum_tolebytes_6
+        .private_extern _bignum_tolebytes_6
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
@@ -33,25 +33,25 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_littleendian_6
-        .private_extern bignum_littleendian_6
+        S2N_ASM_HIDDEN(bignum_littleendian_6)
 
         .globl _bignum_littleendian_6
-        .private_extern _bignum_littleendian_6
+        S2N_ASM_HIDDEN(_bignum_littleendian_6)
 
         .globl bignum_fromlebytes_6
-        .private_extern bignum_fromlebytes_6
+        S2N_ASM_HIDDEN(bignum_fromlebytes_6)
 
         .globl _bignum_fromlebytes_6
-        .private_extern _bignum_fromlebytes_6
+        S2N_ASM_HIDDEN(_bignum_fromlebytes_6)
 
         .globl bignum_tolebytes_6
-        .private_extern bignum_tolebytes_6
+        S2N_ASM_HIDDEN(bignum_tolebytes_6)
 
         .globl _bignum_tolebytes_6
-        .private_extern _bignum_tolebytes_6
+        S2N_ASM_HIDDEN(_bignum_tolebytes_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
@@ -32,26 +32,17 @@
 // Since x86 is little-endian, this is just copying.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_littleendian_6
-        S2N_ASM_HIDDEN(bignum_littleendian_6)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_littleendian_6
-        S2N_ASM_HIDDEN(_bignum_littleendian_6)
-
-        .globl bignum_fromlebytes_6
-        S2N_ASM_HIDDEN(bignum_fromlebytes_6)
-
-        .globl _bignum_fromlebytes_6
-        S2N_ASM_HIDDEN(_bignum_fromlebytes_6)
-
-        .globl bignum_tolebytes_6
-        S2N_ASM_HIDDEN(bignum_tolebytes_6)
-
-        .globl _bignum_tolebytes_6
-        S2N_ASM_HIDDEN(_bignum_tolebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_littleendian_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_littleendian_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_fromlebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tolebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tolebytes_6)
 
         .text
 
@@ -59,32 +50,40 @@
 #define x %rsi
 #define a %rax
 
-bignum_littleendian_6:
-_bignum_littleendian_6:
-bignum_fromlebytes_6:
-_bignum_fromlebytes_6:
-bignum_tolebytes_6:
-_bignum_tolebytes_6:
+S2N_BN_SYMBOL(bignum_littleendian_6):
+S2N_BN_SYMBOL(bignum_fromlebytes_6):
+S2N_BN_SYMBOL(bignum_tolebytes_6):
 
-                movq    (x), a
-                movq    a, (z)
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
-                movq    8(x), a
-                movq    a, 8(z)
+        movq    (x), a
+        movq    a, (z)
 
-                movq    16(x), a
-                movq    a, 16(z)
+        movq    8(x), a
+        movq    a, 8(z)
 
-                movq    24(x), a
-                movq    a, 24(z)
+        movq    16(x), a
+        movq    a, 16(z)
 
-                movq    32(x), a
-                movq    a, 32(z)
+        movq    24(x), a
+        movq    a, 24(z)
 
-                movq    40(x), a
-                movq    a, 40(z)
+        movq    32(x), a
+        movq    a, 32(z)
 
-                ret
+        movq    40(x), a
+        movq    a, 40(z)
+
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
@@ -26,8 +26,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_n384
-        .globl  _bignum_mod_n384
+        .globl bignum_mod_n384
+        .private_extern bignum_mod_n384
+
+        .globl _bignum_mod_n384
+        .private_extern _bignum_mod_n384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
@@ -24,13 +24,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n384
-        .private_extern bignum_mod_n384
+        S2N_ASM_HIDDEN(bignum_mod_n384)
 
         .globl _bignum_mod_n384
-        .private_extern _bignum_mod_n384
+        S2N_ASM_HIDDEN(_bignum_mod_n384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
@@ -23,14 +23,13 @@
 // Reduction is modulo the group order of the NIST curve P-384.
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
+// Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mod_n384
-        S2N_ASM_HIDDEN(bignum_mod_n384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mod_n384
-        S2N_ASM_HIDDEN(_bignum_mod_n384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384)
 
         .text
 
@@ -55,173 +54,184 @@
 #define qshort %edx
 
 
-bignum_mod_n384:
-_bignum_mod_n384:
+S2N_BN_SYMBOL(bignum_mod_n384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save extra registers
 
-                pushq   %rbx
-                pushq   %r12
-                pushq   %r13
-                pushq   %r14
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
 
 // If the input is already <= 5 words long, go to a trivial "copy" path
 
-                cmpq    $6, k
-                jc      shortinput
+        cmpq    $6, k
+        jc      shortinput
 
 // Otherwise load the top 6 digits (top-down) and reduce k by 6
 
-                subq    $6, k
-                movq    40(%rdx,k,8), m5
-                movq    32(%rdx,k,8), m4
-                movq    24(%rdx,k,8), m3
-                movq    16(%rdx,k,8), m2
-                movq    8(%rdx,k,8), m1
-                movq    (%rdx,k,8), m0
+        subq    $6, k
+        movq    40(%rdx,k,8), m5
+        movq    32(%rdx,k,8), m4
+        movq    24(%rdx,k,8), m3
+        movq    16(%rdx,k,8), m2
+        movq    8(%rdx,k,8), m1
+        movq    (%rdx,k,8), m0
 
 // Move x into another register to leave %rdx free for multiplies and use of n2
 
-                movq    %rdx, x
+        movq    %rdx, x
 
 // Reduce the top 6 digits mod n_384 (a conditional subtraction of n_384)
 
-                movq    $0x1313e695333ad68d, n0
-                movq    $0xa7e5f24db74f5885, n1
-                movq    $0x389cb27e0bc8d220, n2
+        movq    $0x1313e695333ad68d, n0
+        movq    $0xa7e5f24db74f5885, n1
+        movq    $0x389cb27e0bc8d220, n2
 
-                addq    n0, m0
-                adcq    n1, m1
-                adcq    n2, m2
-                adcq    $0, m3
-                adcq    $0, m4
-                adcq    $0, m5
-                sbbq    d, d
-                notq    d
-                andq    d, n0
-                andq    d, n1
-                andq    d, n2
-                subq    n0, m0
-                sbbq    n1, m1
-                sbbq    n2, m2
-                sbbq    $0, m3
-                sbbq    $0, m4
-                sbbq    $0, m5
+        addq    n0, m0
+        adcq    n1, m1
+        adcq    n2, m2
+        adcq    $0, m3
+        adcq    $0, m4
+        adcq    $0, m5
+        sbbq    d, d
+        notq    d
+        andq    d, n0
+        andq    d, n1
+        andq    d, n2
+        subq    n0, m0
+        sbbq    n1, m1
+        sbbq    n2, m2
+        sbbq    $0, m3
+        sbbq    $0, m4
+        sbbq    $0, m5
 
 // Now do (k-6) iterations of 7->6 word modular reduction
 
-                testq   k, k
-                jz      writeback
+        testq   k, k
+        jz      writeback
 
 loop:
 
 // Compute q = min (m5 + 1) (2^64 - 1)
 
-                movl    $1, qshort
-                addq    m5, q
-                sbbq    d, d
-                orq     d, q
+        movl    $1, qshort
+        addq    m5, q
+        sbbq    d, d
+        orq     d, q
 
 // Load the next digit so current m to reduce = [m5;m4;m3;m2;m1;m0;d]
 
-                movq    -8(x,k,8), d
+        movq    -8(x,k,8), d
 
 // Now form [m5;m4;m3;m2;m1;m0;d] = m - q * n_384
 
-                subq    q, m5
-                xorq    n0, n0
-                movq    $0x1313e695333ad68d, n0
-                mulxq   n0, n0, n1
-                adcxq   n0, d
-                adoxq   n1, m0
-                movq    $0xa7e5f24db74f5885, n0
-                mulxq   n0, n0, n1
-                adcxq   n0, m0
-                adoxq   n1, m1
-                movq    $0x389cb27e0bc8d220, n0
-                mulxq   n0, n0, n1
-                adcxq   n0, m1
-                movl    $0, n0short
-                adoxq   n0, n1
-                adcxq   n1, m2
-                adcq    $0, m3
-                adcq    $0, m4
-                adcq    $0, m5
+        subq    q, m5
+        xorq    n0, n0
+        movq    $0x1313e695333ad68d, n0
+        mulxq   n0, n0, n1
+        adcxq   n0, d
+        adoxq   n1, m0
+        movq    $0xa7e5f24db74f5885, n0
+        mulxq   n0, n0, n1
+        adcxq   n0, m0
+        adoxq   n1, m1
+        movq    $0x389cb27e0bc8d220, n0
+        mulxq   n0, n0, n1
+        adcxq   n0, m1
+        movl    $0, n0short
+        adoxq   n0, n1
+        adcxq   n1, m2
+        adcq    $0, m3
+        adcq    $0, m4
+        adcq    $0, m5
 
 // Now our top word m5 is either zero or all 1s. Use it for a masked
 // addition of n_384, which we can do by a *subtraction* of
 // 2^384 - n_384 from our portion
 
-                movq    $0x1313e695333ad68d, n0
-                andq    m5, n0
-                movq    $0xa7e5f24db74f5885, n1
-                andq    m5, n1
-                movq    $0x389cb27e0bc8d220, n2
-                andq    m5, n2
+        movq    $0x1313e695333ad68d, n0
+        andq    m5, n0
+        movq    $0xa7e5f24db74f5885, n1
+        andq    m5, n1
+        movq    $0x389cb27e0bc8d220, n2
+        andq    m5, n2
 
-                subq    n0, d
-                sbbq    n1, m0
-                sbbq    n2, m1
-                sbbq    $0, m2
-                sbbq    $0, m3
-                sbbq    $0, m4
+        subq    n0, d
+        sbbq    n1, m0
+        sbbq    n2, m1
+        sbbq    $0, m2
+        sbbq    $0, m3
+        sbbq    $0, m4
 
 // Now shuffle registers up and loop
 
-                movq    m4, m5
-                movq    m3, m4
-                movq    m2, m3
-                movq    m1, m2
-                movq    m0, m1
-                movq    d, m0
+        movq    m4, m5
+        movq    m3, m4
+        movq    m2, m3
+        movq    m1, m2
+        movq    m0, m1
+        movq    d, m0
 
-                decq    k
-                jnz     loop
+        decq    k
+        jnz     loop
 
 // Write back
 
 writeback:
 
-                movq    m0, (z)
-                movq    m1, 8(z)
-                movq    m2, 16(z)
-                movq    m3, 24(z)
-                movq    m4, 32(z)
-                movq    m5, 40(z)
+        movq    m0, (z)
+        movq    m1, 8(z)
+        movq    m2, 16(z)
+        movq    m3, 24(z)
+        movq    m4, 32(z)
+        movq    m5, 40(z)
 
 // Restore registers and return
 
-                popq    %r14
-                popq    %r13
-                popq    %r12
-                popq    %rbx
-                ret
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 shortinput:
 
-                xorq    m0, m0
-                xorq    m1, m1
-                xorq    m2, m2
-                xorq    m3, m3
-                xorq    m4, m4
-                xorq    m5, m5
+        xorq    m0, m0
+        xorq    m1, m1
+        xorq    m2, m2
+        xorq    m3, m3
+        xorq    m4, m4
+        xorq    m5, m5
 
-                testq   k, k
-                jz      writeback
-                movq    (%rdx), m0
-                decq    k
-                jz      writeback
-                movq    8(%rdx), m1
-                decq    k
-                jz      writeback
-                movq    16(%rdx), m2
-                decq    k
-                jz      writeback
-                movq    24(%rdx), m3
-                decq    k
-                jz      writeback
-                movq    32(%rdx), m4
-                jmp     writeback
+        testq   k, k
+        jz      writeback
+        movq    (%rdx), m0
+        decq    k
+        jz      writeback
+        movq    8(%rdx), m1
+        decq    k
+        jz      writeback
+        movq    16(%rdx), m2
+        decq    k
+        jz      writeback
+        movq    24(%rdx), m3
+        decq    k
+        jz      writeback
+        movq    32(%rdx), m4
+        jmp     writeback
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
@@ -24,13 +24,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n384_6
-        .private_extern bignum_mod_n384_6
+        S2N_ASM_HIDDEN(bignum_mod_n384_6)
 
         .globl _bignum_mod_n384_6
-        .private_extern _bignum_mod_n384_6
+        S2N_ASM_HIDDEN(_bignum_mod_n384_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
@@ -26,8 +26,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_n384_6
-        .globl  _bignum_mod_n384_6
+        .globl bignum_mod_n384_6
+        .private_extern bignum_mod_n384_6
+
+        .globl _bignum_mod_n384_6
+        .private_extern _bignum_mod_n384_6
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
@@ -23,14 +23,13 @@
 // Reduction is modulo the group order of the NIST curve P-384.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mod_n384_6
-        S2N_ASM_HIDDEN(bignum_mod_n384_6)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mod_n384_6
-        S2N_ASM_HIDDEN(_bignum_mod_n384_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384_6)
 
         .text
 
@@ -52,8 +51,14 @@
 
 
 
-bignum_mod_n384_6:
-_bignum_mod_n384_6:
+S2N_BN_SYMBOL(bignum_mod_n384_6):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Load the input and compute x + (2^384 - n_384)
 
@@ -110,6 +115,10 @@ _bignum_mod_n384_6:
         sbbq    $0, d5
         movq    d5, 40(z)
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
@@ -26,8 +26,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_n384_alt
-        .globl  _bignum_mod_n384_alt
+        .globl bignum_mod_n384_alt
+        .private_extern bignum_mod_n384_alt
+
+        .globl _bignum_mod_n384_alt
+        .private_extern _bignum_mod_n384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
@@ -24,13 +24,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n384_alt
-        .private_extern bignum_mod_n384_alt
+        S2N_ASM_HIDDEN(bignum_mod_n384_alt)
 
         .globl _bignum_mod_n384_alt
-        .private_extern _bignum_mod_n384_alt
+        S2N_ASM_HIDDEN(_bignum_mod_n384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
@@ -23,14 +23,13 @@
 // Reduction is modulo the group order of the NIST curve P-384.
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
+// Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mod_n384_alt
-        S2N_ASM_HIDDEN(bignum_mod_n384_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mod_n384_alt
-        S2N_ASM_HIDDEN(_bignum_mod_n384_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384_alt)
 
         .text
 
@@ -56,176 +55,187 @@
 #define n0short %eax
 #define qshort %ebp
 
-bignum_mod_n384_alt:
-_bignum_mod_n384_alt:
+S2N_BN_SYMBOL(bignum_mod_n384_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save extra registers
 
-                pushq   %rbp
-                pushq   %rbx
-                pushq   %r12
-                pushq   %r13
-                pushq   %r14
+        pushq   %rbp
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
 
 // If the input is already <= 5 words long, go to a trivial "copy" path
 
-                cmpq    $6, k
-                jc      shortinput
+        cmpq    $6, k
+        jc      shortinput
 
 // Otherwise load the top 6 digits (top-down) and reduce k by 6
 
-                subq    $6, k
-                movq    40(%rdx,k,8), m5
-                movq    32(%rdx,k,8), m4
-                movq    24(%rdx,k,8), m3
-                movq    16(%rdx,k,8), m2
-                movq    8(%rdx,k,8), m1
-                movq    (%rdx,k,8), m0
+        subq    $6, k
+        movq    40(%rdx,k,8), m5
+        movq    32(%rdx,k,8), m4
+        movq    24(%rdx,k,8), m3
+        movq    16(%rdx,k,8), m2
+        movq    8(%rdx,k,8), m1
+        movq    (%rdx,k,8), m0
 
 // Move x into another register to leave %rdx free for multiplies and use of n2
 
-                movq    %rdx, x
+        movq    %rdx, x
 
 // Reduce the top 6 digits mod n_384 (a conditional subtraction of n_384)
 
-                movq    $0x1313e695333ad68d, n0
-                movq    $0xa7e5f24db74f5885, n1
-                movq    $0x389cb27e0bc8d220, n2
+        movq    $0x1313e695333ad68d, n0
+        movq    $0xa7e5f24db74f5885, n1
+        movq    $0x389cb27e0bc8d220, n2
 
-                addq    n0, m0
-                adcq    n1, m1
-                adcq    n2, m2
-                adcq    $0, m3
-                adcq    $0, m4
-                adcq    $0, m5
-                sbbq    d, d
-                notq    d
-                andq    d, n0
-                andq    d, n1
-                andq    d, n2
-                subq    n0, m0
-                sbbq    n1, m1
-                sbbq    n2, m2
-                sbbq    $0, m3
-                sbbq    $0, m4
-                sbbq    $0, m5
+        addq    n0, m0
+        adcq    n1, m1
+        adcq    n2, m2
+        adcq    $0, m3
+        adcq    $0, m4
+        adcq    $0, m5
+        sbbq    d, d
+        notq    d
+        andq    d, n0
+        andq    d, n1
+        andq    d, n2
+        subq    n0, m0
+        sbbq    n1, m1
+        sbbq    n2, m2
+        sbbq    $0, m3
+        sbbq    $0, m4
+        sbbq    $0, m5
 
 // Now do (k-6) iterations of 7->6 word modular reduction
 
-                testq   k, k
-                jz      writeback
+        testq   k, k
+        jz      writeback
 
 loop:
 
 // Compute q = min (m5 + 1) (2^64 - 1)
 
-                movl    $1, qshort
-                addq    m5, q
-                sbbq    d, d
-                orq     d, q
+        movl    $1, qshort
+        addq    m5, q
+        sbbq    d, d
+        orq     d, q
 
 // Load the next digit so current m to reduce = [m5;m4;m3;m2;m1;m0;d]
 
-                movq    -8(x,k,8), d
+        movq    -8(x,k,8), d
 
 // Now form [m5;m4;m3;m2;m1;m0;d] = m - q * n_384
 
-                subq    q, m5
-                movq    $0x1313e695333ad68d, %rax
-                mulq    q
-                addq    %rax, d
-                adcq    %rdx, m0
-                sbbq    c, c
-                movq    $0xa7e5f24db74f5885, %rax
-                mulq    q
-                subq    c, %rdx
-                addq    %rax, m0
-                adcq    %rdx, m1
-                sbbq    c, c
-                movq    $0x389cb27e0bc8d220, n0
-                mulq    q
-                subq    c, %rdx
-                addq    %rax, m1
-                adcq    %rdx, m2
-                adcq    $0, m3
-                adcq    $0, m4
-                adcq    $0, m5
+        subq    q, m5
+        movq    $0x1313e695333ad68d, %rax
+        mulq    q
+        addq    %rax, d
+        adcq    %rdx, m0
+        sbbq    c, c
+        movq    $0xa7e5f24db74f5885, %rax
+        mulq    q
+        subq    c, %rdx
+        addq    %rax, m0
+        adcq    %rdx, m1
+        sbbq    c, c
+        movq    $0x389cb27e0bc8d220, n0
+        mulq    q
+        subq    c, %rdx
+        addq    %rax, m1
+        adcq    %rdx, m2
+        adcq    $0, m3
+        adcq    $0, m4
+        adcq    $0, m5
 
 // Now our top word m5 is either zero or all 1s. Use it for a masked
 // addition of n_384, which we can do by a *subtraction* of
 // 2^384 - n_384 from our portion
 
-                movq    $0x1313e695333ad68d, n0
-                andq    m5, n0
-                movq    $0xa7e5f24db74f5885, n1
-                andq    m5, n1
-                movq    $0x389cb27e0bc8d220, n2
-                andq    m5, n2
+        movq    $0x1313e695333ad68d, n0
+        andq    m5, n0
+        movq    $0xa7e5f24db74f5885, n1
+        andq    m5, n1
+        movq    $0x389cb27e0bc8d220, n2
+        andq    m5, n2
 
-                subq    n0, d
-                sbbq    n1, m0
-                sbbq    n2, m1
-                sbbq    $0, m2
-                sbbq    $0, m3
-                sbbq    $0, m4
+        subq    n0, d
+        sbbq    n1, m0
+        sbbq    n2, m1
+        sbbq    $0, m2
+        sbbq    $0, m3
+        sbbq    $0, m4
 
 // Now shuffle registers up and loop
 
-                movq    m4, m5
-                movq    m3, m4
-                movq    m2, m3
-                movq    m1, m2
-                movq    m0, m1
-                movq    d, m0
+        movq    m4, m5
+        movq    m3, m4
+        movq    m2, m3
+        movq    m1, m2
+        movq    m0, m1
+        movq    d, m0
 
-                decq    k
-                jnz     loop
+        decq    k
+        jnz     loop
 
 // Write back
 
 writeback:
 
-                movq    m0, (z)
-                movq    m1, 8(z)
-                movq    m2, 16(z)
-                movq    m3, 24(z)
-                movq    m4, 32(z)
-                movq    m5, 40(z)
+        movq    m0, (z)
+        movq    m1, 8(z)
+        movq    m2, 16(z)
+        movq    m3, 24(z)
+        movq    m4, 32(z)
+        movq    m5, 40(z)
 
 // Restore registers and return
 
-                popq    %r14
-                popq    %r13
-                popq    %r12
-                popq    %rbx
-                popq    %rbp
-                ret
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+        popq    %rbp
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 shortinput:
 
-                xorq    m0, m0
-                xorq    m1, m1
-                xorq    m2, m2
-                xorq    m3, m3
-                xorq    m4, m4
-                xorq    m5, m5
+        xorq    m0, m0
+        xorq    m1, m1
+        xorq    m2, m2
+        xorq    m3, m3
+        xorq    m4, m4
+        xorq    m5, m5
 
-                testq   k, k
-                jz      writeback
-                movq    (%rdx), m0
-                decq    k
-                jz      writeback
-                movq    8(%rdx), m1
-                decq    k
-                jz      writeback
-                movq    16(%rdx), m2
-                decq    k
-                jz      writeback
-                movq    24(%rdx), m3
-                decq    k
-                jz      writeback
-                movq    32(%rdx), m4
-                jmp     writeback
+        testq   k, k
+        jz      writeback
+        movq    (%rdx), m0
+        decq    k
+        jz      writeback
+        movq    8(%rdx), m1
+        decq    k
+        jz      writeback
+        movq    16(%rdx), m2
+        decq    k
+        jz      writeback
+        movq    24(%rdx), m3
+        decq    k
+        jz      writeback
+        movq    32(%rdx), m4
+        jmp     writeback
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 6], uint64_t k, uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
+// Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mod_p384
-        S2N_ASM_HIDDEN(bignum_mod_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mod_p384
-        S2N_ASM_HIDDEN(_bignum_mod_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384)
 
         .text
 
@@ -54,173 +53,184 @@
 #define qshort %edx
 
 
-bignum_mod_p384:
-_bignum_mod_p384:
+S2N_BN_SYMBOL(bignum_mod_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save extra registers
 
-                pushq   %rbx
-                pushq   %r12
-                pushq   %r13
-                pushq   %r14
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
 
 // If the input is already <= 5 words long, go to a trivial "copy" path
 
-                cmpq    $6, k
-                jc      shortinput
+        cmpq    $6, k
+        jc      shortinput
 
 // Otherwise load the top 6 digits (top-down) and reduce k by 6
 
-                subq    $6, k
-                movq    40(%rdx,k,8), m5
-                movq    32(%rdx,k,8), m4
-                movq    24(%rdx,k,8), m3
-                movq    16(%rdx,k,8), m2
-                movq    8(%rdx,k,8), m1
-                movq    (%rdx,k,8), m0
+        subq    $6, k
+        movq    40(%rdx,k,8), m5
+        movq    32(%rdx,k,8), m4
+        movq    24(%rdx,k,8), m3
+        movq    16(%rdx,k,8), m2
+        movq    8(%rdx,k,8), m1
+        movq    (%rdx,k,8), m0
 
 // Move x into another register to leave %rdx free for multiplies and use of n2
 
-                movq    %rdx, x
+        movq    %rdx, x
 
 // Reduce the top 6 digits mod p_384 (a conditional subtraction of p_384)
 
-                movl    $0x00000000ffffffff, n0short
-                movq    $0xffffffff00000000, n1
-                movq    $0xfffffffffffffffe, n2
+        movl    $0x00000000ffffffff, n0short
+        movq    $0xffffffff00000000, n1
+        movq    $0xfffffffffffffffe, n2
 
-                subq    n0, m0
-                sbbq    n1, m1
-                sbbq    n2, m2
-                sbbq    $-1, m3
-                sbbq    $-1, m4
-                sbbq    $-1, m5
+        subq    n0, m0
+        sbbq    n1, m1
+        sbbq    n2, m2
+        sbbq    $-1, m3
+        sbbq    $-1, m4
+        sbbq    $-1, m5
 
-                sbbq    d, d
-                andq    d, n0
-                andq    d, n1
-                andq    d, n2
-                addq    n0, m0
-                adcq    n1, m1
-                adcq    n2, m2
-                adcq    d, m3
-                adcq    d, m4
-                adcq    d, m5
+        sbbq    d, d
+        andq    d, n0
+        andq    d, n1
+        andq    d, n2
+        addq    n0, m0
+        adcq    n1, m1
+        adcq    n2, m2
+        adcq    d, m3
+        adcq    d, m4
+        adcq    d, m5
 
 // Now do (k-6) iterations of 7->6 word modular reduction
 
-                testq   k, k
-                jz      writeback
+        testq   k, k
+        jz      writeback
 
 loop:
 
 // Compute q = min (m5 + 1) (2^64 - 1)
 
-                movl    $1, qshort
-                addq    m5, q
-                sbbq    d, d
-                orq     d, q
+        movl    $1, qshort
+        addq    m5, q
+        sbbq    d, d
+        orq     d, q
 
 // Load the next digit so current m to reduce = [m5;m4;m3;m2;m1;m0;d]
 
-                movq    -8(x,k,8), d
+        movq    -8(x,k,8), d
 
 // Now form [m5;m4;m3;m2;m1;m0;d] = m - q * p_384. To use an addition for
 // the main calculation we do (m - 2^384 * q) + q * (2^384 - p_384)
 // where 2^384 - p_384 = [0;0;0;1;0x00000000ffffffff;0xffffffff00000001].
 // The extra subtraction of 2^384 * q is the first instruction.
 
-                subq    q, m5
-                xorq    n0, n0
-                movq    $0xffffffff00000001, n0
-                mulxq   n0, n0, n1
-                adcxq   n0, d
-                adoxq   n1, m0
-                movl    $0x00000000ffffffff, n0short
-                mulxq   n0, n0, n1
-                adcxq   n0, m0
-                adoxq   n1, m1
-                adcxq   q, m1
-                movl    $0, n0short
-                adoxq   n0, n0
-                adcxq   n0, m2
-                adcq    $0, m3
-                adcq    $0, m4
-                adcq    $0, m5
+        subq    q, m5
+        xorq    n0, n0
+        movq    $0xffffffff00000001, n0
+        mulxq   n0, n0, n1
+        adcxq   n0, d
+        adoxq   n1, m0
+        movl    $0x00000000ffffffff, n0short
+        mulxq   n0, n0, n1
+        adcxq   n0, m0
+        adoxq   n1, m1
+        adcxq   q, m1
+        movl    $0, n0short
+        adoxq   n0, n0
+        adcxq   n0, m2
+        adcq    $0, m3
+        adcq    $0, m4
+        adcq    $0, m5
 
 // Now our top word m5 is either zero or all 1s. Use it for a masked
 // addition of p_384, which we can do by a *subtraction* of
 // 2^384 - p_384 from our portion
 
-                movq    $0xffffffff00000001, n0
-                andq    m5, n0
-                movl    $0x00000000ffffffff, n1short
-                andq    m5, n1
-                andq    $1, m5
+        movq    $0xffffffff00000001, n0
+        andq    m5, n0
+        movl    $0x00000000ffffffff, n1short
+        andq    m5, n1
+        andq    $1, m5
 
-                subq    n0, d
-                sbbq    n1, m0
-                sbbq    m5, m1
-                sbbq    $0, m2
-                sbbq    $0, m3
-                sbbq    $0, m4
+        subq    n0, d
+        sbbq    n1, m0
+        sbbq    m5, m1
+        sbbq    $0, m2
+        sbbq    $0, m3
+        sbbq    $0, m4
 
 // Now shuffle registers up and loop
 
-                movq    m4, m5
-                movq    m3, m4
-                movq    m2, m3
-                movq    m1, m2
-                movq    m0, m1
-                movq    d, m0
+        movq    m4, m5
+        movq    m3, m4
+        movq    m2, m3
+        movq    m1, m2
+        movq    m0, m1
+        movq    d, m0
 
-                decq    k
-                jnz     loop
+        decq    k
+        jnz     loop
 
 // Write back
 
 writeback:
 
-                movq    m0, (z)
-                movq    m1, 8(z)
-                movq    m2, 16(z)
-                movq    m3, 24(z)
-                movq    m4, 32(z)
-                movq    m5, 40(z)
+        movq    m0, (z)
+        movq    m1, 8(z)
+        movq    m2, 16(z)
+        movq    m3, 24(z)
+        movq    m4, 32(z)
+        movq    m5, 40(z)
 
 // Restore registers and return
 
-                popq    %r14
-                popq    %r13
-                popq    %r12
-                popq    %rbx
-                ret
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 shortinput:
 
-                xorq    m0, m0
-                xorq    m1, m1
-                xorq    m2, m2
-                xorq    m3, m3
-                xorq    m4, m4
-                xorq    m5, m5
+        xorq    m0, m0
+        xorq    m1, m1
+        xorq    m2, m2
+        xorq    m3, m3
+        xorq    m4, m4
+        xorq    m5, m5
 
-                testq   k, k
-                jz      writeback
-                movq    (%rdx), m0
-                decq    k
-                jz      writeback
-                movq    8(%rdx), m1
-                decq    k
-                jz      writeback
-                movq    16(%rdx), m2
-                decq    k
-                jz      writeback
-                movq    24(%rdx), m3
-                decq    k
-                jz      writeback
-                movq    32(%rdx), m4
-                jmp     writeback
+        testq   k, k
+        jz      writeback
+        movq    (%rdx), m0
+        decq    k
+        jz      writeback
+        movq    8(%rdx), m1
+        decq    k
+        jz      writeback
+        movq    16(%rdx), m2
+        decq    k
+        jz      writeback
+        movq    24(%rdx), m3
+        decq    k
+        jz      writeback
+        movq    32(%rdx), m4
+        jmp     writeback
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_p384
-        .globl  _bignum_mod_p384
+        .globl bignum_mod_p384
+        .private_extern bignum_mod_p384
+
+        .globl _bignum_mod_p384
+        .private_extern _bignum_mod_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p384
-        .private_extern bignum_mod_p384
+        S2N_ASM_HIDDEN(bignum_mod_p384)
 
         .globl _bignum_mod_p384
-        .private_extern _bignum_mod_p384
+        S2N_ASM_HIDDEN(_bignum_mod_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_p384_6
-        .globl  _bignum_mod_p384_6
+        .globl bignum_mod_p384_6
+        .private_extern bignum_mod_p384_6
+
+        .globl _bignum_mod_p384_6
+        .private_extern _bignum_mod_p384_6
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p384_6
-        .private_extern bignum_mod_p384_6
+        S2N_ASM_HIDDEN(bignum_mod_p384_6)
 
         .globl _bignum_mod_p384_6
-        .private_extern _bignum_mod_p384_6
+        S2N_ASM_HIDDEN(_bignum_mod_p384_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 6], uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mod_p384_6
-        S2N_ASM_HIDDEN(bignum_mod_p384_6)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mod_p384_6
-        S2N_ASM_HIDDEN(_bignum_mod_p384_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384_6)
 
         .text
 
@@ -51,8 +50,14 @@
 
 
 
-bignum_mod_p384_6:
-_bignum_mod_p384_6:
+S2N_BN_SYMBOL(bignum_mod_p384_6):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Load the input and subtract p_384 from it
 
@@ -108,6 +113,10 @@ _bignum_mod_p384_6:
         sbbq    $0, d5
         movq    d5, 40(z)
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p384_alt
-        .private_extern bignum_mod_p384_alt
+        S2N_ASM_HIDDEN(bignum_mod_p384_alt)
 
         .globl _bignum_mod_p384_alt
-        .private_extern _bignum_mod_p384_alt
+        S2N_ASM_HIDDEN(_bignum_mod_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 6], uint64_t k, uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
+// Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mod_p384_alt
-        S2N_ASM_HIDDEN(bignum_mod_p384_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mod_p384_alt
-        S2N_ASM_HIDDEN(_bignum_mod_p384_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384_alt)
 
         .text
 
@@ -58,173 +57,184 @@
 #define qshort %ebx
 
 
-bignum_mod_p384_alt:
-_bignum_mod_p384_alt:
+S2N_BN_SYMBOL(bignum_mod_p384_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save extra registers
 
-                pushq   %rbx
-                pushq   %r12
-                pushq   %r13
-                pushq   %r14
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
 
 // If the input is already <= 5 words long, go to a trivial "copy" path
 
-                cmpq    $6, k
-                jc      shortinput
+        cmpq    $6, k
+        jc      shortinput
 
 // Otherwise load the top 6 digits (top-down) and reduce k by 6
 
-                subq    $6, k
-                movq    40(%rdx,k,8), m5
-                movq    32(%rdx,k,8), m4
-                movq    24(%rdx,k,8), m3
-                movq    16(%rdx,k,8), m2
-                movq    8(%rdx,k,8), m1
-                movq    (%rdx,k,8), m0
+        subq    $6, k
+        movq    40(%rdx,k,8), m5
+        movq    32(%rdx,k,8), m4
+        movq    24(%rdx,k,8), m3
+        movq    16(%rdx,k,8), m2
+        movq    8(%rdx,k,8), m1
+        movq    (%rdx,k,8), m0
 
 // Move x into another register to leave %rdx free for multiplies and use of n2
 
-                movq    %rdx, x
+        movq    %rdx, x
 
 // Reduce the top 6 digits mod p_384 (a conditional subtraction of p_384)
 
-                movl    $0x00000000ffffffff, n0short
-                movq    $0xffffffff00000000, n1
-                movq    $0xfffffffffffffffe, n2
+        movl    $0x00000000ffffffff, n0short
+        movq    $0xffffffff00000000, n1
+        movq    $0xfffffffffffffffe, n2
 
-                subq    n0, m0
-                sbbq    n1, m1
-                sbbq    n2, m2
-                sbbq    $-1, m3
-                sbbq    $-1, m4
-                sbbq    $-1, m5
+        subq    n0, m0
+        sbbq    n1, m1
+        sbbq    n2, m2
+        sbbq    $-1, m3
+        sbbq    $-1, m4
+        sbbq    $-1, m5
 
-                sbbq    d, d
-                andq    d, n0
-                andq    d, n1
-                andq    d, n2
-                addq    n0, m0
-                adcq    n1, m1
-                adcq    n2, m2
-                adcq    d, m3
-                adcq    d, m4
-                adcq    d, m5
+        sbbq    d, d
+        andq    d, n0
+        andq    d, n1
+        andq    d, n2
+        addq    n0, m0
+        adcq    n1, m1
+        adcq    n2, m2
+        adcq    d, m3
+        adcq    d, m4
+        adcq    d, m5
 
 // Now do (k-6) iterations of 7->6 word modular reduction
 
-                testq   k, k
-                jz      writeback
+        testq   k, k
+        jz      writeback
 
 loop:
 
 // Compute q = min (m5 + 1) (2^64 - 1)
 
-                movl    $1, qshort
-                addq    m5, q
-                sbbq    d, d
-                orq     d, q
+        movl    $1, qshort
+        addq    m5, q
+        sbbq    d, d
+        orq     d, q
 
 // Load the next digit so current m to reduce = [m5;m4;m3;m2;m1;m0;d]
 
-                movq    -8(x,k,8), d
+        movq    -8(x,k,8), d
 
 // Now form [m5;m4;m3;m2;m1;m0;d] = m - q * p_384. To use an addition for
 // the main calculation we do (m - 2^384 * q) + q * (2^384 - p_384)
 // where 2^384 - p_384 = [0;0;0;1;0x00000000ffffffff;0xffffffff00000001].
 // The extra subtraction of 2^384 * q is the first instruction.
 
-                subq    q, m5
-                movq    $0xffffffff00000001, %rax
-                mulq    q
-                addq    %rax, d
-                adcq    %rdx, m0
-                adcq    q, m1
-                movq    q, %rax
-                sbbq    c, c
-                movl    $0x00000000ffffffff, %edx
-                negq    c
-                mulq    %rdx
-                addq    %rax, m0
-                adcq    %rdx, m1
-                adcq    c, m2
-                adcq    $0, m3
-                adcq    $0, m4
-                adcq    $0, m5
+        subq    q, m5
+        movq    $0xffffffff00000001, %rax
+        mulq    q
+        addq    %rax, d
+        adcq    %rdx, m0
+        adcq    q, m1
+        movq    q, %rax
+        sbbq    c, c
+        movl    $0x00000000ffffffff, %edx
+        negq    c
+        mulq    %rdx
+        addq    %rax, m0
+        adcq    %rdx, m1
+        adcq    c, m2
+        adcq    $0, m3
+        adcq    $0, m4
+        adcq    $0, m5
 
 // Now our top word m5 is either zero or all 1s. Use it for a masked
 // addition of p_384, which we can do by a *subtraction* of
 // 2^384 - p_384 from our portion
 
-                movq    $0xffffffff00000001, n0
-                andq    m5, n0
-                movl    $0x00000000ffffffff, n1short
-                andq    m5, n1
-                andq    $1, m5
+        movq    $0xffffffff00000001, n0
+        andq    m5, n0
+        movl    $0x00000000ffffffff, n1short
+        andq    m5, n1
+        andq    $1, m5
 
-                subq    n0, d
-                sbbq    n1, m0
-                sbbq    m5, m1
-                sbbq    $0, m2
-                sbbq    $0, m3
-                sbbq    $0, m4
+        subq    n0, d
+        sbbq    n1, m0
+        sbbq    m5, m1
+        sbbq    $0, m2
+        sbbq    $0, m3
+        sbbq    $0, m4
 
 // Now shuffle registers up and loop
 
-                movq    m4, m5
-                movq    m3, m4
-                movq    m2, m3
-                movq    m1, m2
-                movq    m0, m1
-                movq    d, m0
+        movq    m4, m5
+        movq    m3, m4
+        movq    m2, m3
+        movq    m1, m2
+        movq    m0, m1
+        movq    d, m0
 
-                decq    k
-                jnz     loop
+        decq    k
+        jnz     loop
 
 // Write back
 
 writeback:
 
-                movq    m0, (z)
-                movq    m1, 8(z)
-                movq    m2, 16(z)
-                movq    m3, 24(z)
-                movq    m4, 32(z)
-                movq    m5, 40(z)
+        movq    m0, (z)
+        movq    m1, 8(z)
+        movq    m2, 16(z)
+        movq    m3, 24(z)
+        movq    m4, 32(z)
+        movq    m5, 40(z)
 
 // Restore registers and return
 
-                popq    %r14
-                popq    %r13
-                popq    %r12
-                popq    %rbx
-                ret
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 shortinput:
 
-                xorq    m0, m0
-                xorq    m1, m1
-                xorq    m2, m2
-                xorq    m3, m3
-                xorq    m4, m4
-                xorq    m5, m5
+        xorq    m0, m0
+        xorq    m1, m1
+        xorq    m2, m2
+        xorq    m3, m3
+        xorq    m4, m4
+        xorq    m5, m5
 
-                testq   k, k
-                jz      writeback
-                movq    (%rdx), m0
-                decq    k
-                jz      writeback
-                movq    8(%rdx), m1
-                decq    k
-                jz      writeback
-                movq    16(%rdx), m2
-                decq    k
-                jz      writeback
-                movq    24(%rdx), m3
-                decq    k
-                jz      writeback
-                movq    32(%rdx), m4
-                jmp     writeback
+        testq   k, k
+        jz      writeback
+        movq    (%rdx), m0
+        decq    k
+        jz      writeback
+        movq    8(%rdx), m1
+        decq    k
+        jz      writeback
+        movq    16(%rdx), m2
+        decq    k
+        jz      writeback
+        movq    24(%rdx), m3
+        decq    k
+        jz      writeback
+        movq    32(%rdx), m4
+        jmp     writeback
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_p384_alt
-        .globl  _bignum_mod_p384_alt
+        .globl bignum_mod_p384_alt
+        .private_extern bignum_mod_p384_alt
+
+        .globl _bignum_mod_p384_alt
+        .private_extern _bignum_mod_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
@@ -25,14 +25,13 @@
 // the "usual" case x < p_384 and y < p_384).
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // -----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_montmul_p384
-        S2N_ASM_HIDDEN(bignum_montmul_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_montmul_p384
-        S2N_ASM_HIDDEN(_bignum_montmul_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p384)
 
         .text
 
@@ -75,31 +74,38 @@
 
 #define montredc(d7,d6,d5,d4,d3,d2,d1,d0)                               \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
-                movq    d0, %rdx ;                                        \
-                shlq    $32, %rdx ;                                        \
-                addq    d0, %rdx ;                                        \
+        movq    d0, %rdx ;                                        \
+        shlq    $32, %rdx ;                                        \
+        addq    d0, %rdx ;                                        \
 /* Construct [%rbp;%rbx;%rax;-] = (2^384 - p_384) * w */                   \
 /* We know the lowest word will cancel so we can re-use d0 as a temp */ \
-                xorl    %ebp, %ebp ;                                       \
-                movq    $0xffffffff00000001, %rax ;                        \
-                mulxq   %rax, %rbx, %rax ;                                  \
-                movl    $0x00000000ffffffff, %ebx ;                        \
-                mulxq   %rbx, d0, %rbx ;                                   \
-                adcq    d0, %rax ;                                        \
-                adcq    %rdx, %rbx ;                                       \
-                adcl    %ebp, %ebp ;                                       \
+        xorl    %ebp, %ebp ;                                       \
+        movq    $0xffffffff00000001, %rax ;                        \
+        mulxq   %rax, %rbx, %rax ;                                  \
+        movl    $0x00000000ffffffff, %ebx ;                        \
+        mulxq   %rbx, d0, %rbx ;                                   \
+        adcq    d0, %rax ;                                        \
+        adcq    %rdx, %rbx ;                                       \
+        adcl    %ebp, %ebp ;                                       \
 /*  Now subtract that and add 2^384 * w */                              \
-                subq    %rax, d1 ;                                        \
-                sbbq    %rbx, d2 ;                                        \
-                sbbq    %rbp, d3 ;                                        \
-                sbbq    $0, d4 ;                                          \
-                sbbq    $0, d5 ;                                          \
-                sbbq    $0, %rdx ;                                         \
-                addq    %rdx, d6 ;                                        \
-                adcq    $0, d7
+        subq    %rax, d1 ;                                        \
+        sbbq    %rbx, d2 ;                                        \
+        sbbq    %rbp, d3 ;                                        \
+        sbbq    $0, d4 ;                                          \
+        sbbq    $0, d5 ;                                          \
+        sbbq    $0, %rdx ;                                         \
+        addq    %rdx, d6 ;                                        \
+        adcq    $0, d7
 
-bignum_montmul_p384:
-_bignum_montmul_p384:
+S2N_BN_SYMBOL(bignum_montmul_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save more registers to play with
 
@@ -280,6 +286,10 @@ _bignum_montmul_p384:
         popq    %rbp
         popq    %rbx
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
@@ -28,8 +28,12 @@
 // -----------------------------------------------------------------------------
 
 
-        .globl  bignum_montmul_p384
-        .globl  _bignum_montmul_p384
+        .globl bignum_montmul_p384
+        .private_extern bignum_montmul_p384
+
+        .globl _bignum_montmul_p384
+        .private_extern _bignum_montmul_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
@@ -26,13 +26,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // -----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p384
-        .private_extern bignum_montmul_p384
+        S2N_ASM_HIDDEN(bignum_montmul_p384)
 
         .globl _bignum_montmul_p384
-        .private_extern _bignum_montmul_p384
+        S2N_ASM_HIDDEN(_bignum_montmul_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
@@ -26,13 +26,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // -----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p384_alt
-        .private_extern bignum_montmul_p384_alt
+        S2N_ASM_HIDDEN(bignum_montmul_p384_alt)
 
         .globl _bignum_montmul_p384_alt
-        .private_extern _bignum_montmul_p384_alt
+        S2N_ASM_HIDDEN(_bignum_montmul_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
@@ -25,14 +25,13 @@
 // the "usual" case x < p_384 and y < p_384).
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // -----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_montmul_p384_alt
-        S2N_ASM_HIDDEN(bignum_montmul_p384_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_montmul_p384_alt
-        S2N_ASM_HIDDEN(_bignum_montmul_p384_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p384_alt)
 
         .text
 
@@ -96,32 +95,39 @@
 
 #define montredc(d7,d6,d5,d4,d3,d2,d1,d0)                               \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
-                movq    d0, %rbx ;                                        \
-                shlq    $32, %rbx ;                                        \
-                addq    d0, %rbx ;                                        \
+        movq    d0, %rbx ;                                        \
+        shlq    $32, %rbx ;                                        \
+        addq    d0, %rbx ;                                        \
 /* Construct [%rbp;%rdx;%rax;-] = (2^384 - p_384) * w */                   \
 /* We know the lowest word will cancel so we can re-use d0 as a temp */ \
-                xorl    %ebp, %ebp ;                                       \
-                movq    $0xffffffff00000001, %rax ;                        \
-                mulq    %rbx;                                            \
-                movq    %rdx, d0 ;                                        \
-                movq    $0x00000000ffffffff, %rax ;                        \
-                mulq    %rbx;                                            \
-                addq    d0, %rax ;                                        \
-                adcq    %rbx, %rdx ;                                       \
-                adcl    %ebp, %ebp ;                                       \
+        xorl    %ebp, %ebp ;                                       \
+        movq    $0xffffffff00000001, %rax ;                        \
+        mulq    %rbx;                                            \
+        movq    %rdx, d0 ;                                        \
+        movq    $0x00000000ffffffff, %rax ;                        \
+        mulq    %rbx;                                            \
+        addq    d0, %rax ;                                        \
+        adcq    %rbx, %rdx ;                                       \
+        adcl    %ebp, %ebp ;                                       \
 /*  Now subtract that and add 2^384 * w */                              \
-                subq    %rax, d1 ;                                        \
-                sbbq    %rdx, d2 ;                                        \
-                sbbq    %rbp, d3 ;                                        \
-                sbbq    $0, d4 ;                                          \
-                sbbq    $0, d5 ;                                          \
-                sbbq    $0, %rbx ;                                         \
-                addq    %rbx, d6 ;                                        \
-                adcq    $0, d7
+        subq    %rax, d1 ;                                        \
+        sbbq    %rdx, d2 ;                                        \
+        sbbq    %rbp, d3 ;                                        \
+        sbbq    $0, d4 ;                                          \
+        sbbq    $0, d5 ;                                          \
+        sbbq    $0, %rbx ;                                         \
+        addq    %rbx, d6 ;                                        \
+        adcq    $0, d7
 
-bignum_montmul_p384_alt:
-_bignum_montmul_p384_alt:
+S2N_BN_SYMBOL(bignum_montmul_p384_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save more registers to play with
 
@@ -305,6 +311,10 @@ _bignum_montmul_p384_alt:
         popq    %rbp
         popq    %rbx
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
@@ -28,8 +28,12 @@
 // -----------------------------------------------------------------------------
 
 
-        .globl  bignum_montmul_p384_alt
-        .globl  _bignum_montmul_p384_alt
+        .globl bignum_montmul_p384_alt
+        .private_extern bignum_montmul_p384_alt
+
+        .globl _bignum_montmul_p384_alt
+        .private_extern _bignum_montmul_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montsqr_p384
-        .globl  _bignum_montsqr_p384
+        .globl bignum_montsqr_p384
+        .private_extern bignum_montsqr_p384
+
+        .globl _bignum_montsqr_p384
+        .private_extern _bignum_montsqr_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
@@ -24,14 +24,13 @@
 // guaranteed in particular if x < p_384 initially (the "intended" case).
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_montsqr_p384
-        S2N_ASM_HIDDEN(bignum_montsqr_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_montsqr_p384
-        S2N_ASM_HIDDEN(_bignum_montsqr_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p384)
 
         .text
 
@@ -72,31 +71,37 @@
 
 #define montreds(d6,d5,d4,d3,d2,d1,d0)                                  \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
-                movq    d0, %rdx ;                                        \
-                shlq    $32, %rdx ;                                        \
-                addq    d0, %rdx ;                                        \
+        movq    d0, %rdx ;                                        \
+        shlq    $32, %rdx ;                                        \
+        addq    d0, %rdx ;                                        \
 /* Construct [%rbx;d0;%rax;-] = (2^384 - p_384) * w            */         \
 /* We know the lowest word will cancel so we can re-use d0   */         \
 /* and %rbx as temps.                                         */         \
-                movq    $0xffffffff00000001, %rax ;                        \
-                mulxq   %rax, d0, %rax ;                                   \
-                movl    $0x00000000ffffffff, %ebx ;                        \
-                mulxq   %rbx, %rbx, d0 ;                                   \
-                addq    %rbx, %rax ;                                       \
-                adcq    %rdx, d0 ;                                        \
-                movl    $0, %ebx ;                                         \
-                adcq    %rbx, %rbx ;                                       \
+        movq    $0xffffffff00000001, %rax ;                        \
+        mulxq   %rax, d0, %rax ;                                   \
+        movl    $0x00000000ffffffff, %ebx ;                        \
+        mulxq   %rbx, %rbx, d0 ;                                   \
+        addq    %rbx, %rax ;                                       \
+        adcq    %rdx, d0 ;                                        \
+        movl    $0, %ebx ;                                         \
+        adcq    %rbx, %rbx ;                                       \
 /* Now subtract that and add 2^384 * w                       */         \
-                subq    %rax, d1 ;                                        \
-                sbbq    d0, d2 ;                                         \
-                sbbq    %rbx, d3 ;                                        \
-                sbbq    $0, d4 ;                                          \
-                sbbq    $0, d5 ;                                          \
-                movq    %rdx, d6 ;                                        \
-                sbbq    $0, d6
+        subq    %rax, d1 ;                                        \
+        sbbq    d0, d2 ;                                         \
+        sbbq    %rbx, d3 ;                                        \
+        sbbq    $0, d4 ;                                          \
+        sbbq    $0, d5 ;                                          \
+        movq    %rdx, d6 ;                                        \
+        sbbq    $0, d6
 
-bignum_montsqr_p384:
-_bignum_montsqr_p384:
+S2N_BN_SYMBOL(bignum_montsqr_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save more registers to play with
 
@@ -285,6 +290,10 @@ _bignum_montsqr_p384:
         popq    %r12
         popq    %rbp
         popq    %rbx
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p384
-        .private_extern bignum_montsqr_p384
+        S2N_ASM_HIDDEN(bignum_montsqr_p384)
 
         .globl _bignum_montsqr_p384
-        .private_extern _bignum_montsqr_p384
+        S2N_ASM_HIDDEN(_bignum_montsqr_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p384_alt
-        .private_extern bignum_montsqr_p384_alt
+        S2N_ASM_HIDDEN(bignum_montsqr_p384_alt)
 
         .globl _bignum_montsqr_p384_alt
-        .private_extern _bignum_montsqr_p384_alt
+        S2N_ASM_HIDDEN(_bignum_montsqr_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montsqr_p384_alt
-        .globl  _bignum_montsqr_p384_alt
+        .globl bignum_montsqr_p384_alt
+        .private_extern bignum_montsqr_p384_alt
+
+        .globl _bignum_montsqr_p384_alt
+        .private_extern _bignum_montsqr_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
@@ -24,14 +24,13 @@
 // guaranteed in particular if x < p_384 initially (the "intended" case).
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_montsqr_p384_alt
-        S2N_ASM_HIDDEN(bignum_montsqr_p384_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_montsqr_p384_alt
-        S2N_ASM_HIDDEN(_bignum_montsqr_p384_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p384_alt)
 
         .text
 
@@ -93,32 +92,38 @@
 
 #define montreds(d6,d5,d4,d3,d2,d1,d0)                                  \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
-                movq    d0, %rbx ;                                        \
-                shlq    $32, %rbx ;                                        \
-                addq    d0, %rbx ;                                        \
+        movq    d0, %rbx ;                                        \
+        shlq    $32, %rbx ;                                        \
+        addq    d0, %rbx ;                                        \
 /* Construct [%rax;%rdx;d0;-] = (2^384 - p_384) * w            */         \
 /* We know the lowest word will cancel so we can re-use d0   */         \
 /* and %rbx as temps.                                         */         \
-                movq    $0xffffffff00000001, %rax ;                        \
-                mulq    %rbx;                                            \
-                movq    %rdx, d0 ;                                        \
-                movq    $0x00000000ffffffff, %rax ;                        \
-                mulq    %rbx;                                            \
-                addq    %rax, d0 ;                                        \
-                movl    $0, %eax ;                                         \
-                adcq    %rbx, %rdx ;                                       \
-                adcl    %eax, %eax ;                                       \
+        movq    $0xffffffff00000001, %rax ;                        \
+        mulq    %rbx;                                            \
+        movq    %rdx, d0 ;                                        \
+        movq    $0x00000000ffffffff, %rax ;                        \
+        mulq    %rbx;                                            \
+        addq    %rax, d0 ;                                        \
+        movl    $0, %eax ;                                         \
+        adcq    %rbx, %rdx ;                                       \
+        adcl    %eax, %eax ;                                       \
 /* Now subtract that and add 2^384 * w                       */         \
-                subq    d0, d1 ;                                         \
-                sbbq    %rdx, d2 ;                                        \
-                sbbq    %rax, d3 ;                                        \
-                sbbq    $0, d4 ;                                          \
-                sbbq    $0, d5 ;                                          \
-                movq    %rbx, d6 ;                                        \
-                sbbq    $0, d6
+        subq    d0, d1 ;                                         \
+        sbbq    %rdx, d2 ;                                        \
+        sbbq    %rax, d3 ;                                        \
+        sbbq    $0, d4 ;                                          \
+        sbbq    $0, d5 ;                                          \
+        movq    %rbx, d6 ;                                        \
+        sbbq    $0, d6
 
-bignum_montsqr_p384_alt:
-_bignum_montsqr_p384_alt:
+S2N_BN_SYMBOL(bignum_montsqr_p384_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save more registers to play with
 
@@ -330,6 +335,10 @@ _bignum_montsqr_p384_alt:
         popq    %r12
         popq    %rbp
         popq    %rbx
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mux_6
-        .globl  _bignum_mux_6
+        .globl bignum_mux_6
+        .private_extern bignum_mux_6
+
+        .globl _bignum_mux_6
+        .private_extern _bignum_mux_6
+
         .text
 
 #define p %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
@@ -24,14 +24,13 @@
 // It is assumed that all numbers x, y and z have the same size 6 digits.
 //
 // Standard x86-64 ABI: RDI = p, RSI = z, RDX = x, RCX = y
+// Microsoft x64 ABI:   RCX = p, RDX = z, R8 = x, R9 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mux_6
-        S2N_ASM_HIDDEN(bignum_mux_6)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mux_6
-        S2N_ASM_HIDDEN(_bignum_mux_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mux_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mux_6)
 
         .text
 
@@ -43,41 +42,53 @@
 #define b %r8
 
 
-bignum_mux_6:
-_bignum_mux_6:
-                testq   p, p
+S2N_BN_SYMBOL(bignum_mux_6):
 
-                movq    (x), a
-                movq    (y), b
-                cmovzq  b, a
-                movq    a, (z)
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+        movq    %r9, %rcx
+#endif
+        testq   p, p
 
-                movq    8(x), a
-                movq    8(y), b
-                cmovzq  b, a
-                movq    a, 8(z)
+        movq    (x), a
+        movq    (y), b
+        cmovzq  b, a
+        movq    a, (z)
 
-                movq    16(x), a
-                movq    16(y), b
-                cmovzq  b, a
-                movq    a, 16(z)
+        movq    8(x), a
+        movq    8(y), b
+        cmovzq  b, a
+        movq    a, 8(z)
 
-                movq    24(x), a
-                movq    24(y), b
-                cmovzq  b, a
-                movq    a, 24(z)
+        movq    16(x), a
+        movq    16(y), b
+        cmovzq  b, a
+        movq    a, 16(z)
 
-                movq    32(x), a
-                movq    32(y), b
-                cmovzq  b, a
-                movq    a, 32(z)
+        movq    24(x), a
+        movq    24(y), b
+        cmovzq  b, a
+        movq    a, 24(z)
 
-                movq    40(x), a
-                movq    40(y), b
-                cmovzq  b, a
-                movq    a, 40(z)
+        movq    32(x), a
+        movq    32(y), b
+        cmovzq  b, a
+        movq    a, 32(z)
 
-                ret
+        movq    40(x), a
+        movq    40(y), b
+        cmovzq  b, a
+        movq    a, 40(z)
+
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = p, RSI = z, RDX = x, RCX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mux_6
-        .private_extern bignum_mux_6
+        S2N_ASM_HIDDEN(bignum_mux_6)
 
         .globl _bignum_mux_6
-        .private_extern _bignum_mux_6
+        S2N_ASM_HIDDEN(_bignum_mux_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
@@ -21,13 +21,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_neg_p384
-        .private_extern bignum_neg_p384
+        S2N_ASM_HIDDEN(bignum_neg_p384)
 
         .globl _bignum_neg_p384
-        .private_extern _bignum_neg_p384
+        S2N_ASM_HIDDEN(_bignum_neg_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
@@ -20,14 +20,13 @@
 //    extern void bignum_neg_p384 (uint64_t z[static 6], uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_neg_p384
-        S2N_ASM_HIDDEN(bignum_neg_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_neg_p384
-        S2N_ASM_HIDDEN(_bignum_neg_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p384)
 
         .text
 
@@ -43,53 +42,63 @@
 
 #define n0short %eax
 
-bignum_neg_p384:
-_bignum_neg_p384:
+S2N_BN_SYMBOL(bignum_neg_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Or together the input digits and create a bitmask q if this is nonzero, so
 // that we avoid doing -0 = p_384 and hence maintain strict modular reduction
 
-                movq    (x), n0
-                orq     8(x), n0
-                movq    16(x), n1
-                orq     24(x), n1
-                movq    32(x), n2
-                orq     40(x), n2
-                orq     n1, n0
-                orq     n2, n0
-                negq    n0
-                sbbq    q, q
+        movq    (x), n0
+        orq     8(x), n0
+        movq    16(x), n1
+        orq     24(x), n1
+        movq    32(x), n2
+        orq     40(x), n2
+        orq     n1, n0
+        orq     n2, n0
+        negq    n0
+        sbbq    q, q
 
 // Let [q;n4;n3;n2;n1;n0] = if q then p_384 else 0
 
-                movl    $0x00000000ffffffff, n0short
-                andq    q, n0
-                movq    $0xffffffff00000000, n1
-                andq    q, n1
-                movq    $0xfffffffffffffffe, n2
-                andq    q, n2
-                movq    q, n3
-                movq    q, n4
+        movl    $0x00000000ffffffff, n0short
+        andq    q, n0
+        movq    $0xffffffff00000000, n1
+        andq    q, n1
+        movq    $0xfffffffffffffffe, n2
+        andq    q, n2
+        movq    q, n3
+        movq    q, n4
 
 // Do the subtraction
 
-                subq    (x), n0
-                sbbq    8(x), n1
-                sbbq    16(x), n2
-                sbbq    24(x), n3
-                sbbq    32(x), n4
-                sbbq    40(x), q
+        subq    (x), n0
+        sbbq    8(x), n1
+        sbbq    16(x), n2
+        sbbq    24(x), n3
+        sbbq    32(x), n4
+        sbbq    40(x), q
 
 // Write back
 
-                movq    n0, (z)
-                movq    n1, 8(z)
-                movq    n2, 16(z)
-                movq    n3, 24(z)
-                movq    n4, 32(z)
-                movq    q, 40(z)
+        movq    n0, (z)
+        movq    n1, 8(z)
+        movq    n2, 16(z)
+        movq    n3, 24(z)
+        movq    n4, 32(z)
+        movq    q, 40(z)
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
@@ -23,8 +23,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_neg_p384
-        .globl  _bignum_neg_p384
+        .globl bignum_neg_p384
+        .private_extern bignum_neg_p384
+
+        .globl _bignum_neg_p384
+        .private_extern _bignum_neg_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
@@ -21,13 +21,13 @@
 //
 // Standard x86-64 ABI: RDI = x, returns RAX
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_nonzero_6
-        .private_extern bignum_nonzero_6
+        S2N_ASM_HIDDEN(bignum_nonzero_6)
 
         .globl _bignum_nonzero_6
-        .private_extern _bignum_nonzero_6
+        S2N_ASM_HIDDEN(_bignum_nonzero_6)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
@@ -23,8 +23,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_nonzero_6
-        .globl  _bignum_nonzero_6
+        .globl bignum_nonzero_6
+        .private_extern bignum_nonzero_6
+
+        .globl _bignum_nonzero_6
+        .private_extern _bignum_nonzero_6
+
         .text
 
 #define x %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
@@ -20,14 +20,13 @@
 //    extern uint64_t bignum_nonzero_6(uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = x, returns RAX
+// Microsoft x64 ABI:   RCX = x, returns RAX
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_nonzero_6
-        S2N_ASM_HIDDEN(bignum_nonzero_6)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_nonzero_6
-        S2N_ASM_HIDDEN(_bignum_nonzero_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_nonzero_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_nonzero_6)
 
         .text
 
@@ -38,25 +37,34 @@
 
 
 
-bignum_nonzero_6:
-_bignum_nonzero_6:
+S2N_BN_SYMBOL(bignum_nonzero_6):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+#endif
 
 // Generate a = an OR of all the words in the bignum
 
-                movq    (x), a
-                movq    8(x), d
-                orq     16(x), a
-                orq     24(x), d
-                orq     32(x), a
-                orq     40(x), d
-                orq     d, a
+        movq    (x), a
+        movq    8(x), d
+        orq     16(x), a
+        orq     24(x), d
+        orq     32(x), a
+        orq     40(x), d
+        orq     d, a
 
 // Set a standard C condition based on whether a is nonzero
 
-                movl    $1, dshort
-                cmovnzq d, a
+        movl    $1, dshort
+        cmovnzq d, a
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_optneg_p384
-        .private_extern bignum_optneg_p384
+        S2N_ASM_HIDDEN(bignum_optneg_p384)
 
         .globl _bignum_optneg_p384
-        .private_extern _bignum_optneg_p384
+        S2N_ASM_HIDDEN(_bignum_optneg_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_optneg_p384
-        .globl  _bignum_optneg_p384
+        .globl bignum_optneg_p384
+        .private_extern bignum_optneg_p384
+
+        .globl _bignum_optneg_p384
+        .private_extern _bignum_optneg_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
@@ -22,14 +22,13 @@
 //      (uint64_t z[static 6], uint64_t p, uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
+// Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_optneg_p384
-        S2N_ASM_HIDDEN(bignum_optneg_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_optneg_p384
-        S2N_ASM_HIDDEN(_bignum_optneg_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p384)
 
         .text
 
@@ -46,71 +45,82 @@
 
 #define n0short %eax
 
-bignum_optneg_p384:
-_bignum_optneg_p384:
+S2N_BN_SYMBOL(bignum_optneg_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Adjust q by zeroing it if the input is zero (to avoid giving -0 = p_384,
 // which is not strictly reduced even though it's correct modulo p_384).
 // This step is redundant if we know a priori that the input is nonzero, which
 // is the case for the y coordinate of points on the P-384 curve, for example.
 
-                movq    (x), n0
-                orq     8(x), n0
-                movq    16(x), n1
-                orq     24(x), n1
-                movq    32(x), n2
-                orq     40(x), n2
-                orq     n1, n0
-                orq     n2, n0
-                negq    n0
-                sbbq    n0, n0
-                andq    n0, q
+        movq    (x), n0
+        orq     8(x), n0
+        movq    16(x), n1
+        orq     24(x), n1
+        movq    32(x), n2
+        orq     40(x), n2
+        orq     n1, n0
+        orq     n2, n0
+        negq    n0
+        sbbq    n0, n0
+        andq    n0, q
 
 // Turn q into a bitmask, all 1s for q=false, all 0s for q=true
 
-                negq    q
-                sbbq    q, q
-                notq    q
+        negq    q
+        sbbq    q, q
+        notq    q
 
 // Let [n5;n4;n3;n2;n1] = if q then p_384 else -1
 
-                movl    $0x00000000ffffffff, n0short
-                orq     q, n0
-                movq    $0xffffffff00000000, n1
-                orq     q, n1
-                movq    $0xfffffffffffffffe, n2
-                orq     q, n2
-                movq    $0xffffffffffffffff, n3
-                movq    n3, n4
-                movq    n3, n5
+        movl    $0x00000000ffffffff, n0short
+        orq     q, n0
+        movq    $0xffffffff00000000, n1
+        orq     q, n1
+        movq    $0xfffffffffffffffe, n2
+        orq     q, n2
+        movq    $0xffffffffffffffff, n3
+        movq    n3, n4
+        movq    n3, n5
 
 // Subtract so [n5;n4;n3;n2;n1;n0] = if q then p_384 - x else -1 - x
 
-                subq    (x), n0
-                sbbq    8(x), n1
-                sbbq    16(x), n2
-                sbbq    24(x), n3
-                sbbq    32(x), n4
-                sbbq    40(x), n5
+        subq    (x), n0
+        sbbq    8(x), n1
+        sbbq    16(x), n2
+        sbbq    24(x), n3
+        sbbq    32(x), n4
+        sbbq    40(x), n5
 
 // XOR the words with the bitmask, which in the case q = false has the
 // effect of restoring ~(-1 - x) = -(-1 - x) - 1 = 1 + x - 1 = x
 // and write back the digits to the output
 
-                xorq    q, n0
-                movq    n0, (z)
-                xorq    q, n1
-                movq    n1, 8(z)
-                xorq    q, n2
-                movq    n2, 16(z)
-                xorq    q, n3
-                movq    n3, 24(z)
-                xorq    q, n4
-                movq    n4, 32(z)
-                xorq    q, n5
-                movq    n5, 40(z)
+        xorq    q, n0
+        movq    n0, (z)
+        xorq    q, n1
+        movq    n1, 8(z)
+        xorq    q, n2
+        movq    n2, 16(z)
+        xorq    q, n3
+        movq    n3, 24(z)
+        xorq    q, n4
+        movq    n4, 32(z)
+        xorq    q, n5
+        movq    n5, 40(z)
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sub_p384
-        .private_extern bignum_sub_p384
+        S2N_ASM_HIDDEN(bignum_sub_p384)
 
         .globl _bignum_sub_p384
-        .private_extern _bignum_sub_p384
+        S2N_ASM_HIDDEN(_bignum_sub_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_sub_p384
-        S2N_ASM_HIDDEN(bignum_sub_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_sub_p384
-        S2N_ASM_HIDDEN(_bignum_sub_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p384)
 
         .text
 
@@ -52,8 +51,15 @@
 
 
 
-bignum_sub_p384:
-_bignum_sub_p384:
+S2N_BN_SYMBOL(bignum_sub_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Subtract the inputs as [d5;d4;d3;d2;d1;d0] = x - y (modulo 2^384)
 // Capture the top carry as a bitmask for the condition x < y
@@ -107,6 +113,10 @@ _bignum_sub_p384:
         sbbq    $0, d5
         movq    d5, 40(z)
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_sub_p384
-        .globl  _bignum_sub_p384
+        .globl bignum_sub_p384
+        .private_extern bignum_sub_p384
+
+        .globl _bignum_sub_p384
+        .private_extern _bignum_sub_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tomont_p384
-        .private_extern bignum_tomont_p384
+        S2N_ASM_HIDDEN(bignum_tomont_p384)
 
         .globl _bignum_tomont_p384
-        .private_extern _bignum_tomont_p384
+        S2N_ASM_HIDDEN(_bignum_tomont_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 6], uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_tomont_p384
-        S2N_ASM_HIDDEN(bignum_tomont_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_tomont_p384
-        S2N_ASM_HIDDEN(_bignum_tomont_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p384)
 
         .text
 
@@ -74,31 +73,37 @@
 
 #define montredc(d7,d6,d5,d4,d3,d2,d1,d0)                               \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
-                movq    d0, %rdx ;                                        \
-                shlq    $32, %rdx ;                                        \
-                addq    d0, %rdx ;                                        \
+        movq    d0, %rdx ;                                        \
+        shlq    $32, %rdx ;                                        \
+        addq    d0, %rdx ;                                        \
 /* Construct [%rbp;%rcx;%rax;-] = (2^384 - p_384) * w */                   \
 /* We know the lowest word will cancel so we can re-use d0 as a temp */ \
-                xorl    %ebp, %ebp ;                                       \
-                movq    $0xffffffff00000001, %rax ;                        \
-                mulxq   %rax, %rcx, %rax ;                                  \
-                movl    $0x00000000ffffffff, %ecx ;                        \
-                mulxq   %rcx, d0, %rcx ;                                   \
-                adcq    d0, %rax ;                                        \
-                adcq    %rdx, %rcx ;                                       \
-                adcl    %ebp, %ebp ;                                       \
+        xorl    %ebp, %ebp ;                                       \
+        movq    $0xffffffff00000001, %rax ;                        \
+        mulxq   %rax, %rcx, %rax ;                                  \
+        movl    $0x00000000ffffffff, %ecx ;                        \
+        mulxq   %rcx, d0, %rcx ;                                   \
+        adcq    d0, %rax ;                                        \
+        adcq    %rdx, %rcx ;                                       \
+        adcl    %ebp, %ebp ;                                       \
 /*  Now subtract that and add 2^384 * w */                              \
-                subq    %rax, d1 ;                                        \
-                sbbq    %rcx, d2 ;                                        \
-                sbbq    %rbp, d3 ;                                        \
-                sbbq    $0, d4 ;                                          \
-                sbbq    $0, d5 ;                                          \
-                sbbq    $0, %rdx ;                                         \
-                addq    %rdx, d6 ;                                        \
-                adcq    $0, d7
+        subq    %rax, d1 ;                                        \
+        sbbq    %rcx, d2 ;                                        \
+        sbbq    %rbp, d3 ;                                        \
+        sbbq    $0, d4 ;                                          \
+        sbbq    $0, d5 ;                                          \
+        sbbq    $0, %rdx ;                                         \
+        addq    %rdx, d6 ;                                        \
+        adcq    $0, d7
 
-bignum_tomont_p384:
-_bignum_tomont_p384:
+S2N_BN_SYMBOL(bignum_tomont_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // We are essentially just doing a Montgomery multiplication of x and the
 // precomputed constant y = 2^768 mod p, so the code is almost the same
@@ -286,6 +291,10 @@ _bignum_tomont_p384:
         popq    %r12
         popq    %rbp
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_tomont_p384
-        .globl  _bignum_tomont_p384
+        .globl bignum_tomont_p384
+        .private_extern bignum_tomont_p384
+
+        .globl _bignum_tomont_p384
+        .private_extern _bignum_tomont_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tomont_p384_alt
-        .private_extern bignum_tomont_p384_alt
+        S2N_ASM_HIDDEN(bignum_tomont_p384_alt)
 
         .globl _bignum_tomont_p384_alt
-        .private_extern _bignum_tomont_p384_alt
+        S2N_ASM_HIDDEN(_bignum_tomont_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_tomont_p384_alt
-        .globl  _bignum_tomont_p384_alt
+        .globl bignum_tomont_p384_alt
+        .private_extern bignum_tomont_p384_alt
+
+        .globl _bignum_tomont_p384_alt
+        .private_extern _bignum_tomont_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 6], uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_tomont_p384_alt
-        S2N_ASM_HIDDEN(bignum_tomont_p384_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_tomont_p384_alt
-        S2N_ASM_HIDDEN(_bignum_tomont_p384_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p384_alt)
 
         .text
 
@@ -91,32 +90,38 @@
 
 #define montredc(d7,d6,d5,d4,d3,d2,d1,d0)                               \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64 */         \
-                movq    d0, %rbx ;                                        \
-                shlq    $32, %rbx ;                                        \
-                addq    d0, %rbx ;                                        \
+        movq    d0, %rbx ;                                        \
+        shlq    $32, %rbx ;                                        \
+        addq    d0, %rbx ;                                        \
 /* Construct [%rcx;%rdx;%rax;-] = (2^384 - p_384) * w */                   \
 /* We know the lowest word will cancel so we can re-use d0 as a temp */ \
-                xorl    %ecx, %ecx ;                                       \
-                movq    $0xffffffff00000001, %rax ;                        \
-                mulq    %rbx;                                            \
-                movq    %rdx, d0 ;                                        \
-                movq    $0x00000000ffffffff, %rax ;                        \
-                mulq    %rbx;                                            \
-                addq    d0, %rax ;                                        \
-                adcq    %rbx, %rdx ;                                       \
-                adcl    %ecx, %ecx ;                                       \
+        xorl    %ecx, %ecx ;                                       \
+        movq    $0xffffffff00000001, %rax ;                        \
+        mulq    %rbx;                                            \
+        movq    %rdx, d0 ;                                        \
+        movq    $0x00000000ffffffff, %rax ;                        \
+        mulq    %rbx;                                            \
+        addq    d0, %rax ;                                        \
+        adcq    %rbx, %rdx ;                                       \
+        adcl    %ecx, %ecx ;                                       \
 /*  Now subtract that and add 2^384 * w */                              \
-                subq    %rax, d1 ;                                        \
-                sbbq    %rdx, d2 ;                                        \
-                sbbq    %rcx, d3 ;                                        \
-                sbbq    $0, d4 ;                                          \
-                sbbq    $0, d5 ;                                          \
-                sbbq    $0, %rbx ;                                         \
-                addq    %rbx, d6 ;                                        \
-                adcq    $0, d7
+        subq    %rax, d1 ;                                        \
+        sbbq    %rdx, d2 ;                                        \
+        sbbq    %rcx, d3 ;                                        \
+        sbbq    $0, d4 ;                                          \
+        sbbq    $0, d5 ;                                          \
+        sbbq    $0, %rbx ;                                         \
+        addq    %rbx, d6 ;                                        \
+        adcq    $0, d7
 
-bignum_tomont_p384_alt:
-_bignum_tomont_p384_alt:
+S2N_BN_SYMBOL(bignum_tomont_p384_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // We are essentially just doing a Montgomery multiplication of x and the
 // precomputed constant y = 2^768 mod p, so the code is almost the same
@@ -315,6 +320,10 @@ _bignum_tomont_p384_alt:
         popq    %r12
         popq    %rbx
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p384
-        .private_extern bignum_triple_p384
+        S2N_ASM_HIDDEN(bignum_triple_p384)
 
         .globl _bignum_triple_p384
-        .private_extern _bignum_triple_p384
+        S2N_ASM_HIDDEN(_bignum_triple_p384)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_triple_p384
-        .globl  _bignum_triple_p384
+        .globl bignum_triple_p384
+        .private_extern bignum_triple_p384
+
+        .globl _bignum_triple_p384
+        .private_extern _bignum_triple_p384
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
@@ -24,14 +24,13 @@
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_384.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_triple_p384
-        S2N_ASM_HIDDEN(bignum_triple_p384)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_triple_p384
-        S2N_ASM_HIDDEN(_bignum_triple_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p384)
 
         .text
 
@@ -52,95 +51,105 @@
 #define ashort %eax
 #define qshort %edx
 
-bignum_triple_p384:
-_bignum_triple_p384:
+S2N_BN_SYMBOL(bignum_triple_p384):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // We seem to need (just!) one extra register, which we need to save and restore
 
-                pushq   %rbx
+        pushq   %rbx
 
 // Multiply, accumulating the result as 2^384 * h + [d5;d4;d3;d2;d1;d0]
 // but actually immediately producing q = h + 1, our quotient approximation,
 // by adding 1 to it.
 
-                xorl    ashort, ashort
+        xorl    ashort, ashort
 
-                movq    (x), q
-                movq    q, d0
-                adcxq   q, q
-                adoxq   q, d0
-                movq    8(x), q
-                movq    q, d1
-                adcxq   q, q
-                adoxq   q, d1
-                movq    16(x), q
-                movq    q, d2
-                adcxq   q, q
-                adoxq   q, d2
-                movq    24(x), q
-                movq    q, d3
-                adcxq   q, q
-                adoxq   q, d3
-                movq    32(x), q
-                movq    q, d4
-                adcxq   q, q
-                adoxq   q, d4
-                movq    40(x), q
-                movq    q, d5
-                adcxq   q, q
-                adoxq   q, d5
+        movq    (x), q
+        movq    q, d0
+        adcxq   q, q
+        adoxq   q, d0
+        movq    8(x), q
+        movq    q, d1
+        adcxq   q, q
+        adoxq   q, d1
+        movq    16(x), q
+        movq    q, d2
+        adcxq   q, q
+        adoxq   q, d2
+        movq    24(x), q
+        movq    q, d3
+        adcxq   q, q
+        adoxq   q, d3
+        movq    32(x), q
+        movq    q, d4
+        adcxq   q, q
+        adoxq   q, d4
+        movq    40(x), q
+        movq    q, d5
+        adcxq   q, q
+        adoxq   q, d5
 
-                movl    $1, qshort
-                adcxq   a, q
-                adoxq   a, q
+        movl    $1, qshort
+        adcxq   a, q
+        adoxq   a, q
 
 // Initial subtraction of z - q * p_384, with bitmask c for the carry
 // Actually done as an addition of (z - 2^384 * h) + q * (2^384 - p_384)
 // which, because q = h + 1, is exactly 2^384 + (z - q * p_384), and
 // therefore CF <=> 2^384 + (z - q * p_384) >= 2^384 <=> z >= q * p_384.
 
-                movq    q, c
-                shlq    $32, c
-                movq    q, a
-                subq    c, a
-                sbbq    $0, c
+        movq    q, c
+        shlq    $32, c
+        movq    q, a
+        subq    c, a
+        sbbq    $0, c
 
-                addq    a, d0
-                adcq    c, d1
-                adcq    q, d2
-                adcq    $0, d3
-                adcq    $0, d4
-                adcq    $0, d5
-                sbbq    c, c
-                notq    c
+        addq    a, d0
+        adcq    c, d1
+        adcq    q, d2
+        adcq    $0, d3
+        adcq    $0, d4
+        adcq    $0, d5
+        sbbq    c, c
+        notq    c
 
 // Now use that mask for a masked addition of p_384, which again is in
 // fact done by a masked subtraction of 2^384 - p_384, so that we only
 // have three nonzero digits and so can avoid using another register.
 
-                movl    $0x00000000ffffffff, qshort
-                xorl    ashort, ashort
-                andq    c, q
-                subq    q, a
-                negq    c
+        movl    $0x00000000ffffffff, qshort
+        xorl    ashort, ashort
+        andq    c, q
+        subq    q, a
+        negq    c
 
-                subq    a, d0
-                movq    d0, (z)
-                sbbq    q, d1
-                movq    d1, 8(z)
-                sbbq    c, d2
-                movq    d2, 16(z)
-                sbbq    $0, d3
-                movq    d3, 24(z)
-                sbbq    $0, d4
-                movq    d4, 32(z)
-                sbbq    $0, d5
-                movq    d5, 40(z)
+        subq    a, d0
+        movq    d0, (z)
+        sbbq    q, d1
+        movq    d1, 8(z)
+        sbbq    c, d2
+        movq    d2, 16(z)
+        sbbq    $0, d3
+        movq    d3, 24(z)
+        sbbq    $0, d4
+        movq    d4, 32(z)
+        sbbq    $0, d5
+        movq    d5, 40(z)
 
 // Return
 
-                popq    %rbx
-                ret
+        popq    %rbx
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p384_alt
-        .private_extern bignum_triple_p384_alt
+        S2N_ASM_HIDDEN(bignum_triple_p384_alt)
 
         .globl _bignum_triple_p384_alt
-        .private_extern _bignum_triple_p384_alt
+        S2N_ASM_HIDDEN(_bignum_triple_p384_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
@@ -24,14 +24,13 @@
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_384.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_triple_p384_alt
-        S2N_ASM_HIDDEN(bignum_triple_p384_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_triple_p384_alt
-        S2N_ASM_HIDDEN(_bignum_triple_p384_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p384_alt)
 
         .text
 
@@ -55,102 +54,112 @@
 #define qshort %ecx
 #define dshort %edx
 
-bignum_triple_p384_alt:
-_bignum_triple_p384_alt:
+S2N_BN_SYMBOL(bignum_triple_p384_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // We seem to need (just!) one extra register, which we need to save and restore
 
-                pushq   %rbx
+        pushq   %rbx
 
 // Multiply, accumulating the result as 2^384 * h + [d5;d4;d3;d2;d1;d0]
 // but actually immediately producing q = h + 1, our quotient approximation,
 // by adding 1 to it.
 
-                movl    $3, cshort
+        movl    $3, cshort
 
-                movq    (x), a
-                mulq    c
-                movq    a, d0
-                movq    d, d1
+        movq    (x), a
+        mulq    c
+        movq    a, d0
+        movq    d, d1
 
-                movq    8(x), a
-                xorq    d2, d2
-                mulq    c
-                addq    a, d1
-                adcq    d, d2
+        movq    8(x), a
+        xorq    d2, d2
+        mulq    c
+        addq    a, d1
+        adcq    d, d2
 
-                movq    16(x), a
-                xorq    d3, d3
-                mulq    c
-                addq    a, d2
-                adcq    d, d3
+        movq    16(x), a
+        xorq    d3, d3
+        mulq    c
+        addq    a, d2
+        adcq    d, d3
 
-                movq    24(x), a
-                xorq    d4, d4
-                mulq    c
-                addq    a, d3
-                adcq    d, d4
+        movq    24(x), a
+        xorq    d4, d4
+        mulq    c
+        addq    a, d3
+        adcq    d, d4
 
-                movq    32(x), a
-                mulq    c
-                addq    a, d4
-                adcq    $0, d
+        movq    32(x), a
+        mulq    c
+        addq    a, d4
+        adcq    $0, d
 
-                movq    40(x), a
-                movq    d, d5
-                mulq    c
-                addq    a, d5
+        movq    40(x), a
+        movq    d, d5
+        mulq    c
+        addq    a, d5
 
-                movl    $1, qshort
-                adcq    d, q
+        movl    $1, qshort
+        adcq    d, q
 
 // Initial subtraction of z - q * p_384, with bitmask c for the carry
 // Actually done as an addition of (z - 2^384 * h) + q * (2^384 - p_384)
 // which, because q = h + 1, is exactly 2^384 + (z - q * p_384), and
 // therefore CF <=> 2^384 + (z - q * p_384) >= 2^384 <=> z >= q * p_384.
 
-                movq    q, d
-                shlq    $32, d
-                movq    q, a
-                subq    d, a
-                sbbq    $0, d
+        movq    q, d
+        shlq    $32, d
+        movq    q, a
+        subq    d, a
+        sbbq    $0, d
 
-                addq    a, d0
-                adcq    d, d1
-                adcq    q, d2
-                adcq    $0, d3
-                adcq    $0, d4
-                adcq    $0, d5
-                sbbq    d, d
-                notq    d
+        addq    a, d0
+        adcq    d, d1
+        adcq    q, d2
+        adcq    $0, d3
+        adcq    $0, d4
+        adcq    $0, d5
+        sbbq    d, d
+        notq    d
 
 // Now use that mask for a masked addition of p_384, which again is in
 // fact done by a masked subtraction of 2^384 - p_384, so that we only
 // have three nonzero digits and so can avoid using another register.
 
-                movl    $0x00000000ffffffff, qshort
-                xorl    ashort, ashort
-                andq    d, q
-                subq    q, a
-                negq    d
+        movl    $0x00000000ffffffff, qshort
+        xorl    ashort, ashort
+        andq    d, q
+        subq    q, a
+        negq    d
 
-                subq    a, d0
-                movq    d0, (z)
-                sbbq    q, d1
-                movq    d1, 8(z)
-                sbbq    d, d2
-                movq    d2, 16(z)
-                sbbq    $0, d3
-                movq    d3, 24(z)
-                sbbq    $0, d4
-                movq    d4, 32(z)
-                sbbq    $0, d5
-                movq    d5, 40(z)
+        subq    a, d0
+        movq    d0, (z)
+        sbbq    q, d1
+        movq    d1, 8(z)
+        sbbq    d, d2
+        movq    d2, 16(z)
+        sbbq    $0, d3
+        movq    d3, 24(z)
+        sbbq    $0, d4
+        movq    d4, 32(z)
+        sbbq    $0, d5
+        movq    d5, 40(z)
 
 // Return
 
-                popq    %rbx
-                ret
+        popq    %rbx
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_triple_p384_alt
-        .globl  _bignum_triple_p384_alt
+        .globl bignum_triple_p384_alt
+        .private_extern bignum_triple_p384_alt
+
+        .globl _bignum_triple_p384_alt
+        .private_extern _bignum_triple_p384_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_add_p521
-        .globl  _bignum_add_p521
+        .globl bignum_add_p521
+        .private_extern bignum_add_p521
+
+        .globl _bignum_add_p521
+        .private_extern _bignum_add_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_add_p521
-        S2N_ASM_HIDDEN(bignum_add_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_add_p521
-        S2N_ASM_HIDDEN(_bignum_add_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p521)
 
         .text
 
@@ -52,8 +51,15 @@
 
 
 
-bignum_add_p521:
-_bignum_add_p521:
+S2N_BN_SYMBOL(bignum_add_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save more registers to play with
 
@@ -120,6 +126,10 @@ _bignum_add_p521:
         popq    %r12
         popq    %rbx
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_add_p521
-        .private_extern bignum_add_p521
+        S2N_ASM_HIDDEN(bignum_add_p521)
 
         .globl _bignum_add_p521
-        .private_extern _bignum_add_p521
+        S2N_ASM_HIDDEN(_bignum_add_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p521
-        .private_extern bignum_cmul_p521
+        S2N_ASM_HIDDEN(bignum_cmul_p521)
 
         .globl _bignum_cmul_p521
-        .private_extern _bignum_cmul_p521
+        S2N_ASM_HIDDEN(_bignum_cmul_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_cmul_p521
-        .globl  _bignum_cmul_p521
+        .globl bignum_cmul_p521
+        .private_extern bignum_cmul_p521
+
+        .globl _bignum_cmul_p521
+        .private_extern _bignum_cmul_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
@@ -22,14 +22,13 @@
 //     (uint64_t z[static 9], uint64_t c, uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
+// Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_cmul_p521
-        S2N_ASM_HIDDEN(bignum_cmul_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_cmul_p521
-        S2N_ASM_HIDDEN(_bignum_cmul_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p521)
 
         .text
 
@@ -64,41 +63,48 @@
 
 #define h d9
 
-bignum_cmul_p521:
-_bignum_cmul_p521:
+S2N_BN_SYMBOL(bignum_cmul_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save additional registers to use
 
-                pushq   %rbx
-                pushq   %rbp
-                pushq   %r12
-                pushq   %r13
+        pushq   %rbx
+        pushq   %rbp
+        pushq   %r12
+        pushq   %r13
 
 // Shuffle inputs (since we want the multiplier in %rdx)
 
-                movq    %rdx, x
-                movq    %rsi, c
+        movq    %rdx, x
+        movq    %rsi, c
 
 // Multiply as [d9; ...; d0] = c * x.
 
-                mulxq   (x), d0, d1
-                mulxq   8(x), a, d2
-                addq    a, d1
-                mulxq   16(x), a, d3
-                adcq    a, d2
-                mulxq   24(x), a, d4
-                adcq    a, d3
-                mulxq   32(x), a, d5
-                adcq    a, d4
-                mulxq   40(x), a, d6
-                adcq    a, d5
-                mulxq   48(x), a, d7
-                adcq    a, d6
-                mulxq   56(x), a, d8
-                adcq    a, d7
-                mulxq   64(x), a, d9
-                adcq    a, d8
-                adcq    $0, d9
+        mulxq   (x), d0, d1
+        mulxq   8(x), a, d2
+        addq    a, d1
+        mulxq   16(x), a, d3
+        adcq    a, d2
+        mulxq   24(x), a, d4
+        adcq    a, d3
+        mulxq   32(x), a, d5
+        adcq    a, d4
+        mulxq   40(x), a, d6
+        adcq    a, d5
+        mulxq   48(x), a, d7
+        adcq    a, d6
+        mulxq   56(x), a, d8
+        adcq    a, d7
+        mulxq   64(x), a, d9
+        adcq    a, d8
+        adcq    $0, d9
 
 // Create an AND "dd" of digits d7,...,d1, a computation we hope will
 // get nicely interleaved with the multiplication chain above.
@@ -106,19 +112,19 @@ _bignum_cmul_p521:
 // bunch it up here since AND destroys the flags and we overwrite the
 // register used as a stage temporary variable for the multiplications.
 
-                movq    d1, dd
-                andq    d2, dd
-                andq    d3, dd
-                andq    d4, dd
-                andq    d5, dd
-                andq    d6, dd
-                andq    d7, dd
+        movq    d1, dd
+        andq    d2, dd
+        andq    d3, dd
+        andq    d4, dd
+        andq    d5, dd
+        andq    d6, dd
+        andq    d7, dd
 
 // Extract the high part h==d9 and mask off the low part l = [d8;d7;...;d0]
 // but stuff d8 with 1 bits at the left to ease a comparison below
 
-                shldq   $55, d8, h
-                orq     $~0x1FF, d8
+        shldq   $55, d8, h
+        orq     $~0x1FF, d8
 
 // Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
 // happen if digits d7,...d1 are all 1s, we use the AND of them "dd" to
@@ -127,46 +133,50 @@ _bignum_cmul_p521:
 // Since x was assumed reduced, h cannot be maximal, so the "lea" is safe,
 // i.e. does not carry or wrap round.
 
-                leaq    1(h), c
-                addq    d0, c
-                movl    $0, cshort
-                adcq    c, dd
-                movq    d8, a
-                adcq    c, a
+        leaq    1(h), c
+        addq    d0, c
+        movl    $0, cshort
+        adcq    c, dd
+        movq    d8, a
+        adcq    c, a
 
 // Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
 // while otherwise we want just h + l. So mask h + l + CF to 521 bits.
 // This masking also gets rid of the stuffing with 1s we did above.
 // Write back the digits as they are generated.
 
-                adcq    h, d0
-                movq    d0, (z)
-                adcq    c, d1
-                movq    d1, 8(z)
-                adcq    c, d2
-                movq    d2, 16(z)
-                adcq    c, d3
-                movq    d3, 24(z)
-                adcq    c, d4
-                movq    d4, 32(z)
-                adcq    c, d5
-                movq    d5, 40(z)
-                adcq    c, d6
-                movq    d6, 48(z)
-                adcq    c, d7
-                movq    d7, 56(z)
-                adcq    c, d8
-                andq    $0x1FF, d8
-                movq    d8, 64(z)
+        adcq    h, d0
+        movq    d0, (z)
+        adcq    c, d1
+        movq    d1, 8(z)
+        adcq    c, d2
+        movq    d2, 16(z)
+        adcq    c, d3
+        movq    d3, 24(z)
+        adcq    c, d4
+        movq    d4, 32(z)
+        adcq    c, d5
+        movq    d5, 40(z)
+        adcq    c, d6
+        movq    d6, 48(z)
+        adcq    c, d7
+        movq    d7, 56(z)
+        adcq    c, d8
+        andq    $0x1FF, d8
+        movq    d8, 64(z)
 
 // Restore registers and return
 
-                popq    %r13
-                popq    %r12
-                popq    %rbp
-                popq    %rbx
+        popq    %r13
+        popq    %r12
+        popq    %rbp
+        popq    %rbx
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
@@ -22,14 +22,13 @@
 //     (uint64_t z[static 9], uint64_t c, uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
+// Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_cmul_p521_alt
-        S2N_ASM_HIDDEN(bignum_cmul_p521_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_cmul_p521_alt
-        S2N_ASM_HIDDEN(_bignum_cmul_p521_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p521_alt)
 
         .text
 
@@ -68,91 +67,98 @@
 
 #define h d9
 
-bignum_cmul_p521_alt:
-_bignum_cmul_p521_alt:
+S2N_BN_SYMBOL(bignum_cmul_p521_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save additional registers to use
 
-                pushq   %rbx
-                pushq   %rbp
-                pushq   %r12
-                pushq   %r13
+        pushq   %rbx
+        pushq   %rbp
+        pushq   %r12
+        pushq   %r13
 
 // Shuffle inputs (since we want %rdx for the high parts of products)
 
-                movq    %rdx, x
+        movq    %rdx, x
 
 // Multiply as [d9; ...; d0] = c * x.
 
-                movq    (x), a
-                mulq    m
-                movq    a, d0
-                movq    d, d1
+        movq    (x), a
+        mulq    m
+        movq    a, d0
+        movq    d, d1
 
-                movq    8(x), a
-                mulq    m
-                xorq    d2, d2
-                addq    a, d1
-                adcq    d, d2
+        movq    8(x), a
+        mulq    m
+        xorq    d2, d2
+        addq    a, d1
+        adcq    d, d2
 
-                movq    16(x), a
-                mulq    m
-                xorq    d3, d3
-                addq    a, d2
-                adcq    d, d3
+        movq    16(x), a
+        mulq    m
+        xorq    d3, d3
+        addq    a, d2
+        adcq    d, d3
 
-                movq    24(x), a
-                mulq    m
-                xorq    d4, d4
-                addq    a, d3
-                adcq    d, d4
+        movq    24(x), a
+        mulq    m
+        xorq    d4, d4
+        addq    a, d3
+        adcq    d, d4
 
-                movq    32(x), a
-                mulq    m
-                xorq    d5, d5
-                addq    a, d4
-                adcq    d, d5
+        movq    32(x), a
+        mulq    m
+        xorq    d5, d5
+        addq    a, d4
+        adcq    d, d5
 
-                movq    40(x), a
-                mulq    m
-                xorq    d6, d6
-                addq    a, d5
-                adcq    d, d6
+        movq    40(x), a
+        mulq    m
+        xorq    d6, d6
+        addq    a, d5
+        adcq    d, d6
 
-                movq    48(x), a
-                mulq    m
-                xorq    d7, d7
-                addq    a, d6
-                adcq    d, d7
+        movq    48(x), a
+        mulq    m
+        xorq    d7, d7
+        addq    a, d6
+        adcq    d, d7
 
-                movq    56(x), a
-                mulq    m
-                addq    a, d7
-                movq    64(x), a
-                movq    $0, d8
-                adcq    d, d8
-                mulq    m
-                xorq    d9, d9
-                addq    a, d8
-                adcq    d, d9
+        movq    56(x), a
+        mulq    m
+        addq    a, d7
+        movq    64(x), a
+        movq    $0, d8
+        adcq    d, d8
+        mulq    m
+        xorq    d9, d9
+        addq    a, d8
+        adcq    d, d9
 
 // Create an AND "dd" of digits d7,...,d1, a computation we hope will
 // get nicely interleaved with the multiplication chain above, though
 // we can't do so directly as we are using the same register %rax.
 
-                movq    d1, dd
-                andq    d2, dd
-                andq    d3, dd
-                andq    d4, dd
-                andq    d5, dd
-                andq    d6, dd
-                andq    d7, dd
+        movq    d1, dd
+        andq    d2, dd
+        andq    d3, dd
+        andq    d4, dd
+        andq    d5, dd
+        andq    d6, dd
+        andq    d7, dd
 
 // Extract the high part h==d9 and mask off the low part l = [d8;d7;...;d0]
 // but stuff d8 with 1 bits at the left to ease a comparison below
 
-                shldq   $55, d8, h
-                orq     $~0x1FF, d8
+        shldq   $55, d8, h
+        orq     $~0x1FF, d8
 
 // Decide whether h + l >= p_521 <=> h + l + 1 >= 2^521. Since this can only
 // happen if digits d7,...d1 are all 1s, we use the AND of them "dd" to
@@ -161,46 +167,50 @@ _bignum_cmul_p521_alt:
 // Since x was assumed reduced, h cannot be maximal, so the "lea" is safe,
 // i.e. does not carry or wrap round.
 
-                leaq    1(h), c
-                addq    d0, c
-                movl    $0, cshort
-                adcq    c, dd
-                movq    d8, a
-                adcq    c, a
+        leaq    1(h), c
+        addq    d0, c
+        movl    $0, cshort
+        adcq    c, dd
+        movq    d8, a
+        adcq    c, a
 
 // Now if CF is set we want (h + l) - p_521 = (h + l + 1) - 2^521
 // while otherwise we want just h + l. So mask h + l + CF to 521 bits.
 // This masking also gets rid of the stuffing with 1s we did above.
 // Write back the digits as they are generated.
 
-                adcq    h, d0
-                movq    d0, (z)
-                adcq    c, d1
-                movq    d1, 8(z)
-                adcq    c, d2
-                movq    d2, 16(z)
-                adcq    c, d3
-                movq    d3, 24(z)
-                adcq    c, d4
-                movq    d4, 32(z)
-                adcq    c, d5
-                movq    d5, 40(z)
-                adcq    c, d6
-                movq    d6, 48(z)
-                adcq    c, d7
-                movq    d7, 56(z)
-                adcq    c, d8
-                andq    $0x1FF, d8
-                movq    d8, 64(z)
+        adcq    h, d0
+        movq    d0, (z)
+        adcq    c, d1
+        movq    d1, 8(z)
+        adcq    c, d2
+        movq    d2, 16(z)
+        adcq    c, d3
+        movq    d3, 24(z)
+        adcq    c, d4
+        movq    d4, 32(z)
+        adcq    c, d5
+        movq    d5, 40(z)
+        adcq    c, d6
+        movq    d6, 48(z)
+        adcq    c, d7
+        movq    d7, 56(z)
+        adcq    c, d8
+        andq    $0x1FF, d8
+        movq    d8, 64(z)
 
 // Restore registers and return
 
-                popq    %r13
-                popq    %r12
-                popq    %rbp
-                popq    %rbx
+        popq    %r13
+        popq    %r12
+        popq    %rbp
+        popq    %rbx
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_cmul_p521_alt
-        .private_extern bignum_cmul_p521_alt
+        S2N_ASM_HIDDEN(bignum_cmul_p521_alt)
 
         .globl _bignum_cmul_p521_alt
-        .private_extern _bignum_cmul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_cmul_p521_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_cmul_p521_alt
-        .globl  _bignum_cmul_p521_alt
+        .globl bignum_cmul_p521_alt
+        .private_extern bignum_cmul_p521_alt
+
+        .globl _bignum_cmul_p521_alt
+        .private_extern _bignum_cmul_p521_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_deamont_p521
-        .private_extern bignum_deamont_p521
+        S2N_ASM_HIDDEN(bignum_deamont_p521)
 
         .globl _bignum_deamont_p521
-        .private_extern _bignum_deamont_p521
+        S2N_ASM_HIDDEN(_bignum_deamont_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_deamont_p521
-        .globl  _bignum_deamont_p521
+        .globl bignum_deamont_p521
+        .private_extern bignum_deamont_p521
+
+        .globl _bignum_deamont_p521
+        .private_extern _bignum_deamont_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
@@ -24,14 +24,13 @@
 // "almost" meaning any 9-digit input will work, with no range restriction.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_deamont_p521
-        S2N_ASM_HIDDEN(bignum_deamont_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_deamont_p521
-        S2N_ASM_HIDDEN(_bignum_deamont_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p521)
 
         .text
 
@@ -52,8 +51,14 @@
 #define d7 %r13
 #define d8 %rbp
 
-bignum_deamont_p521:
-_bignum_deamont_p521:
+S2N_BN_SYMBOL(bignum_deamont_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save more registers to play with
 
@@ -138,6 +143,10 @@ _bignum_deamont_p521:
         popq    %r12
         popq    %rbx
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
@@ -24,14 +24,13 @@
 // use the variant "bignum_deamont_p521" instead.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_demont_p521
-        S2N_ASM_HIDDEN(bignum_demont_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_demont_p521
-        S2N_ASM_HIDDEN(_bignum_demont_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p521)
 
         .text
 
@@ -52,8 +51,14 @@
 #define d7 %rcx
 #define d8 %rdx
 
-bignum_demont_p521:
-_bignum_demont_p521:
+S2N_BN_SYMBOL(bignum_demont_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Rotate, as a 521-bit quantity, by 9*64 - 521 = 55 bits right.
 
@@ -87,6 +92,10 @@ _bignum_demont_p521:
         movq    d7, 56(z)
         shrq    $55, d8
         movq    d8, 64(z)
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
@@ -25,13 +25,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_demont_p521
-        .private_extern bignum_demont_p521
+        S2N_ASM_HIDDEN(bignum_demont_p521)
 
         .globl _bignum_demont_p521
-        .private_extern _bignum_demont_p521
+        S2N_ASM_HIDDEN(_bignum_demont_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
@@ -27,8 +27,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_demont_p521
-        .globl  _bignum_demont_p521
+        .globl bignum_demont_p521
+        .private_extern bignum_demont_p521
+
+        .globl _bignum_demont_p521
+        .private_extern _bignum_demont_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_double_p521
-        .private_extern bignum_double_p521
+        S2N_ASM_HIDDEN(bignum_double_p521)
 
         .globl _bignum_double_p521
-        .private_extern _bignum_double_p521
+        S2N_ASM_HIDDEN(_bignum_double_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_double_p521
-        .globl  _bignum_double_p521
+        .globl bignum_double_p521
+        .private_extern bignum_double_p521
+
+        .globl _bignum_double_p521
+        .private_extern _bignum_double_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 9], uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_double_p521
-        S2N_ASM_HIDDEN(bignum_double_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_double_p521
-        S2N_ASM_HIDDEN(_bignum_double_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p521)
 
         .text
 
@@ -40,8 +39,14 @@
 
 
 
-bignum_double_p521:
-_bignum_double_p521:
+S2N_BN_SYMBOL(bignum_double_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // We can decide whether 2 * x >= p_521 just by 2 * x >= 2^521, which
 // as we assume x < p_521 amounts to looking at bit 8 of the top word
@@ -89,6 +94,10 @@ _bignum_double_p521:
         andq    $0x1FF, c
         movq    c, 64(z)
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
@@ -28,8 +28,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_fromlebytes_p521
-        .globl  _bignum_fromlebytes_p521
+        .globl bignum_fromlebytes_p521
+        .private_extern bignum_fromlebytes_p521
+
+        .globl _bignum_fromlebytes_p521
+        .private_extern _bignum_fromlebytes_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
@@ -26,13 +26,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_fromlebytes_p521
-        .private_extern bignum_fromlebytes_p521
+        S2N_ASM_HIDDEN(bignum_fromlebytes_p521)
 
         .globl _bignum_fromlebytes_p521
-        .private_extern _bignum_fromlebytes_p521
+        S2N_ASM_HIDDEN(_bignum_fromlebytes_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
@@ -25,14 +25,13 @@
 // Since x86 is little-endian, this is just copying.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_fromlebytes_p521
-        S2N_ASM_HIDDEN(bignum_fromlebytes_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_fromlebytes_p521
-        S2N_ASM_HIDDEN(_bignum_fromlebytes_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_fromlebytes_p521)
 
         .text
 
@@ -40,38 +39,48 @@
 #define x %rsi
 #define a %rax
 
-bignum_fromlebytes_p521:
-_bignum_fromlebytes_p521:
+S2N_BN_SYMBOL(bignum_fromlebytes_p521):
 
-                movq    (x), a
-                movq    a, (z)
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
-                movq    8(x), a
-                movq    a, 8(z)
+        movq    (x), a
+        movq    a, (z)
 
-                movq    16(x), a
-                movq    a, 16(z)
+        movq    8(x), a
+        movq    a, 8(z)
 
-                movq    24(x), a
-                movq    a, 24(z)
+        movq    16(x), a
+        movq    a, 16(z)
 
-                movq    32(x), a
-                movq    a, 32(z)
+        movq    24(x), a
+        movq    a, 24(z)
 
-                movq    40(x), a
-                movq    a, 40(z)
+        movq    32(x), a
+        movq    a, 32(z)
 
-                movq    48(x), a
-                movq    a, 48(z)
+        movq    40(x), a
+        movq    a, 40(z)
 
-                movq    56(x), a
-                movq    a, 56(z)
+        movq    48(x), a
+        movq    a, 48(z)
 
-                xorl    %eax, %eax
-                movw    64(x), %ax
-                movq    a, 64(z)
+        movq    56(x), a
+        movq    a, 56(z)
 
-                ret
+        xorl    %eax, %eax
+        movw    64(x), %ax
+        movq    a, 64(z)
+
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_half_p521
-        .private_extern bignum_half_p521
+        S2N_ASM_HIDDEN(bignum_half_p521)
 
         .globl _bignum_half_p521
-        .private_extern _bignum_half_p521
+        S2N_ASM_HIDDEN(_bignum_half_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 9], uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_half_p521
-        S2N_ASM_HIDDEN(bignum_half_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_half_p521
-        S2N_ASM_HIDDEN(_bignum_half_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p521)
 
         .text
 
@@ -51,54 +50,64 @@
 
 
 
-bignum_half_p521:
-_bignum_half_p521:
+S2N_BN_SYMBOL(bignum_half_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // We do a 521-bit rotation one bit right, since 2^521 == 1 (mod p_521)
 
-                movq    (x), d0
-                movl    $1, ashort
-                andq    d0, a
+        movq    (x), d0
+        movl    $1, ashort
+        andq    d0, a
 
-                movq    8(x), d1
-                shrdq   $1, d1, d0
-                movq    d0, (z)
+        movq    8(x), d1
+        shrdq   $1, d1, d0
+        movq    d0, (z)
 
-                movq    16(x), d2
-                shrdq   $1, d2, d1
-                movq    d1, 8(z)
+        movq    16(x), d2
+        shrdq   $1, d2, d1
+        movq    d1, 8(z)
 
-                movq    24(x), d3
-                shrdq   $1, d3, d2
-                movq    d2, 16(z)
+        movq    24(x), d3
+        shrdq   $1, d3, d2
+        movq    d2, 16(z)
 
-                movq    32(x), d4
-                shrdq   $1, d4, d3
-                movq    d3, 24(z)
+        movq    32(x), d4
+        shrdq   $1, d4, d3
+        movq    d3, 24(z)
 
-                movq    40(x), d5
-                shrdq   $1, d5, d4
-                movq    d4, 32(z)
+        movq    40(x), d5
+        shrdq   $1, d5, d4
+        movq    d4, 32(z)
 
-                movq    48(x), d6
-                shrdq   $1, d6, d5
-                movq    d5, 40(z)
+        movq    48(x), d6
+        shrdq   $1, d6, d5
+        movq    d5, 40(z)
 
-                movq    56(x), d7
-                shrdq   $1, d7, d6
-                movq    d6, 48(z)
+        movq    56(x), d7
+        shrdq   $1, d7, d6
+        movq    d6, 48(z)
 
-                movq    64(x), d8
-                shrdq   $1, d8, d7
-                movq    d7, 56(z)
+        movq    64(x), d8
+        shrdq   $1, d8, d7
+        movq    d7, 56(z)
 
-                shlq    $55, d8
-                shrdq   $56, a, d8
-                movq    d8, 64(z)
+        shlq    $55, d8
+        shrdq   $56, a, d8
+        movq    d8, 64(z)
 
 // Return
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_half_p521
-        .globl  _bignum_half_p521
+        .globl bignum_half_p521
+        .private_extern bignum_half_p521
+
+        .globl _bignum_half_p521
+        .private_extern _bignum_half_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
@@ -26,8 +26,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_n521_9
-        .globl  _bignum_mod_n521_9
+        .globl bignum_mod_n521_9
+        .private_extern bignum_mod_n521_9
+
+        .globl _bignum_mod_n521_9
+        .private_extern _bignum_mod_n521_9
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
@@ -24,13 +24,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n521_9
-        .private_extern bignum_mod_n521_9
+        S2N_ASM_HIDDEN(bignum_mod_n521_9)
 
         .globl _bignum_mod_n521_9
-        .private_extern _bignum_mod_n521_9
+        S2N_ASM_HIDDEN(_bignum_mod_n521_9)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
@@ -23,14 +23,13 @@
 // Reduction is modulo the group order of the NIST curve P-521.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mod_n521_9
-        S2N_ASM_HIDDEN(bignum_mod_n521_9)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mod_n521_9
-        S2N_ASM_HIDDEN(_bignum_mod_n521_9)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n521_9)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n521_9)
 
         .text
 
@@ -52,8 +51,14 @@
 #define cshort %ecx
 #define qshort %edx
 
-bignum_mod_n521_9:
-_bignum_mod_n521_9:
+S2N_BN_SYMBOL(bignum_mod_n521_9):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Load the top digit, putting a bit-stuffed version in output buffer.
 // The initial quotient estimate is q = h + 1 where x = 2^521 * h + t
@@ -143,6 +148,10 @@ _bignum_mod_n521_9:
         andl    $0x1FF, cshort
         movq    c, 64(z)
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
@@ -23,14 +23,13 @@
 // Reduction is modulo the group order of the NIST curve P-521.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mod_n521_9_alt
-        S2N_ASM_HIDDEN(bignum_mod_n521_9_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mod_n521_9_alt
-        S2N_ASM_HIDDEN(_bignum_mod_n521_9_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n521_9_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n521_9_alt)
 
         .text
 
@@ -52,8 +51,14 @@
 #define cshort %ecx
 #define qshort %edx
 
-bignum_mod_n521_9_alt:
-_bignum_mod_n521_9_alt:
+S2N_BN_SYMBOL(bignum_mod_n521_9_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Load the top digit, putting a bit-stuffed version in output buffer.
 // The initial quotient estimate is q = h + 1 where x = 2^521 * h + t
@@ -152,6 +157,10 @@ _bignum_mod_n521_9_alt:
         andl    $0x1FF, cshort
         movq    c, 64(z)
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
@@ -24,13 +24,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_n521_9_alt
-        .private_extern bignum_mod_n521_9_alt
+        S2N_ASM_HIDDEN(bignum_mod_n521_9_alt)
 
         .globl _bignum_mod_n521_9_alt
-        .private_extern _bignum_mod_n521_9_alt
+        S2N_ASM_HIDDEN(_bignum_mod_n521_9_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
@@ -26,8 +26,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_n521_9_alt
-        .globl  _bignum_mod_n521_9_alt
+        .globl bignum_mod_n521_9_alt
+        .private_extern bignum_mod_n521_9_alt
+
+        .globl _bignum_mod_n521_9_alt
+        .private_extern _bignum_mod_n521_9_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 9], uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mod_p521_9
-        S2N_ASM_HIDDEN(bignum_mod_p521_9)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mod_p521_9
-        S2N_ASM_HIDDEN(_bignum_mod_p521_9)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p521_9)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p521_9)
 
         .text
 
@@ -51,8 +50,14 @@
 
 #define d7 %rsi
 
-bignum_mod_p521_9:
-_bignum_mod_p521_9:
+S2N_BN_SYMBOL(bignum_mod_p521_9):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save one more register
 
@@ -115,6 +120,10 @@ _bignum_mod_p521_9:
 // Restore register
 
         popq    %rbx
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mod_p521_9
-        .globl  _bignum_mod_p521_9
+        .globl bignum_mod_p521_9
+        .private_extern bignum_mod_p521_9
+
+        .globl _bignum_mod_p521_9
+        .private_extern _bignum_mod_p521_9
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mod_p521_9
-        .private_extern bignum_mod_p521_9
+        S2N_ASM_HIDDEN(bignum_mod_p521_9)
 
         .globl _bignum_mod_p521_9
-        .private_extern _bignum_mod_p521_9
+        S2N_ASM_HIDDEN(_bignum_mod_p521_9)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
@@ -29,8 +29,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montmul_p521
-        .globl  _bignum_montmul_p521
+        .globl bignum_montmul_p521
+        .private_extern bignum_montmul_p521
+
+        .globl _bignum_montmul_p521
+        .private_extern _bignum_montmul_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
@@ -27,13 +27,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p521
-        .private_extern bignum_montmul_p521
+        S2N_ASM_HIDDEN(bignum_montmul_p521)
 
         .globl _bignum_montmul_p521
-        .private_extern _bignum_montmul_p521
+        S2N_ASM_HIDDEN(_bignum_montmul_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
@@ -26,14 +26,13 @@
 // can be considered a Montgomery operation to base 2^521.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_montmul_p521
-        S2N_ASM_HIDDEN(bignum_montmul_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_montmul_p521
-        S2N_ASM_HIDDEN(_bignum_montmul_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p521)
 
         .text
 
@@ -53,8 +52,15 @@
         adcxq   %rax, low ;               \
         adoxq   %rbx, high
 
-bignum_montmul_p521:
-_bignum_montmul_p521:
+S2N_BN_SYMBOL(bignum_montmul_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save more registers to play with and make temporary space on stack
 
@@ -407,6 +413,10 @@ _bignum_montmul_p521:
         popq    %rbx
         popq    %rbp
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
@@ -27,13 +27,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montmul_p521_alt
-        .private_extern bignum_montmul_p521_alt
+        S2N_ASM_HIDDEN(bignum_montmul_p521_alt)
 
         .globl _bignum_montmul_p521_alt
-        .private_extern _bignum_montmul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_montmul_p521_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
@@ -26,14 +26,13 @@
 // can be considered a Montgomery operation to base 2^521.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_montmul_p521_alt
-        S2N_ASM_HIDDEN(bignum_montmul_p521_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_montmul_p521_alt
-        S2N_ASM_HIDDEN(_bignum_montmul_p521_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p521_alt)
 
         .text
 
@@ -70,8 +69,15 @@
         addq    %rax, l ;                         \
         adcq    %rdx, h
 
-bignum_montmul_p521_alt:
-_bignum_montmul_p521_alt:
+S2N_BN_SYMBOL(bignum_montmul_p521_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Make more registers available and make temporary space on stack
 
@@ -337,6 +343,10 @@ _bignum_montmul_p521_alt:
         popq    %r14
         popq    %r13
         popq    %r12
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
@@ -29,8 +29,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montmul_p521_alt
-        .globl  _bignum_montmul_p521_alt
+        .globl bignum_montmul_p521_alt
+        .private_extern bignum_montmul_p521_alt
+
+        .globl _bignum_montmul_p521_alt
+        .private_extern _bignum_montmul_p521_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
@@ -29,8 +29,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montsqr_p521
-        .globl  _bignum_montsqr_p521
+        .globl bignum_montsqr_p521
+        .private_extern bignum_montsqr_p521
+
+        .globl _bignum_montsqr_p521
+        .private_extern _bignum_montsqr_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
@@ -26,14 +26,13 @@
 // considered a Montgomery operation to base 2^521.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_montsqr_p521
-        S2N_ASM_HIDDEN(bignum_montsqr_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_montsqr_p521
-        S2N_ASM_HIDDEN(_bignum_montsqr_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p521)
 
         .text
 
@@ -64,8 +63,14 @@
         adcxq   %rax, low ;               \
         adoxq   zero, high
 
-bignum_montsqr_p521:
-_bignum_montsqr_p521:
+S2N_BN_SYMBOL(bignum_montsqr_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save more registers to play with and make temporary space on stack
 
@@ -317,6 +322,10 @@ _bignum_montsqr_p521:
         popq    %r12
         popq    %rbp
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
@@ -27,13 +27,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p521
-        .private_extern bignum_montsqr_p521
+        S2N_ASM_HIDDEN(bignum_montsqr_p521)
 
         .globl _bignum_montsqr_p521
-        .private_extern _bignum_montsqr_p521
+        S2N_ASM_HIDDEN(_bignum_montsqr_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
@@ -29,8 +29,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_montsqr_p521_alt
-        .globl  _bignum_montsqr_p521_alt
+        .globl bignum_montsqr_p521_alt
+        .private_extern bignum_montsqr_p521_alt
+
+        .globl _bignum_montsqr_p521_alt
+        .private_extern _bignum_montsqr_p521_alt
+
         .text
 
 // Input arguments

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
@@ -27,13 +27,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_montsqr_p521_alt
-        .private_extern bignum_montsqr_p521_alt
+        S2N_ASM_HIDDEN(bignum_montsqr_p521_alt)
 
         .globl _bignum_montsqr_p521_alt
-        .private_extern _bignum_montsqr_p521_alt
+        S2N_ASM_HIDDEN(_bignum_montsqr_p521_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
@@ -26,14 +26,13 @@
 // considered a Montgomery operation to base 2^521.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_montsqr_p521_alt
-        S2N_ASM_HIDDEN(bignum_montsqr_p521_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_montsqr_p521_alt
-        S2N_ASM_HIDDEN(_bignum_montsqr_p521_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p521_alt)
 
         .text
 
@@ -99,8 +98,14 @@
         adcq    %rdx, h ;                         \
         adcq    $0, c
 
-bignum_montsqr_p521_alt:
-_bignum_montsqr_p521_alt:
+S2N_BN_SYMBOL(bignum_montsqr_p521_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Make more registers available and make temporary space on stack
 
@@ -330,6 +335,10 @@ _bignum_montsqr_p521_alt:
         popq    %r12
         popq    %rbx
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mul_p521
-        .globl  _bignum_mul_p521
+        .globl bignum_mul_p521
+        .private_extern bignum_mul_p521
+
+        .globl _bignum_mul_p521
+        .private_extern _bignum_mul_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mul_p521
-        .private_extern bignum_mul_p521
+        S2N_ASM_HIDDEN(bignum_mul_p521)
 
         .globl _bignum_mul_p521
-        .private_extern _bignum_mul_p521
+        S2N_ASM_HIDDEN(_bignum_mul_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mul_p521
-        S2N_ASM_HIDDEN(bignum_mul_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mul_p521
-        S2N_ASM_HIDDEN(_bignum_mul_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p521)
 
         .text
 
@@ -48,8 +47,15 @@
         adcxq   %rax, low ;               \
         adoxq   %rbx, high
 
-bignum_mul_p521:
-_bignum_mul_p521:
+S2N_BN_SYMBOL(bignum_mul_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save more registers to play with and make temporary space on stack
 
@@ -384,6 +390,10 @@ _bignum_mul_p521:
         popq    %rbx
         popq    %rbp
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_mul_p521_alt
-        S2N_ASM_HIDDEN(bignum_mul_p521_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_mul_p521_alt
-        S2N_ASM_HIDDEN(_bignum_mul_p521_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p521_alt)
 
         .text
 
@@ -65,8 +64,15 @@
         addq    %rax, l ;                         \
         adcq    %rdx, h
 
-bignum_mul_p521_alt:
-_bignum_mul_p521_alt:
+S2N_BN_SYMBOL(bignum_mul_p521_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Make more registers available and make temporary space on stack
 
@@ -314,6 +320,10 @@ _bignum_mul_p521_alt:
         popq    %r14
         popq    %r13
         popq    %r12
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_mul_p521_alt
-        .globl  _bignum_mul_p521_alt
+        .globl bignum_mul_p521_alt
+        .private_extern bignum_mul_p521_alt
+
+        .globl _bignum_mul_p521_alt
+        .private_extern _bignum_mul_p521_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_mul_p521_alt
-        .private_extern bignum_mul_p521_alt
+        S2N_ASM_HIDDEN(bignum_mul_p521_alt)
 
         .globl _bignum_mul_p521_alt
-        .private_extern _bignum_mul_p521_alt
+        S2N_ASM_HIDDEN(_bignum_mul_p521_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
@@ -23,8 +23,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_neg_p521
-        .globl  _bignum_neg_p521
+        .globl bignum_neg_p521
+        .private_extern bignum_neg_p521
+
+        .globl _bignum_neg_p521
+        .private_extern _bignum_neg_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
@@ -20,14 +20,13 @@
 //    extern void bignum_neg_p521 (uint64_t z[static 9], uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_neg_p521
-        S2N_ASM_HIDDEN(bignum_neg_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_neg_p521
-        S2N_ASM_HIDDEN(_bignum_neg_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p521)
 
         .text
 
@@ -42,62 +41,72 @@
 #define d4 %r10
 #define d5 %r11
 
-bignum_neg_p521:
-_bignum_neg_p521:
+S2N_BN_SYMBOL(bignum_neg_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Load most inputs (into the limited registers) and OR all of them to get p
 
-                movq    (x), d0
-                movq    d0, p
-                movq    8(x), d1
-                orq     d1, p
-                movq    16(x), d2
-                orq     d2, p
-                movq    24(x), d3
-                orq     d3, p
-                movq    32(x), d4
-                orq     d4, p
-                movq    40(x), d5
-                orq     d5, p
-                orq     48(x), p
-                orq     56(x), p
-                orq     64(x), p
+        movq    (x), d0
+        movq    d0, p
+        movq    8(x), d1
+        orq     d1, p
+        movq    16(x), d2
+        orq     d2, p
+        movq    24(x), d3
+        orq     d3, p
+        movq    32(x), d4
+        orq     d4, p
+        movq    40(x), d5
+        orq     d5, p
+        orq     48(x), p
+        orq     56(x), p
+        orq     64(x), p
 
 // Turn p into a bitmask for "input is nonzero", so that we avoid doing
 // -0 = p_521 and hence maintain strict modular reduction
 
-                negq    p
-                sbbq    p, p
+        negq    p
+        sbbq    p, p
 
 // Since p_521 is all 1s, the subtraction is just an exclusive-or with p
 // to give an optional inversion, with a slight fiddle for the top digit.
 
-                xorq    p, d0
-                movq    d0, (z)
-                xorq    p, d1
-                movq    d1, 8(z)
-                xorq    p, d2
-                movq    d2, 16(z)
-                xorq    p, d3
-                movq    d3, 24(z)
-                xorq    p, d4
-                movq    d4, 32(z)
-                xorq    p, d5
-                movq    d5, 40(z)
-                movq    48(x), d0
-                xorq    p, d0
-                movq    d0, 48(z)
-                movq    56(x), d1
-                xorq    p, d1
-                movq    d1, 56(z)
-                movq    64(x), d2
-                andq    $0x1FF, p
-                xorq    p, d2
-                movq    d2, 64(z)
+        xorq    p, d0
+        movq    d0, (z)
+        xorq    p, d1
+        movq    d1, 8(z)
+        xorq    p, d2
+        movq    d2, 16(z)
+        xorq    p, d3
+        movq    d3, 24(z)
+        xorq    p, d4
+        movq    d4, 32(z)
+        xorq    p, d5
+        movq    d5, 40(z)
+        movq    48(x), d0
+        xorq    p, d0
+        movq    d0, 48(z)
+        movq    56(x), d1
+        xorq    p, d1
+        movq    d1, 56(z)
+        movq    64(x), d2
+        andq    $0x1FF, p
+        xorq    p, d2
+        movq    d2, 64(z)
 
 // Return
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
@@ -21,13 +21,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_neg_p521
-        .private_extern bignum_neg_p521
+        S2N_ASM_HIDDEN(bignum_neg_p521)
 
         .globl _bignum_neg_p521
-        .private_extern _bignum_neg_p521
+        S2N_ASM_HIDDEN(_bignum_neg_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
@@ -25,8 +25,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_optneg_p521
-        .globl  _bignum_optneg_p521
+        .globl bignum_optneg_p521
+        .private_extern bignum_optneg_p521
+
+        .globl _bignum_optneg_p521
+        .private_extern _bignum_optneg_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
@@ -22,14 +22,13 @@
 //      (uint64_t z[static 9], uint64_t p, uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
+// Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_optneg_p521
-        S2N_ASM_HIDDEN(bignum_optneg_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_optneg_p521
-        S2N_ASM_HIDDEN(_bignum_optneg_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p521)
 
         .text
 
@@ -44,64 +43,75 @@
 #define d3 %r10
 #define d4 %r11
 
-bignum_optneg_p521:
-_bignum_optneg_p521:
+S2N_BN_SYMBOL(bignum_optneg_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Load most inputs (into the limited registers) and OR all of them to get q
 
-                movq    (x), d0
-                movq    d0, q
-                movq    8(x), d1
-                orq     d1, q
-                movq    16(x), d2
-                orq     d2, q
-                movq    24(x), d3
-                orq     d3, q
-                movq    32(x), d4
-                orq     d4, q
-                orq     40(x), q
-                orq     48(x), q
-                orq     56(x), q
-                orq     64(x), q
+        movq    (x), d0
+        movq    d0, q
+        movq    8(x), d1
+        orq     d1, q
+        movq    16(x), d2
+        orq     d2, q
+        movq    24(x), d3
+        orq     d3, q
+        movq    32(x), d4
+        orq     d4, q
+        orq     40(x), q
+        orq     48(x), q
+        orq     56(x), q
+        orq     64(x), q
 
 // Turn q into a bitmask for "input is nonzero and p is nonzero", so that
 // we avoid doing -0 = p_521 and hence maintain strict modular reduction
 
-                negq    q
-                sbbq    q, q
-                testq   p, p
-                cmovzq  p, q
+        negq    q
+        sbbq    q, q
+        testq   p, p
+        cmovzq  p, q
 
 // Since p_521 is all 1s, the subtraction is just an exclusive-or with q
 // to give an optional inversion, with a slight fiddle for the top digit.
 
-                xorq    q, d0
-                movq    d0, (z)
-                xorq    q, d1
-                movq    d1, 8(z)
-                xorq    q, d2
-                movq    d2, 16(z)
-                xorq    q, d3
-                movq    d3, 24(z)
-                xorq    q, d4
-                movq    d4, 32(z)
-                movq    40(x), d0
-                xorq    q, d0
-                movq    d0, 40(z)
-                movq    48(x), d1
-                xorq    q, d1
-                movq    d1, 48(z)
-                movq    56(x), d2
-                xorq    q, d2
-                movq    d2, 56(z)
-                movq    64(x), d3
-                andq    $0x1FF, q
-                xorq    q, d3
-                movq    d3, 64(z)
+        xorq    q, d0
+        movq    d0, (z)
+        xorq    q, d1
+        movq    d1, 8(z)
+        xorq    q, d2
+        movq    d2, 16(z)
+        xorq    q, d3
+        movq    d3, 24(z)
+        xorq    q, d4
+        movq    d4, 32(z)
+        movq    40(x), d0
+        xorq    q, d0
+        movq    d0, 40(z)
+        movq    48(x), d1
+        xorq    q, d1
+        movq    d1, 48(z)
+        movq    56(x), d2
+        xorq    q, d2
+        movq    d2, 56(z)
+        movq    64(x), d3
+        andq    $0x1FF, q
+        xorq    q, d3
+        movq    d3, 64(z)
 
 // Return
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
@@ -23,13 +23,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_optneg_p521
-        .private_extern bignum_optneg_p521
+        S2N_ASM_HIDDEN(bignum_optneg_p521)
 
         .globl _bignum_optneg_p521
-        .private_extern _bignum_optneg_p521
+        S2N_ASM_HIDDEN(_bignum_optneg_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
@@ -23,8 +23,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_sqr_p521
-        .globl  _bignum_sqr_p521
+        .globl bignum_sqr_p521
+        .private_extern bignum_sqr_p521
+
+        .globl _bignum_sqr_p521
+        .private_extern _bignum_sqr_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
@@ -20,14 +20,13 @@
 //    extern void bignum_sqr_p521 (uint64_t z[static 9], uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_sqr_p521
-        S2N_ASM_HIDDEN(bignum_sqr_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_sqr_p521
-        S2N_ASM_HIDDEN(_bignum_sqr_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p521)
 
         .text
 
@@ -58,8 +57,14 @@
         adcxq   %rax, low ;               \
         adoxq   zero, high
 
-bignum_sqr_p521:
-_bignum_sqr_p521:
+S2N_BN_SYMBOL(bignum_sqr_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save more registers to play with and make temporary space on stack
 
@@ -293,6 +298,10 @@ _bignum_sqr_p521:
         popq    %r12
         popq    %rbp
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
@@ -21,13 +21,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sqr_p521
-        .private_extern bignum_sqr_p521
+        S2N_ASM_HIDDEN(bignum_sqr_p521)
 
         .globl _bignum_sqr_p521
-        .private_extern _bignum_sqr_p521
+        S2N_ASM_HIDDEN(_bignum_sqr_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
@@ -23,8 +23,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_sqr_p521_alt
-        .globl  _bignum_sqr_p521_alt
+        .globl bignum_sqr_p521_alt
+        .private_extern bignum_sqr_p521_alt
+
+        .globl _bignum_sqr_p521_alt
+        .private_extern _bignum_sqr_p521_alt
+
         .text
 
 // Input arguments

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
@@ -20,14 +20,13 @@
 //    extern void bignum_sqr_p521_alt (uint64_t z[static 9], uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_sqr_p521_alt
-        S2N_ASM_HIDDEN(bignum_sqr_p521_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_sqr_p521_alt
-        S2N_ASM_HIDDEN(_bignum_sqr_p521_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p521_alt)
 
         .text
 
@@ -93,8 +92,14 @@
         adcq    %rdx, h ;                         \
         adcq    $0, c
 
-bignum_sqr_p521_alt:
-_bignum_sqr_p521_alt:
+S2N_BN_SYMBOL(bignum_sqr_p521_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Make more registers available and make temporary space on stack
 
@@ -305,6 +310,10 @@ _bignum_sqr_p521_alt:
         popq    %r13
         popq    %r12
         popq    %rbx
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
@@ -21,13 +21,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sqr_p521_alt
-        .private_extern bignum_sqr_p521_alt
+        S2N_ASM_HIDDEN(bignum_sqr_p521_alt)
 
         .globl _bignum_sqr_p521_alt
-        .private_extern _bignum_sqr_p521_alt
+        S2N_ASM_HIDDEN(_bignum_sqr_p521_alt)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_sub_p521
-        .globl  _bignum_sub_p521
+        .globl bignum_sub_p521
+        .private_extern bignum_sub_p521
+
+        .globl _bignum_sub_p521
+        .private_extern _bignum_sub_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_sub_p521
-        .private_extern bignum_sub_p521
+        S2N_ASM_HIDDEN(bignum_sub_p521)
 
         .globl _bignum_sub_p521
-        .private_extern _bignum_sub_p521
+        S2N_ASM_HIDDEN(_bignum_sub_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_sub_p521
-        S2N_ASM_HIDDEN(bignum_sub_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_sub_p521
-        S2N_ASM_HIDDEN(_bignum_sub_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p521)
 
         .text
 
@@ -51,8 +50,15 @@
 
 
 
-bignum_sub_p521:
-_bignum_sub_p521:
+S2N_BN_SYMBOL(bignum_sub_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+#endif
 
 // Save more registers to play with
 
@@ -110,6 +116,10 @@ _bignum_sub_p521:
         popq    %r12
         popq    %rbx
 
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
@@ -26,13 +26,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tolebytes_p521
-        .private_extern bignum_tolebytes_p521
+        S2N_ASM_HIDDEN(bignum_tolebytes_p521)
 
         .globl _bignum_tolebytes_p521
-        .private_extern _bignum_tolebytes_p521
+        S2N_ASM_HIDDEN(_bignum_tolebytes_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
@@ -28,8 +28,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_tolebytes_p521
-        .globl  _bignum_tolebytes_p521
+        .globl bignum_tolebytes_p521
+        .private_extern bignum_tolebytes_p521
+
+        .globl _bignum_tolebytes_p521
+        .private_extern _bignum_tolebytes_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
@@ -25,14 +25,13 @@
 // Since x86 is little-endian, this is just copying.
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_tolebytes_p521
-        S2N_ASM_HIDDEN(bignum_tolebytes_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_tolebytes_p521
-        S2N_ASM_HIDDEN(_bignum_tolebytes_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tolebytes_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tolebytes_p521)
 
         .text
 
@@ -40,37 +39,47 @@
 #define x %rsi
 #define a %rax
 
-bignum_tolebytes_p521:
-_bignum_tolebytes_p521:
+S2N_BN_SYMBOL(bignum_tolebytes_p521):
 
-                movq    (x), a
-                movq    a, (z)
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
-                movq    8(x), a
-                movq    a, 8(z)
+        movq    (x), a
+        movq    a, (z)
 
-                movq    16(x), a
-                movq    a, 16(z)
+        movq    8(x), a
+        movq    a, 8(z)
 
-                movq    24(x), a
-                movq    a, 24(z)
+        movq    16(x), a
+        movq    a, 16(z)
 
-                movq    32(x), a
-                movq    a, 32(z)
+        movq    24(x), a
+        movq    a, 24(z)
 
-                movq    40(x), a
-                movq    a, 40(z)
+        movq    32(x), a
+        movq    a, 32(z)
 
-                movq    48(x), a
-                movq    a, 48(z)
+        movq    40(x), a
+        movq    a, 40(z)
 
-                movq    56(x), a
-                movq    a, 56(z)
+        movq    48(x), a
+        movq    a, 48(z)
 
-                movq    64(x), a
-                movw    %ax, 64(z)
+        movq    56(x), a
+        movq    a, 56(z)
 
-                ret
+        movq    64(x), a
+        movw    %ax, 64(z)
+
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_tomont_p521
-        .private_extern bignum_tomont_p521
+        S2N_ASM_HIDDEN(bignum_tomont_p521)
 
         .globl _bignum_tomont_p521
-        .private_extern _bignum_tomont_p521
+        S2N_ASM_HIDDEN(_bignum_tomont_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 9], uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_tomont_p521
-        S2N_ASM_HIDDEN(bignum_tomont_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_tomont_p521
-        S2N_ASM_HIDDEN(_bignum_tomont_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p521)
 
         .text
 
@@ -51,8 +50,14 @@
 
 #define d7 %rsi
 
-bignum_tomont_p521:
-_bignum_tomont_p521:
+S2N_BN_SYMBOL(bignum_tomont_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save one more register
 
@@ -133,6 +138,10 @@ _bignum_tomont_p521:
 // Restore register
 
         popq    %rbx
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
         ret
 
 #if defined(__linux__) && defined(__ELF__)

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_tomont_p521
-        .globl  _bignum_tomont_p521
+        .globl bignum_tomont_p521
+        .private_extern bignum_tomont_p521
+
+        .globl _bignum_tomont_p521
+        .private_extern _bignum_tomont_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p521
-        .private_extern bignum_triple_p521
+        S2N_ASM_HIDDEN(bignum_triple_p521)
 
         .globl _bignum_triple_p521
-        .private_extern _bignum_triple_p521
+        S2N_ASM_HIDDEN(_bignum_triple_p521)
 
         .text
 

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 9], uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_triple_p521
-        S2N_ASM_HIDDEN(bignum_triple_p521)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_triple_p521
-        S2N_ASM_HIDDEN(_bignum_triple_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p521)
 
         .text
 
@@ -52,108 +51,118 @@
 
 
 
-bignum_triple_p521:
-_bignum_triple_p521:
+S2N_BN_SYMBOL(bignum_triple_p521):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save more registers to play with
 
-                pushq   %rbx
-                pushq   %r12
+        pushq   %rbx
+        pushq   %r12
 
 // Load the top (short) word first to compute the initial carry-in
 // Set OF according to bit 520, but *always* set CF to get a +1 bump
 
-                movq    64(x), m
-                movq    m, d8
-                shlq    $54, m
-                addq    m, m
-                stc
+        movq    64(x), m
+        movq    m, d8
+        shlq    $54, m
+        addq    m, m
+        stc
 
 // Use a double carry chain to compute x' + x + 1 where x' is a
 // 1-bit left rotation of x; this is then == 3 * x + 1 (mod p_521)
 // This gives us s = [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x + x' + 1.
 
-                movq    (x), m
-                movq    m, d0
-                adcxq   m, m
-                adoxq   m, d0
-                movq    8(x), m
-                movq    m, d1
-                adcxq   m, m
-                adoxq   m, d1
-                movq    16(x), m
-                movq    m, d2
-                adcxq   m, m
-                adoxq   m, d2
-                movq    24(x), m
-                movq    m, d3
-                adcxq   m, m
-                adoxq   m, d3
-                movq    32(x), m
-                movq    m, d4
-                adcxq   m, m
-                adoxq   m, d4
-                movq    40(x), m
-                movq    m, d5
-                adcxq   m, m
-                adoxq   m, d5
-                movq    48(x), m
-                movq    m, d6
-                adcxq   m, m
-                adoxq   m, d6
-                movq    56(x), m
-                movq    m, d7
-                adcxq   m, m
-                adoxq   m, d7
+        movq    (x), m
+        movq    m, d0
+        adcxq   m, m
+        adoxq   m, d0
+        movq    8(x), m
+        movq    m, d1
+        adcxq   m, m
+        adoxq   m, d1
+        movq    16(x), m
+        movq    m, d2
+        adcxq   m, m
+        adoxq   m, d2
+        movq    24(x), m
+        movq    m, d3
+        adcxq   m, m
+        adoxq   m, d3
+        movq    32(x), m
+        movq    m, d4
+        adcxq   m, m
+        adoxq   m, d4
+        movq    40(x), m
+        movq    m, d5
+        adcxq   m, m
+        adoxq   m, d5
+        movq    48(x), m
+        movq    m, d6
+        adcxq   m, m
+        adoxq   m, d6
+        movq    56(x), m
+        movq    m, d7
+        adcxq   m, m
+        adoxq   m, d7
 
 // The last word is slightly more intricate: we naturally end up adding
 // 2 * top bit when we shouldn't (because it's a rotation and we've already
 // added it at the LSB position) but then compensate by subtracting it.
 
-                movq    d8, m
-                adcxq   m, m
-                adoxq   m, d8
-                andq    $0x200, m
-                subq    m, d8
+        movq    d8, m
+        adcxq   m, m
+        adoxq   m, d8
+        andq    $0x200, m
+        subq    m, d8
 
 // Now x + x' >= p_521 <=> s = x + x' + 1 >= 2^521
 // Make m = 512 * [x + x' >= p_521]
 
-                movl    $512, mshort
-                andq    d8, m
+        movl    $512, mshort
+        andq    d8, m
 
 // Now if x + x' >= p_521, we want (x + x') - p_521 = s - 2^521
 // while otherwise we want x + x' = s - 1
 // We use the mask m both as an operand and to generate the dual carry
 // Write back the results as generated
 
-                cmpq    $512, m
+        cmpq    $512, m
 
-                sbbq    $0, d0
-                movq    d0, (z)
-                sbbq    $0, d1
-                movq    d1, 8(z)
-                sbbq    $0, d2
-                movq    d2, 16(z)
-                sbbq    $0, d3
-                movq    d3, 24(z)
-                sbbq    $0, d4
-                movq    d4, 32(z)
-                sbbq    $0, d5
-                movq    d5, 40(z)
-                sbbq    $0, d6
-                movq    d6, 48(z)
-                sbbq    $0, d7
-                movq    d7, 56(z)
-                sbbq    m, d8
-                movq    d8, 64(z)
+        sbbq    $0, d0
+        movq    d0, (z)
+        sbbq    $0, d1
+        movq    d1, 8(z)
+        sbbq    $0, d2
+        movq    d2, 16(z)
+        sbbq    $0, d3
+        movq    d3, 24(z)
+        sbbq    $0, d4
+        movq    d4, 32(z)
+        sbbq    $0, d5
+        movq    d5, 40(z)
+        sbbq    $0, d6
+        movq    d6, 48(z)
+        sbbq    $0, d7
+        movq    d7, 56(z)
+        sbbq    m, d8
+        movq    d8, 64(z)
 
 // Restore registers and return
 
-                popq    %r12
-                popq    %rbx
+        popq    %r12
+        popq    %rbx
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_triple_p521
-        .globl  _bignum_triple_p521
+        .globl bignum_triple_p521
+        .private_extern bignum_triple_p521
+
+        .globl _bignum_triple_p521
+        .private_extern _bignum_triple_p521
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
@@ -21,14 +21,13 @@
 //     (uint64_t z[static 9], uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
+// Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
-#include "../../_internal_s2n_bignum.h"
 
-        .globl bignum_triple_p521_alt
-        S2N_ASM_HIDDEN(bignum_triple_p521_alt)
+#include "../../include/_internal_s2n_bignum.h"
 
-        .globl _bignum_triple_p521_alt
-        S2N_ASM_HIDDEN(_bignum_triple_p521_alt)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p521_alt)
 
         .text
 
@@ -53,14 +52,20 @@
 #define a %rax
 #define d %rdx
 
-bignum_triple_p521_alt:
-_bignum_triple_p521_alt:
+S2N_BN_SYMBOL(bignum_triple_p521_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+#endif
 
 // Save additional registers to use
 
-                pushq   %rbx
-                pushq   %rbp
-                pushq   %r12
+        pushq   %rbx
+        pushq   %rbp
+        pushq   %r12
 
 // Let [d8;...;d0] = x' + x + 1 where x' is a rotation left by 1 bit
 // as a 521-bit quantity. This is == 3 * x + 1 (mod p_521) and keeps
@@ -69,99 +74,103 @@ _bignum_triple_p521_alt:
 // at the bottom instead of the top, so the top two digits are a bit
 // more intricate.
 
-                movq    $3, m
-                movq    64(x), d0
-                shrq    $8, d0
-                incq    d0
+        movq    $3, m
+        movq    64(x), d0
+        shrq    $8, d0
+        incq    d0
 
-                movq    (x), a
-                mulq    m
-                xorq    d1, d1
-                addq    a, d0
-                adcq    d, d1
+        movq    (x), a
+        mulq    m
+        xorq    d1, d1
+        addq    a, d0
+        adcq    d, d1
 
-                movq    8(x), a
-                mulq    m
-                xorq    d2, d2
-                addq    a, d1
-                adcq    d, d2
+        movq    8(x), a
+        mulq    m
+        xorq    d2, d2
+        addq    a, d1
+        adcq    d, d2
 
-                movq    16(x), a
-                mulq    m
-                xorq    d3, d3
-                addq    a, d2
-                adcq    d, d3
+        movq    16(x), a
+        mulq    m
+        xorq    d3, d3
+        addq    a, d2
+        adcq    d, d3
 
-                movq    24(x), a
-                mulq    m
-                xorq    d4, d4
-                addq    a, d3
-                adcq    d, d4
+        movq    24(x), a
+        mulq    m
+        xorq    d4, d4
+        addq    a, d3
+        adcq    d, d4
 
-                movq    32(x), a
-                mulq    m
-                xorq    d5, d5
-                addq    a, d4
-                adcq    d, d5
+        movq    32(x), a
+        mulq    m
+        xorq    d5, d5
+        addq    a, d4
+        adcq    d, d5
 
-                movq    40(x), a
-                mulq    m
-                xorq    d6, d6
-                addq    a, d5
-                adcq    d, d6
+        movq    40(x), a
+        mulq    m
+        xorq    d6, d6
+        addq    a, d5
+        adcq    d, d6
 
-                movq    48(x), a
-                mulq    m
-                movq    56(x), d7
-                movq    64(x), d8
-                addq    a, d6
-                adcq    $0, d
+        movq    48(x), a
+        mulq    m
+        movq    56(x), d7
+        movq    64(x), d8
+        addq    a, d6
+        adcq    $0, d
 
-                movq    $0xFF, a
-                andq    d8, a
-                leaq    (d8,a,2), d8
+        movq    $0xFF, a
+        andq    d8, a
+        leaq    (d8,a,2), d8
 
-                xorl    %eax, %eax
-                addq    d7, d
-                adcq    a, d8
-                addq    d7, d7
-                adcq    a, d8
-                addq    d, d7
-                adcq    a, d8
+        xorl    %eax, %eax
+        addq    d7, d
+        adcq    a, d8
+        addq    d7, d7
+        adcq    a, d8
+        addq    d, d7
+        adcq    a, d8
 
 // Now d8 >= 2^9 <=> x' + x + 1 >= 2^521 <=> x' + x >= p_521.
 // If that is the case we want (x' + x) - p_521 = (x' + x + 1) - 2^521
 // while otherwise we want just x' + x = (x' + x + 1) - 1.
 
-                cmpq    $0x200, d8
+        cmpq    $0x200, d8
 
-                sbbq    a, d0
-                movq    d0, (z)
-                sbbq    a, d1
-                movq    d1, 8(z)
-                sbbq    a, d2
-                movq    d2, 16(z)
-                sbbq    a, d3
-                movq    d3, 24(z)
-                sbbq    a, d4
-                movq    d4, 32(z)
-                sbbq    a, d5
-                movq    d5, 40(z)
-                sbbq    a, d6
-                movq    d6, 48(z)
-                sbbq    a, d7
-                movq    d7, 56(z)
-                sbbq    a, d8
-                andq    $0x1FF, d8
-                movq    d8, 64(z)
+        sbbq    a, d0
+        movq    d0, (z)
+        sbbq    a, d1
+        movq    d1, 8(z)
+        sbbq    a, d2
+        movq    d2, 16(z)
+        sbbq    a, d3
+        movq    d3, 24(z)
+        sbbq    a, d4
+        movq    d4, 32(z)
+        sbbq    a, d5
+        movq    d5, 40(z)
+        sbbq    a, d6
+        movq    d6, 48(z)
+        sbbq    a, d7
+        movq    d7, 56(z)
+        sbbq    a, d8
+        andq    $0x1FF, d8
+        movq    d8, 64(z)
 
 // Restore registers and return
 
-                popq    %r12
-                popq    %rbp
-                popq    %rbx
+        popq    %r12
+        popq    %rbp
+        popq    %rbx
 
-                ret
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
 
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
@@ -24,8 +24,12 @@
 // ----------------------------------------------------------------------------
 
 
-        .globl  bignum_triple_p521_alt
-        .globl  _bignum_triple_p521_alt
+        .globl bignum_triple_p521_alt
+        .private_extern bignum_triple_p521_alt
+
+        .globl _bignum_triple_p521_alt
+        .private_extern _bignum_triple_p521_alt
+
         .text
 
 #define z %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
@@ -22,13 +22,13 @@
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // ----------------------------------------------------------------------------
-
+#include "../../_internal_s2n_bignum.h"
 
         .globl bignum_triple_p521_alt
-        .private_extern bignum_triple_p521_alt
+        S2N_ASM_HIDDEN(bignum_triple_p521_alt)
 
         .globl _bignum_triple_p521_alt
-        .private_extern _bignum_triple_p521_alt
+        S2N_ASM_HIDDEN(_bignum_triple_p521_alt)
 
         .text
 

--- a/util/read_symbols.go
+++ b/util/read_symbols.go
@@ -214,7 +214,7 @@ func listSymbolsMachO(contents []byte) ([]string, error) {
 		)
 
 		// Only include exported, defined symbols.
-		if sym.Type&N_EXT != 0 && sym.Type&N_TYPE != N_UNDF {
+		if sym.Type&N_EXT != 0 && sym.Type&N_TYPE != N_UNDF && sym.Type&N_PEXT == 0 {
 			if len(sym.Name) == 0 || sym.Name[0] != '_' {
 				return nil, fmt.Errorf("unexpected symbol without underscore prefix: %q", sym.Name)
 			}


### PR DESCRIPTION
### Description of changes: 
The shared library produced by the current build process externalizes the s2n-bignum symbols (`bignum_*`).

### Call-outs:
The s2n-bignum symbols are still exposed from our *static* library.

### Testing:
I built the shared library on Mac (x86) and Linux (x86 and aarch64). Verified that the s2n-bignum symbols were not being externalized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
