### PR TITLE
Avoid gcc-12 compile warnings.

### DIFF
--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -1279,6 +1279,12 @@ static int ipv6_from_asc(unsigned char v6[16], const char *in)
         /* Copy initial part */
         OPENSSL_memcpy(v6, v6stat.tmp, v6stat.zero_pos);
         /* Zero middle */
+        // This condition is to suppress gcc-12 warning.
+        // https://github.com/awslabs/aws-lc/issues/487
+        if (v6stat.zero_pos >= v6stat.total) {
+            // This should not happen.
+            return 0;
+        }
         OPENSSL_memset(v6 + v6stat.zero_pos, 0, 16 - v6stat.total);
         /* Copy final part */
         if (v6stat.total != v6stat.zero_pos)

--- a/tests/ci/docker_images/linux-x86/build_images.sh
+++ b/tests/ci/docker_images/linux-x86/build_images.sh
@@ -25,6 +25,8 @@ docker build -t ubuntu-20.04:android ubuntu-20.04_android
 docker build -t ubuntu-20.04:clang-7x-bm-framework ubuntu-20.04_clang-7x-bm-framework
 # This passes in the Dockerfile in the folder but uses the parent directory for the context so it has access to cryptofuzz_data.zip
 docker build -t ubuntu-20.04:cryptofuzz -f ubuntu-20.04_cryptofuzz/Dockerfile ../
+docker build -t ubuntu-22.04:base ubuntu-22.04_base
+docker build -t ubuntu-22.04:gcc-12x ubuntu-22.04_gcc-12x
 docker build -t amazonlinux-2:base amazonlinux-2_base
 docker build -t amazonlinux-2:gcc-7x amazonlinux-2_gcc-7x
 docker build -t amazonlinux-2:gcc-7x-intel-sde amazonlinux-2_gcc-7x-intel-sde

--- a/tests/ci/docker_images/linux-x86/push_images.sh
+++ b/tests/ci/docker_images/linux-x86/push_images.sh
@@ -29,6 +29,7 @@ tag_and_push_img 'ubuntu-20.04:clang-10x_formal-verification' "${ECS_REPO}:ubunt
 tag_and_push_img 'ubuntu-20.04:gcc-7x' "${ECS_REPO}:ubuntu-20.04_gcc-7x"
 tag_and_push_img 'ubuntu-20.04:gcc-8x' "${ECS_REPO}:ubuntu-20.04_gcc-8x"
 tag_and_push_img 'ubuntu-20.04:gcc-11x' "${ECS_REPO}:ubuntu-20.04_gcc-11x"
+tag_and_push_img 'ubuntu-22.04:gcc-12x' "${ECS_REPO}:ubuntu-22.04_gcc-12x"
 tag_and_push_img 'centos-7:gcc-4x' "${ECS_REPO}:centos-7_gcc-4x"
 tag_and_push_img 'amazonlinux-2:gcc-7x' "${ECS_REPO}:amazonlinux-2_gcc-7x"
 tag_and_push_img 'amazonlinux-2:clang-7x' "${ECS_REPO}:amazonlinux-2_clang-7x"

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
@@ -1,0 +1,59 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu:22.04
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV DEPENDENCIES_DIR=/home/dependencies
+ENV LLVM_PROJECT_HOME=${DEPENDENCIES_DIR}/llvm-project
+
+# llvm, llvm-dev, libcxx, and libcxxabi are needed for the sanitizer tests.
+# 11.1.0 is the latest stable release as of 2021-02-16.
+# See https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
+RUN set -ex && \
+    apt-get update && \
+    apt-get -y --no-install-recommends upgrade && \
+    apt-get -y --no-install-recommends install \
+    software-properties-common \
+    cmake \
+    ninja-build \
+    perl \
+    libunwind-dev \
+    pkg-config \
+    git \
+    ca-certificates \
+    wget \
+    lld \
+    llvm \
+    llvm-dev \
+    curl \
+    unzip && \
+    # Based on https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
+    # The awscli is used to publish data to CloudWatch Metrics in some jobs. This requires additional IAM permission
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install --bin-dir /usr/bin && \
+    rm -rf awscliv2.zip aws/ && \
+    # Download a copy of LLVM's libcxx which is required for building and running with Memory Sanitizer
+    mkdir -p ${DEPENDENCIES_DIR} && \
+    cd ${DEPENDENCIES_DIR} && \
+    git clone https://github.com/llvm/llvm-project.git --branch llvmorg-11.1.0  --depth 1 && \
+    cd llvm-project && rm -rf $(ls -A | grep -Ev "(libcxx|libcxxabi)") && \
+    cd /tmp && \
+    wget https://dl.google.com/go/go1.13.12.linux-amd64.tar.gz && \
+    tar -xvf go1.13.12.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+    apt-get --purge remove -y curl unzip && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+ENV GOROOT=/usr/local/go
+ENV GO111MODULE=on
+ENV ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
+ENV PATH="$GOROOT/bin:$PATH"

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-12x/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-12x/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu-22.04:base
+
+SHELL ["/bin/bash", "-c"]
+
+# gcc-11 is relatively new and not readily available, so we must fetch it from a mirror for now.
+RUN set -ex && \
+    # echo "deb http://mirrors.kernel.org/ubuntu hirsute main universe" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get -y --no-install-recommends upgrade && \
+    apt-get -y --no-install-recommends install \
+    gcc-12 g++-12 && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+ENV CC=gcc-12
+ENV CXX=g++-12

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-12x/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-12x/Dockerfile
@@ -5,9 +5,7 @@ FROM ubuntu-22.04:base
 
 SHELL ["/bin/bash", "-c"]
 
-# gcc-11 is relatively new and not readily available, so we must fetch it from a mirror for now.
 RUN set -ex && \
-    # echo "deb http://mirrors.kernel.org/ubuntu hirsute main universe" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install \


### PR DESCRIPTION
### Issues:
https://github.com/awslabs/aws-lc/issues/487

### Description of changes: 

This PR fixed below warnings reported by gcc-12 on x86-64. Both warnings are false-positive.

#### Warning 1
```
In function 'memset',
    inlined from 'OPENSSL_memset' at /home/ubuntu/aws-lc/crypto/x509v3/../internal.h:845:10,
    inlined from 'ipv6_from_asc' at /home/ubuntu/aws-lc/crypto/x509v3/v3_utl.c:1285:9,
    inlined from 'x509v3_a2i_ipadd' at /home/ubuntu/aws-lc/crypto/x509v3/v3_utl.c:1194:14,
    inlined from 'X509_check_ip_asc' at /home/ubuntu/aws-lc/crypto/x509v3/v3_utl.c:1114:21:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:59:10: error: '__builtin_memset' forming offset 16 is out of the bounds [0, 16] of object 'ipout' with type 'unsigned char[16]' [-Werror=array-bounds]
   59 |   return __builtin___memset_chk (__dest, __ch, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   60 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/aws-lc/crypto/x509v3/v3_utl.c: In function 'X509_check_ip_asc':
/home/ubuntu/aws-lc/crypto/x509v3/v3_utl.c:1109:19: note: 'ipout' declared here
 1109 |     unsigned char ipout[16];
      |                   ^~~~~
```


#### Warning 2
```
ubuntu/aws-lc/crypto/fipsmodule/bcm.c
In function 'SHA224_Final':
cc1: error: writing 4 bytes into a region of size 0 [-Werror=stringop-overflow=]
In file included from /home/ubuntu/aws-lc/crypto/fipsmodule/bcm.c:131:
/home/ubuntu/aws-lc/crypto/fipsmodule/sha/sha256.c:194:26: note: at offset 28 into destination object 'out' of size [0, 28]
  194 | int SHA224_Final(uint8_t out[SHA224_DIGEST_LENGTH], SHA256_CTX *ctx) {
      |                  ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

### Call-outs:
* The compile warnings were reported when building with `DCMAKE_BUILD_TYPE=Release`.
* `CryptoAlg-1100` is created to add `gcc-12` into CI.
* Below suppression does not work.
```
# pragma GCC diagnostic push
# pragma GCC diagnostic ignored "-Wstringop-overflow"
```

### Testing:
```sh
source tests/ci/common_posix_setup.sh

# echo "Testing AWS-LC in release mode."
build_and_test -DCMAKE_BUILD_TYPE=Release
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
