### PR TITLE
Update `EVP_MD_CTX_set_pkey_ctx` comments about responsibility

### DIFF
--- a/include/openssl/digest.h
+++ b/include/openssl/digest.h
@@ -317,9 +317,10 @@ OPENSSL_EXPORT int EVP_MD_nid(const EVP_MD *md);
 // responsible for freeing |pctx|. Calling |EVP_MD_CTX_cleanup| will not free
 // |pctx|.
 //
-// A NULL |pctx| pointer is also allowed to clear the |EVP_PKEY_CTX| assigned to
-// |ctx|. However, even when doing so, the caller is still responsible for
-// freeing the |pctx| pointer that had originally been associated.
+// A NULL |pctx| pointer is also allowed to set the |EVP_PKEY_CTX| reference
+// inside |ctx| to NULL. However, even when doing so, the caller is still
+// responsible for freeing the |pctx| pointer that had originally been
+// associated.
 //
 // |EVP_MD_CTX_set_pkey_ctx| will overwrite any |EVP_PKEY_CTX| object associated
 // to |ctx|. If it was not associated through a previous |EVP_MD_CTX_set_pkey_ctx|

--- a/include/openssl/digest.h
+++ b/include/openssl/digest.h
@@ -317,9 +317,9 @@ OPENSSL_EXPORT int EVP_MD_nid(const EVP_MD *md);
 // responsible for freeing |pctx|. Calling |EVP_MD_CTX_cleanup| will not free
 // |pctx|.
 //
-// The caller is responsible for the memory associated to |ctx|'s |EVP_PKEY_CTX|
-// reference (the passed in |pctx| parameter), until |EVP_MD_CTX_set_pkey_ctx|
-// is called again with |pctx| = NULL.
+// A NULL |pctx| pointer is also allowed to clear the |EVP_PKEY_CTX| assigned to
+// |ctx|. However, even when doing so, the caller is still responsible for
+// freeing the |pctx| pointer that had been orginally associated.
 //
 // |EVP_MD_CTX_set_pkey_ctx| will overwrite any |EVP_PKEY_CTX| object associated
 // to |ctx|. If it was not associated through a previous |EVP_MD_CTX_set_pkey_ctx|

--- a/include/openssl/digest.h
+++ b/include/openssl/digest.h
@@ -319,7 +319,7 @@ OPENSSL_EXPORT int EVP_MD_nid(const EVP_MD *md);
 //
 // A NULL |pctx| pointer is also allowed to clear the |EVP_PKEY_CTX| assigned to
 // |ctx|. However, even when doing so, the caller is still responsible for
-// freeing the |pctx| pointer that had been orginally associated.
+// freeing the |pctx| pointer that had originally been associated.
 //
 // |EVP_MD_CTX_set_pkey_ctx| will overwrite any |EVP_PKEY_CTX| object associated
 // to |ctx|. If it was not associated through a previous |EVP_MD_CTX_set_pkey_ctx|


### PR DESCRIPTION
### Issues:
Addresses `P64861145`

### Description of changes: 
Some of the comments in `EVP_MD_CTX_set_pkey_ctx` may have been unclear on who's responsibility it is to free the `pctx` pointer. This tries to clarify that the caller is responsible.  

### Call-outs:
N/A

### Testing:
Tests already exist. When doing the incorrect behavior, the test will fail against address sanitizer tests due to a leaked pointer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
