### PR TITLE
Print information directly in CI

### DIFF
--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -104,16 +104,21 @@ function print_system_and_dependency_information {
   echo ""
   echo "Go version:"
   go version
-  echo ""
-  echo "Perl version:"
-  perl --version
-  echo ""
-  echo "Ninja version"
+  if command -v perl &> /dev/null
+  then
+    echo ""
+    echo "Perl version:"
+    perl --version
+  fi
   # Ninja executable names are not uniform
   if command -v ninja-build &> /dev/null
   then
+    echo ""
+    echo "Ninja version"
     ninja-build --version
-  else
+  elif command -v ninja &> /dev/null
+    echo ""
+    echo "Ninja version"
     ninja --version
   fi
   if command -v gcc &> /dev/null
@@ -129,6 +134,12 @@ function print_system_and_dependency_information {
     echo ""
     echo "Clang version:"
     clang --version
+  fi
+  if command -v make &> /dev/null
+  then
+    echo ""
+    echo "Make version:"
+    make --version
   fi
   echo ""
   echo "Operating system information:"

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -96,3 +96,10 @@ function build_and_run_minimal_test {
   run_build "$@"
   run_cmake_custom_target 'run_minimal_tests'
 }
+
+function print_system_and_dependency_information {
+  echo "CMake version:"
+  cmake --version
+  echo "Operating system information:"
+  uname -a
+}

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -98,8 +98,42 @@ function build_and_run_minimal_test {
 }
 
 function print_system_and_dependency_information {
+  echo ""
   echo "CMake version:"
   cmake --version
+  echo ""
+  echo "Go version:"
+  go version
+  echo ""
+  echo "Perl version:"
+  perl --version
+  echo ""
+  echo "Ninja version"
+  # Ninja executable names are not uniform
+  if command -v ninja-build &> /dev/null
+  then
+    ninja-build --version
+  else
+    ninja --version
+  fi
+  if command -v gcc &> /dev/null
+  then
+    echo ""
+    echo "GCC version:"
+    gcc --version
+    echo ""
+    echo "G++ version:"
+    g++ --version
+  elif command -v clang &> /dev/null
+  then
+    echo ""
+    echo "Clang version:"
+    clang --version
+  fi
+  echo ""
   echo "Operating system information:"
   uname -a
+  echo ""
+  echo "Environment variables"
+  env
 }

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -98,12 +98,18 @@ function build_and_run_minimal_test {
 }
 
 function print_system_and_dependency_information {
-  echo ""
-  echo "CMake version:"
-  cmake --version
-  echo ""
-  echo "Go version:"
-  go version
+  if command -v cmake &> /dev/null
+  then
+    echo ""
+    echo "CMake version:"
+    cmake --version
+  fi
+  if command -v go &> /dev/null
+  then
+    echo ""
+    echo "Go version:"
+    go version
+  fi
   if command -v perl &> /dev/null
   then
     echo ""
@@ -117,6 +123,7 @@ function print_system_and_dependency_information {
     echo "Ninja version"
     ninja-build --version
   elif command -v ninja &> /dev/null
+  then
     echo ""
     echo "Ninja version"
     ninja --version

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -5,6 +5,8 @@ set -exo pipefail
 
 source tests/ci/common_posix_setup.sh
 
+print_system_and_dependency_information
+
 echo "Testing AWS-LC in debug mode."
 build_and_test
 


### PR DESCRIPTION
### Description of changes: 

Needed to know the cmake version, but it is not printed anywhere in the codebuild logs - at least I can't find it.

A first try to print some more information to the log that might be useful.

Not sure what to name the function `print_system_and_dependency_information`(?).

### Call-outs:

Should we add more information?

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
