### PR TITLE
Aws lc s2n bignum update 2022 06 06

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -158,6 +158,8 @@ if((ARCH STREQUAL "x86_64" OR ARCH STREQUAL "aarch64") AND
     set(S2N_BIGNUM_DIR ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/arm)
   endif()
 
+  set(S2N_BIGNUM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/third_party/s2n-bignum/include)
+
   # We add s2n-bignum files to a separate list because they need
   # to go through C preprocessor in case of the static build.
   set(
@@ -230,7 +232,7 @@ function(s2n_asm_cpreprocess dest src)
   add_custom_command(
           OUTPUT ${dest}
           COMMAND ${CMAKE_COMMAND} -E make_directory ${dir}
-          COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -E ${S2N_BIGNUM_DIR}/${src} -I${PROJECT_SOURCE_DIR}/include| tr \"\;\" \"\\n\" > ${dest}
+          COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -E ${S2N_BIGNUM_DIR}/${src} -I${S2N_BIGNUM_INCLUDE_DIR}| tr \"\;\" \"\\n\" > ${dest}
           DEPENDS
           ${S2N_BIGNUM_DIR}/${src}
           WORKING_DIRECTORY .

--- a/third_party/s2n-bignum/arm/p384/Makefile
+++ b/third_party/s2n-bignum/arm/p384/Makefile
@@ -55,7 +55,7 @@ OBJ = bignum_add_p384.o \
       bignum_tomont_p384.o \
       bignum_triple_p384.o
 
-%.o : %.S ; cpp $< | $(GAS) -o $@ -
+%.o : %.S ; $(CC) -E -I../../include $< | $(GAS) -o $@ -
 
 default: $(OBJ);
 

--- a/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_add_p384.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_add_p384
-        .globl  _bignum_add_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p384)
         .text
         .balign 4
 
@@ -41,8 +42,7 @@
 #define d5 x10
 
 
-bignum_add_p384:
-_bignum_add_p384:
+S2N_BN_SYMBOL(bignum_add_p384):
 
 // First just add the numbers as c + [d5; d4; d3; d2; d1; d0]
 

--- a/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_bigendian_6.S
@@ -35,13 +35,15 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_bigendian_6
-        .globl  _bignum_bigendian_6
-        .globl  bignum_frombebytes_6
-        .globl  _bignum_frombebytes_6
-        .globl  bignum_tobebytes_6
-        .globl  _bignum_tobebytes_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_bigendian_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_bigendian_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_frombebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_frombebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tobebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tobebytes_6)
+
         .text
         .balign 4
 
@@ -57,12 +59,9 @@
 // to allow x and z to point to the same buffer without using more
 // intermediate registers.
 
-bignum_bigendian_6:
-_bignum_bigendian_6:
-bignum_frombebytes_6:
-_bignum_frombebytes_6:
-bignum_tobebytes_6:
-_bignum_tobebytes_6:
+S2N_BN_SYMBOL(bignum_bigendian_6):
+S2N_BN_SYMBOL(bignum_frombebytes_6):
+S2N_BN_SYMBOL(bignum_tobebytes_6):
 
 // 0 and 5 words
 

--- a/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_cmul_p384.S
@@ -23,11 +23,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_cmul_p384
-        .globl  _bignum_cmul_p384
-        .globl  bignum_cmul_p384_alt
-        .globl  _bignum_cmul_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384_alt)
         .text
         .balign 4
 
@@ -57,10 +58,9 @@
 #define l x9
 
 
-bignum_cmul_p384:
-_bignum_cmul_p384:
-bignum_cmul_p384_alt:
-_bignum_cmul_p384_alt:
+S2N_BN_SYMBOL(bignum_cmul_p384):
+
+S2N_BN_SYMBOL(bignum_cmul_p384_alt):
 
 // First do the multiply, straightforwardly, getting [h; d5; ...; d0]
 

--- a/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_deamont_p384.S
@@ -25,11 +25,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_deamont_p384
-        .globl  _bignum_deamont_p384
-        .globl  bignum_deamont_p384_alt
-        .globl  _bignum_deamont_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384_alt)
         .text
         .balign 4
 
@@ -90,10 +91,9 @@
 #define v x9
 #define w x10
 
-bignum_deamont_p384:
-_bignum_deamont_p384:
-bignum_deamont_p384_alt:
-_bignum_deamont_p384_alt:
+S2N_BN_SYMBOL(bignum_deamont_p384):
+
+S2N_BN_SYMBOL(bignum_deamont_p384_alt):
 
 // Set up an initial window with the input x and an extra leading zero
 

--- a/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_demont_p384.S
@@ -25,11 +25,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_demont_p384
-        .globl  _bignum_demont_p384
-        .globl  bignum_demont_p384_alt
-        .globl  _bignum_demont_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384_alt)
         .text
         .balign 4
 
@@ -90,10 +91,9 @@
 #define v x9
 #define w x10
 
-bignum_demont_p384:
-_bignum_demont_p384:
-bignum_demont_p384_alt:
-_bignum_demont_p384_alt:
+S2N_BN_SYMBOL(bignum_demont_p384):
+
+S2N_BN_SYMBOL(bignum_demont_p384_alt):
 
 // Set up an initial window with the input x and an extra leading zero
 

--- a/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_double_p384.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_double_p384
-        .globl  _bignum_double_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p384)
         .text
         .balign 4
 
@@ -45,8 +46,7 @@
 #define n5 x14
 
 
-bignum_double_p384:
-_bignum_double_p384:
+S2N_BN_SYMBOL(bignum_double_p384):
 
 // Double the input number as 2 * x = c + [d5; d4; d3; d2; d1; d0]
 // It's worth considering doing this with extr...63 instead

--- a/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_half_p384.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_half_p384
-        .globl  _bignum_half_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p384)
         .text
         .balign 4
 
@@ -43,8 +44,7 @@
 #define n x11
 
 
-bignum_half_p384:
-_bignum_half_p384:
+S2N_BN_SYMBOL(bignum_half_p384):
 
 // Load the 4 digits of x
 

--- a/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_littleendian_6.S
@@ -35,13 +35,15 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_littleendian_6
-        .globl  _bignum_littleendian_6
-        .globl  bignum_fromlebytes_6
-        .globl  _bignum_fromlebytes_6
-        .globl  bignum_tolebytes_6
-        .globl  _bignum_tolebytes_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_littleendian_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_littleendian_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_fromlebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tolebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tolebytes_6)
+
         .text
         .balign 4
 
@@ -52,12 +54,9 @@
 #define dshort w2
 #define a x3
 
-bignum_littleendian_6:
-_bignum_littleendian_6:
-bignum_fromlebytes_6:
-_bignum_fromlebytes_6:
-bignum_tolebytes_6:
-_bignum_tolebytes_6:
+S2N_BN_SYMBOL(bignum_littleendian_6):
+S2N_BN_SYMBOL(bignum_fromlebytes_6):
+S2N_BN_SYMBOL(bignum_tolebytes_6):
 
 // word 0
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384.S
@@ -24,11 +24,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_n384
-        .globl  _bignum_mod_n384
-        .globl  bignum_mod_n384_alt
-        .globl  _bignum_mod_n384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384_alt)
         .text
         .balign 4
 
@@ -75,10 +76,9 @@
         movk    nn, n2, lsl #32;                                    \
         movk    nn, n3, lsl #48
 
-bignum_mod_n384:
-_bignum_mod_n384:
-bignum_mod_n384_alt:
-_bignum_mod_n384_alt:
+S2N_BN_SYMBOL(bignum_mod_n384):
+
+S2N_BN_SYMBOL(bignum_mod_n384_alt):
 
 // If the input is already <= 5 words long, go to a trivial "copy" path
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_n384_6.S
@@ -24,9 +24,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_n384_6
-        .globl  _bignum_mod_n384_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384_6)
         .text
         .balign 4
 
@@ -53,8 +54,7 @@
         movk    nn, n2, lsl #32;                                    \
         movk    nn, n3, lsl #48
 
-bignum_mod_n384_6:
-_bignum_mod_n384_6:
+S2N_BN_SYMBOL(bignum_mod_n384_6):
 
 // Load the complicated lower three words of n_384
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384.S
@@ -22,11 +22,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_p384
-        .globl  _bignum_mod_p384
-        .globl  bignum_mod_p384_alt
-        .globl  _bignum_mod_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384_alt)
         .text
         .balign 4
 
@@ -53,10 +54,9 @@
 #define n2 x17
 
 
-bignum_mod_p384:
-_bignum_mod_p384:
-bignum_mod_p384_alt:
-_bignum_mod_p384_alt:
+S2N_BN_SYMBOL(bignum_mod_p384):
+
+S2N_BN_SYMBOL(bignum_mod_p384_alt):
 
 // If the input is already <= 5 words long, go to a trivial "copy" path
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mod_p384_6.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_p384_6
-        .globl  _bignum_mod_p384_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384_6)
         .text
         .balign 4
 
@@ -46,8 +47,7 @@
 #define d5 x13
 
 
-bignum_mod_p384_6:
-_bignum_mod_p384_6:
+S2N_BN_SYMBOL(bignum_mod_p384_6):
 
 // Load the complicated lower three words of p_384 = [-1;-1;-1;n2;n1;n0]
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384.S
@@ -26,9 +26,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montmul_p384
-        .globl  _bignum_montmul_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p384)
         .text
         .balign 4
 
@@ -113,8 +114,7 @@
 #define t3 x23
 #define t4 x24
 
-bignum_montmul_p384:
-_bignum_montmul_p384:
+S2N_BN_SYMBOL(bignum_montmul_p384):
 
 // Save some registers
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montmul_p384_alt.S
@@ -26,9 +26,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montmul_p384_alt
-        .globl  _bignum_montmul_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p384_alt)
         .text
         .balign 4
 
@@ -102,8 +103,7 @@
 #define u11 x1 // same as x
 #define h b5 // same as b5
 
-bignum_montmul_p384_alt:
-_bignum_montmul_p384_alt:
+S2N_BN_SYMBOL(bignum_montmul_p384_alt):
 
 // Save more registers
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384.S
@@ -25,9 +25,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montsqr_p384
-        .globl  _bignum_montsqr_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p384)
         .text
         .balign 4
 
@@ -104,8 +105,7 @@
 #define d3 x16
 #define d4 x17
 
-bignum_montsqr_p384:
-_bignum_montsqr_p384:
+S2N_BN_SYMBOL(bignum_montsqr_p384):
 
 // Load in all words of the input
 

--- a/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_montsqr_p384_alt.S
@@ -25,9 +25,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montsqr_p384_alt
-        .globl  _bignum_montsqr_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p384_alt)
         .text
         .balign 4
 
@@ -90,8 +91,7 @@
 #define u11 x20
 #define h x6 // same as a4
 
-bignum_montsqr_p384_alt:
-_bignum_montsqr_p384_alt:
+S2N_BN_SYMBOL(bignum_montsqr_p384_alt):
 
 // It's convenient to have two more registers to play with
 

--- a/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_mux_6.S
@@ -25,9 +25,10 @@
 //
 // Standard ARM ABI: X0 = p, X1 = z, X2 = x, X3 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mux_6
-        .globl  _bignum_mux_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mux_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mux_6)
         .text
         .balign 4
 
@@ -38,10 +39,9 @@
 #define a x4
 
 
-bignum_mux_6:
-_bignum_mux_6:
+S2N_BN_SYMBOL(bignum_mux_6):
 
-        cmp     p, #0                    // Set condition codes p = 0
+cmp     p, #0                    // Set condition codes p = 0
 
         ldr     a, [x]
         ldr     p, [y]

--- a/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_neg_p384.S
@@ -21,9 +21,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_neg_p384
-        .globl  _bignum_neg_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p384)
         .text
         .balign 4
 
@@ -41,8 +42,7 @@
 #define d5 x9
 
 
-bignum_neg_p384:
-_bignum_neg_p384:
+S2N_BN_SYMBOL(bignum_neg_p384):
 
 // Load the 6 digits of x
 

--- a/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_nonzero_6.S
@@ -21,9 +21,10 @@
 //
 // Standard ARM ABI: X0 = x, returns X0
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_nonzero_6
-        .globl  _bignum_nonzero_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_nonzero_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_nonzero_6)
         .text
         .balign 4
 
@@ -33,8 +34,7 @@
 #define c x3
 
 
-bignum_nonzero_6:
-_bignum_nonzero_6:
+S2N_BN_SYMBOL(bignum_nonzero_6):
 
 // Generate a = an OR of all the words in the bignum
 

--- a/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_optneg_p384.S
@@ -23,9 +23,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_optneg_p384
-        .globl  _bignum_optneg_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p384)
         .text
         .balign 4
 
@@ -47,8 +48,7 @@
 #define n5 x14
 
 
-bignum_optneg_p384:
-_bignum_optneg_p384:
+S2N_BN_SYMBOL(bignum_optneg_p384):
 
 // Load the 6 digits of x
 

--- a/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_sub_p384
-        .globl  _bignum_sub_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p384)
         .text
         .balign 4
 
@@ -42,8 +43,7 @@
 #define d5 x10
 
 
-bignum_sub_p384:
-_bignum_sub_p384:
+S2N_BN_SYMBOL(bignum_sub_p384):
 
 // First just subtract the numbers as [d5; d4; d3; d2; d1; d0]
 // Set a mask based on (inverted) carry indicating x < y = correction is needed

--- a/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_tomont_p384.S
@@ -22,11 +22,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_tomont_p384
-        .globl  _bignum_tomont_p384
-        .globl  bignum_tomont_p384_alt
-        .globl  _bignum_tomont_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p384_alt)
         .text
         .balign 4
 
@@ -72,10 +73,9 @@
         adcs    d4, d4, t3;                                         \
         adc     d5, d5, t3
 
-bignum_tomont_p384:
-_bignum_tomont_p384:
-bignum_tomont_p384_alt:
-_bignum_tomont_p384_alt:
+S2N_BN_SYMBOL(bignum_tomont_p384):
+
+S2N_BN_SYMBOL(bignum_tomont_p384_alt):
 
 #define d0 x2
 #define d1 x3

--- a/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/arm/p384/bignum_triple_p384.S
@@ -25,11 +25,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_triple_p384
-        .globl  _bignum_triple_p384
-        .globl  bignum_triple_p384_alt
-        .globl  _bignum_triple_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p384)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p384_alt)
         .text
         .balign 4
 
@@ -64,10 +65,9 @@
 #define t1 x10
 
 
-bignum_triple_p384:
-_bignum_triple_p384:
-bignum_triple_p384_alt:
-_bignum_triple_p384_alt:
+S2N_BN_SYMBOL(bignum_triple_p384):
+
+S2N_BN_SYMBOL(bignum_triple_p384_alt):
 
 // Load the inputs
 

--- a/third_party/s2n-bignum/arm/p521/Makefile
+++ b/third_party/s2n-bignum/arm/p521/Makefile
@@ -55,7 +55,7 @@ OBJ = bignum_add_p521.o \
       bignum_tomont_p521.o \
       bignum_triple_p521.o
 
-%.o : %.S ; cpp $< | $(GAS) -o $@ -
+%.o : %.S ; $(CC) -E -I../../include $< | $(GAS) -o $@ -
 
 default: $(OBJ);
 

--- a/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_add_p521.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_add_p521
-        .globl  _bignum_add_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p521)
         .text
         .balign 4
 
@@ -44,8 +45,7 @@
 #define d8 x13
 
 
-bignum_add_p521:
-_bignum_add_p521:
+S2N_BN_SYMBOL(bignum_add_p521):
 
 // Force carry-in to get s = [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x + y + 1.
 // We ignore the carry-out, assuming inputs are reduced so there is none.

--- a/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_cmul_p521.S
@@ -23,11 +23,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_cmul_p521
-        .globl  _bignum_cmul_p521
-        .globl  bignum_cmul_p521_alt
-        .globl  _bignum_cmul_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p521_alt)
         .text
         .balign 4
 
@@ -63,10 +64,9 @@
 #define a8 x14
 #define dd x15
 
-bignum_cmul_p521:
-_bignum_cmul_p521:
-bignum_cmul_p521_alt:
-_bignum_cmul_p521_alt:
+S2N_BN_SYMBOL(bignum_cmul_p521):
+
+S2N_BN_SYMBOL(bignum_cmul_p521_alt):
 
 // First do the multiply, getting [d9; ...; d0], and as this is done
 // accumulate an AND "dd" of digits d7,...,d1 for later use

--- a/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_deamont_p521.S
@@ -25,9 +25,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_deamont_p521
-        .globl  _bignum_deamont_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p521)
         .text
         .balign 4
 
@@ -55,8 +56,7 @@
 #define l x12
 #define u x12
 
-bignum_deamont_p521:
-_bignum_deamont_p521:
+S2N_BN_SYMBOL(bignum_deamont_p521):
 
 // Load all the inputs
 

--- a/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_demont_p521.S
@@ -25,9 +25,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_demont_p521
-        .globl  _bignum_demont_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p521)
         .text
         .balign 4
 
@@ -49,8 +50,7 @@
 #define d8 x2
 #define c x6
 
-bignum_demont_p521:
-_bignum_demont_p521:
+S2N_BN_SYMBOL(bignum_demont_p521):
 
 // Rotate, as a 521-bit quantity, by 9*64 - 521 = 55 bits right.
 

--- a/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_double_p521.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_double_p521
-        .globl  _bignum_double_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p521)
         .text
         .balign 4
 
@@ -35,8 +36,7 @@
 #define h x3
 #define l x4
 
-bignum_double_p521:
-_bignum_double_p521:
+S2N_BN_SYMBOL(bignum_double_p521):
 
 // We can decide whether 2 * x >= p_521 just by 2 * x >= 2^521, which
 // amounts to whether the top word is >= 256

--- a/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_fromlebytes_p521.S
@@ -24,9 +24,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_fromlebytes_p521
-        .globl  _bignum_fromlebytes_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_fromlebytes_p521)
         .text
         .balign 4
 
@@ -37,8 +38,7 @@
 #define dshort w2
 #define a x3
 
-bignum_fromlebytes_p521:
-_bignum_fromlebytes_p521:
+S2N_BN_SYMBOL(bignum_fromlebytes_p521):
 
 // word 0
 

--- a/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_half_p521.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_half_p521
-        .globl  _bignum_half_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p521)
         .text
         .balign 4
 
@@ -45,8 +46,7 @@
 #define a x6
 
 
-bignum_half_p521:
-_bignum_half_p521:
+S2N_BN_SYMBOL(bignum_half_p521):
 
 // We do a 521-bit rotation one bit right, since 2^521 == 1 (mod p_521)
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_n521_9.S
@@ -24,11 +24,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_n521_9
-        .globl  _bignum_mod_n521_9
-        .globl  bignum_mod_n521_9_alt
-        .globl  _bignum_mod_n521_9_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n521_9)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n521_9)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n521_9_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n521_9_alt)
         .text
         .balign 4
 
@@ -63,10 +64,9 @@
         movk    nn, n2, lsl #32;                                    \
         movk    nn, n3, lsl #48
 
-bignum_mod_n521_9:
-_bignum_mod_n521_9:
-bignum_mod_n521_9_alt:
-_bignum_mod_n521_9_alt:
+S2N_BN_SYMBOL(bignum_mod_n521_9):
+
+S2N_BN_SYMBOL(bignum_mod_n521_9_alt):
 
 // Load the top digit first into d8.
 // The initial quotient estimate is q = h + 1 where x = 2^521 * h + t

--- a/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mod_p521_9.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_p521_9
-        .globl  _bignum_mod_p521_9
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p521_9)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p521_9)
         .text
         .balign 4
 
@@ -43,8 +44,7 @@
 #define d7 x11
 #define d8 x12
 
-bignum_mod_p521_9:
-_bignum_mod_p521_9:
+S2N_BN_SYMBOL(bignum_mod_p521_9):
 
 // Load top digit first and get its upper bits in h so that we
 // separate out x = 2^521 * H + L with h = H. Now x mod p_521 =

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521.S
@@ -27,9 +27,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montmul_p521
-        .globl  _bignum_montmul_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p521)
         .text
         .balign 4
 
@@ -158,8 +159,7 @@
         adcs    s6, s6, c;                                      \
         adc     s7, s7, c                                       \
 
-bignum_montmul_p521:
-_bignum_montmul_p521:
+S2N_BN_SYMBOL(bignum_montmul_p521):
 
 // Save registers and make space for the temporary buffer
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montmul_p521_alt.S
@@ -27,9 +27,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montmul_p521_alt
-        .globl  _bignum_montmul_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p521_alt)
         .text
         .balign 4
 
@@ -82,8 +83,7 @@
 #define u15 x20
 #define u16 x21
 
-bignum_montmul_p521_alt:
-_bignum_montmul_p521_alt:
+S2N_BN_SYMBOL(bignum_montmul_p521_alt):
 
 // Save more registers and make space for the temporary buffer
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521.S
@@ -27,9 +27,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montsqr_p521
-        .globl  _bignum_montsqr_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p521)
         .text
         .balign 4
 
@@ -73,8 +74,7 @@
 #define d7 x9
 #define d8 x10
 
-bignum_montsqr_p521:
-_bignum_montsqr_p521:
+S2N_BN_SYMBOL(bignum_montsqr_p521):
 
 // Save registers
 

--- a/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_montsqr_p521_alt.S
@@ -27,9 +27,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montsqr_p521_alt
-        .globl  _bignum_montsqr_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p521_alt)
         .text
         .balign 4
 
@@ -66,8 +67,7 @@
 #define u15 x27
 #define u16 x29
 
-bignum_montsqr_p521_alt:
-_bignum_montsqr_p521_alt:
+S2N_BN_SYMBOL(bignum_montsqr_p521_alt):
 
 // It's convenient to have more registers to play with
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mul_p521
-        .globl  _bignum_mul_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p521)
         .text
         .balign 4
 
@@ -153,8 +154,7 @@
         adcs    s6, s6, c;                                      \
         adc     s7, s7, c                                       \
 
-bignum_mul_p521:
-_bignum_mul_p521:
+S2N_BN_SYMBOL(bignum_mul_p521):
 
 // Save registers and make space for the temporary buffer
 

--- a/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_mul_p521_alt.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mul_p521_alt
-        .globl  _bignum_mul_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p521_alt)
         .text
         .balign 4
 
@@ -77,8 +78,7 @@
 #define u15 x20
 #define u16 x21
 
-bignum_mul_p521_alt:
-_bignum_mul_p521_alt:
+S2N_BN_SYMBOL(bignum_mul_p521_alt):
 
 // Save more registers and make temporary space on stack
 

--- a/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_neg_p521.S
@@ -21,9 +21,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_neg_p521
-        .globl  _bignum_neg_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p521)
         .text
         .balign 4
 
@@ -42,8 +43,7 @@
 #define d7 x10
 #define d8 x11
 
-bignum_neg_p521:
-_bignum_neg_p521:
+S2N_BN_SYMBOL(bignum_neg_p521):
 
 // Load the 9 digits of x and generate p = the OR of them all
 

--- a/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_optneg_p521.S
@@ -23,9 +23,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_optneg_p521
-        .globl  _bignum_optneg_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p521)
         .text
         .balign 4
 
@@ -44,8 +45,7 @@
 #define d7 x11
 #define d8 x12
 
-bignum_optneg_p521:
-_bignum_optneg_p521:
+S2N_BN_SYMBOL(bignum_optneg_p521):
 
 // Load the 9 digits of x and generate q = the OR of them all
 

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521.S
@@ -21,9 +21,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_sqr_p521
-        .globl  _bignum_sqr_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p521)
         .text
         .balign 4
 
@@ -67,8 +68,7 @@
 #define d7 x9
 #define d8 x10
 
-bignum_sqr_p521:
-_bignum_sqr_p521:
+S2N_BN_SYMBOL(bignum_sqr_p521):
 
 // Save registers
 

--- a/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sqr_p521_alt.S
@@ -21,9 +21,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_sqr_p521_alt
-        .globl  _bignum_sqr_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p521_alt)
         .text
         .balign 4
 
@@ -60,8 +61,7 @@
 #define u15 x27
 #define u16 x29
 
-bignum_sqr_p521_alt:
-_bignum_sqr_p521_alt:
+S2N_BN_SYMBOL(bignum_sqr_p521_alt):
 
 // It's convenient to have more registers to play with
 

--- a/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_sub_p521.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_sub_p521
-        .globl  _bignum_sub_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p521)
         .text
         .balign 4
 
@@ -44,8 +45,7 @@
 #define d8 x13
 
 
-bignum_sub_p521:
-_bignum_sub_p521:
+S2N_BN_SYMBOL(bignum_sub_p521):
 
 // First just subtract the numbers as [d8;d7;d6;d5;d4;d3;d2;d1;d0] = x - y
 

--- a/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tolebytes_p521.S
@@ -24,9 +24,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_tolebytes_p521
-        .globl  _bignum_tolebytes_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tolebytes_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tolebytes_p521)
         .text
         .balign 4
 
@@ -36,8 +37,7 @@
 #define d x2
 #define dshort w2
 
-bignum_tolebytes_p521:
-_bignum_tolebytes_p521:
+S2N_BN_SYMBOL(bignum_tolebytes_p521):
 
 // word 0
 

--- a/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_tomont_p521.S
@@ -22,9 +22,10 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_tomont_p521
-        .globl  _bignum_tomont_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p521)
         .text
         .balign 4
 
@@ -43,8 +44,7 @@
 #define d7 x11
 #define d8 x12
 
-bignum_tomont_p521:
-_bignum_tomont_p521:
+S2N_BN_SYMBOL(bignum_tomont_p521):
 
 // Load top digit first and get its upper bits in h so that we
 // separate out x = 2^521 * H + L with h = H. Now x mod p_521 =

--- a/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/arm/p521/bignum_triple_p521.S
@@ -22,11 +22,12 @@
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_triple_p521
-        .globl  _bignum_triple_p521
-        .globl  bignum_triple_p521_alt
-        .globl  _bignum_triple_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p521)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p521_alt)
         .text
         .balign 4
 
@@ -47,10 +48,9 @@
 #define d8 x12
 
 
-bignum_triple_p521:
-_bignum_triple_p521:
-bignum_triple_p521_alt:
-_bignum_triple_p521_alt:
+S2N_BN_SYMBOL(bignum_triple_p521):
+
+S2N_BN_SYMBOL(bignum_triple_p521_alt):
 
 // Pick out top bit to wrap to the zero position in the doubling step
 

--- a/third_party/s2n-bignum/include/_internal_s2n_bignum.h
+++ b/third_party/s2n-bignum/include/_internal_s2n_bignum.h
@@ -1,0 +1,17 @@
+
+#ifdef __APPLE__
+#   define S2N_BN_SYMBOL(NAME) _##NAME
+#else
+#   define S2N_BN_SYMBOL(name) name
+#endif
+
+#define S2N_BN_SYM_VISIBILITY_DIRECTIVE(name) .globl S2N_BN_SYMBOL(name)
+#ifdef S2N_BN_HIDE_SYMBOLS
+#   ifdef __APPLE__
+#      define S2N_BN_SYM_PRIVACY_DIRECTIVE(name) .private_extern S2N_BN_SYMBOL(name)
+#   else
+#      define S2N_BN_SYM_PRIVACY_DIRECTIVE(name) .hidden S2N_BN_SYMBOL(name)
+#   endif
+#else
+#   define S2N_BN_SYM_PRIVACY_DIRECTIVE(name)  /* NO-OP: S2N_BN_SYM_PRIVACY_DIRECTIVE */
+#endif

--- a/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_add_p384.S
@@ -24,10 +24,10 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_add_p384
-        .globl  _bignum_add_p384
-        .text
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p384)
 
 #define z %rdi
 #define x %rsi
@@ -50,8 +50,7 @@
 
 
 
-bignum_add_p384:
-_bignum_add_p384:
+S2N_BN_SYMBOL(bignum_add_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_bigendian_6.S
@@ -36,13 +36,15 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_bigendian_6
-        .globl  _bignum_bigendian_6
-        .globl  bignum_frombebytes_6
-        .globl  _bignum_frombebytes_6
-        .globl  bignum_tobebytes_6
-        .globl  _bignum_tobebytes_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_bigendian_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_bigendian_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_frombebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_frombebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tobebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tobebytes_6)
+
         .text
 
 #define z %rdi
@@ -56,12 +58,9 @@
 // pairs (0-5, 1-4, 2-3) to allow x and z to point to the same buffer
 // without using more intermediate registers.
 
-bignum_bigendian_6:
-_bignum_bigendian_6:
-bignum_frombebytes_6:
-_bignum_frombebytes_6:
-bignum_tobebytes_6:
-_bignum_tobebytes_6:
+S2N_BN_SYMBOL(bignum_bigendian_6):
+S2N_BN_SYMBOL(bignum_frombebytes_6):
+S2N_BN_SYMBOL(bignum_tobebytes_6):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384.S
@@ -25,9 +25,10 @@
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_cmul_p384
-        .globl  _bignum_cmul_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384)
         .text
 
 #define z %rdi
@@ -54,8 +55,7 @@
 #define qshort %edx
 
 
-bignum_cmul_p384:
-_bignum_cmul_p384:
+S2N_BN_SYMBOL(bignum_cmul_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_cmul_p384_alt.S
@@ -25,10 +25,10 @@
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_cmul_p384_alt
-        .globl  _bignum_cmul_p384_alt
-        .text
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384_alt)
 
 #define z %rdi
 
@@ -58,8 +58,7 @@
 #define cshort %ecx
 #define qshort %ecx
 
-bignum_cmul_p384_alt:
-_bignum_cmul_p384_alt:
+S2N_BN_SYMBOL(bignum_cmul_p384_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384.S
@@ -27,11 +27,10 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_deamont_p384
-        .globl  _bignum_deamont_p384
-        .text
-
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384)
 #define z %rdi
 #define x %rsi
 
@@ -80,8 +79,7 @@
         movq    %rdx, d6 ;                                        \
         sbbq    $0, d6
 
-bignum_deamont_p384:
-_bignum_deamont_p384:
+S2N_BN_SYMBOL(bignum_deamont_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_deamont_p384_alt.S
@@ -27,10 +27,10 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_deamont_p384_alt
-        .globl  _bignum_deamont_p384_alt
-        .text
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384_alt)
 
 #define z %rdi
 #define x %rsi
@@ -80,8 +80,7 @@
         movq    %rcx, d6 ;                                        \
         sbbq    $0, d6
 
-bignum_deamont_p384_alt:
-_bignum_deamont_p384_alt:
+S2N_BN_SYMBOL(bignum_deamont_p384_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384.S
@@ -27,10 +27,10 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_demont_p384
-        .globl  _bignum_demont_p384
-        .text
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384)
 
 #define z %rdi
 #define x %rsi
@@ -72,8 +72,7 @@
         movq    %rdx, d6 ;                                        \
         sbbq    $0, d6
 
-bignum_demont_p384:
-_bignum_demont_p384:
+S2N_BN_SYMBOL(bignum_demont_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_demont_p384_alt.S
@@ -27,10 +27,10 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_demont_p384_alt
-        .globl  _bignum_demont_p384_alt
-        .text
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384_alt)
 
 #define z %rdi
 #define x %rsi
@@ -72,8 +72,7 @@
         movq    %rcx, d6 ;                                        \
         sbbq    $0, d6
 
-bignum_demont_p384_alt:
-_bignum_demont_p384_alt:
+S2N_BN_SYMBOL(bignum_demont_p384_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_double_p384.S
@@ -24,9 +24,10 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_double_p384
-        .globl  _bignum_double_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p384)
         .text
 
 #define z %rdi
@@ -48,8 +49,7 @@
 
 
 
-bignum_double_p384:
-_bignum_double_p384:
+S2N_BN_SYMBOL(bignum_double_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_half_p384.S
@@ -24,9 +24,10 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_half_p384
-        .globl  _bignum_half_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p384)
         .text
 
 #define z %rdi
@@ -45,8 +46,7 @@
 
 
 
-bignum_half_p384:
-_bignum_half_p384:
+S2N_BN_SYMBOL(bignum_half_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_littleendian_6.S
@@ -35,25 +35,24 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_littleendian_6
-        .globl  _bignum_littleendian_6
-        .globl  bignum_fromlebytes_6
-        .globl  _bignum_fromlebytes_6
-        .globl  bignum_tolebytes_6
-        .globl  _bignum_tolebytes_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_littleendian_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_littleendian_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_fromlebytes_6)
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tolebytes_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tolebytes_6)
+
         .text
 
 #define z %rdi
 #define x %rsi
 #define a %rax
 
-bignum_littleendian_6:
-_bignum_littleendian_6:
-bignum_fromlebytes_6:
-_bignum_fromlebytes_6:
-bignum_tolebytes_6:
-_bignum_tolebytes_6:
+S2N_BN_SYMBOL(bignum_littleendian_6):
+S2N_BN_SYMBOL(bignum_fromlebytes_6):
+S2N_BN_SYMBOL(bignum_tolebytes_6):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384.S
@@ -26,9 +26,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_n384
-        .globl  _bignum_mod_n384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384)
+
         .text
 
 #define z %rdi
@@ -52,8 +54,7 @@
 #define qshort %edx
 
 
-bignum_mod_n384:
-_bignum_mod_n384:
+S2N_BN_SYMBOL(bignum_mod_n384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_6.S
@@ -26,9 +26,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_n384_6
-        .globl  _bignum_mod_n384_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384_6)
+
         .text
 
 #define z %rdi
@@ -49,8 +51,7 @@
 
 
 
-bignum_mod_n384_6:
-_bignum_mod_n384_6:
+S2N_BN_SYMBOL(bignum_mod_n384_6):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_n384_alt.S
@@ -26,9 +26,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_n384_alt
-        .globl  _bignum_mod_n384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384_alt)
+
         .text
 
 #define z %rdi
@@ -53,8 +55,7 @@
 #define n0short %eax
 #define qshort %ebp
 
-bignum_mod_n384_alt:
-_bignum_mod_n384_alt:
+S2N_BN_SYMBOL(bignum_mod_n384_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_p384
-        .globl  _bignum_mod_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384)
+
         .text
 
 #define z %rdi
@@ -51,8 +53,7 @@
 #define qshort %edx
 
 
-bignum_mod_p384:
-_bignum_mod_p384:
+S2N_BN_SYMBOL(bignum_mod_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_6.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_p384_6
-        .globl  _bignum_mod_p384_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384_6)
+
         .text
 
 #define z %rdi
@@ -48,8 +50,7 @@
 
 
 
-bignum_mod_p384_6:
-_bignum_mod_p384_6:
+S2N_BN_SYMBOL(bignum_mod_p384_6):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mod_p384_alt.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_p384_alt
-        .globl  _bignum_mod_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384_alt)
+
         .text
 
 #define z %rdi
@@ -55,8 +57,7 @@
 #define qshort %ebx
 
 
-bignum_mod_p384_alt:
-_bignum_mod_p384_alt:
+S2N_BN_SYMBOL(bignum_mod_p384_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384.S
@@ -28,9 +28,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // -----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montmul_p384
-        .globl  _bignum_montmul_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p384)
+
         .text
 
 #define z %rdi
@@ -95,8 +97,7 @@
         addq    %rdx, d6 ;                                        \
         adcq    $0, d7
 
-bignum_montmul_p384:
-_bignum_montmul_p384:
+S2N_BN_SYMBOL(bignum_montmul_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montmul_p384_alt.S
@@ -28,9 +28,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // -----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montmul_p384_alt
-        .globl  _bignum_montmul_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p384_alt)
+
         .text
 
 #define z %rdi
@@ -117,8 +119,7 @@
         addq    %rbx, d6 ;                                        \
         adcq    $0, d7
 
-bignum_montmul_p384_alt:
-_bignum_montmul_p384_alt:
+S2N_BN_SYMBOL(bignum_montmul_p384_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384.S
@@ -27,9 +27,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montsqr_p384
-        .globl  _bignum_montsqr_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p384)
+
         .text
 
 #define z %rdi
@@ -92,8 +94,7 @@
         movq    %rdx, d6 ;                                        \
         sbbq    $0, d6
 
-bignum_montsqr_p384:
-_bignum_montsqr_p384:
+S2N_BN_SYMBOL(bignum_montsqr_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_montsqr_p384_alt.S
@@ -27,9 +27,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montsqr_p384_alt
-        .globl  _bignum_montsqr_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p384_alt)
+
         .text
 
 #define z %rdi
@@ -114,8 +116,7 @@
         movq    %rbx, d6 ;                                        \
         sbbq    $0, d6
 
-bignum_montsqr_p384_alt:
-_bignum_montsqr_p384_alt:
+S2N_BN_SYMBOL(bignum_montsqr_p384_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_mux_6.S
@@ -27,9 +27,11 @@
 // Microsoft x64 ABI:   RCX = p, RDX = z, R8 = x, R9 = y
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mux_6
-        .globl  _bignum_mux_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mux_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mux_6)
+
         .text
 
 #define p %rdi
@@ -40,8 +42,7 @@
 #define b %r8
 
 
-bignum_mux_6:
-_bignum_mux_6:
+S2N_BN_SYMBOL(bignum_mux_6):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_neg_p384.S
@@ -23,9 +23,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_neg_p384
-        .globl  _bignum_neg_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p384)
+
         .text
 
 #define z %rdi
@@ -40,8 +42,7 @@
 
 #define n0short %eax
 
-bignum_neg_p384:
-_bignum_neg_p384:
+S2N_BN_SYMBOL(bignum_neg_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_nonzero_6.S
@@ -23,9 +23,11 @@
 // Microsoft x64 ABI:   RCX = x, returns RAX
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_nonzero_6
-        .globl  _bignum_nonzero_6
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_nonzero_6)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_nonzero_6)
+
         .text
 
 #define x %rdi
@@ -35,8 +37,7 @@
 
 
 
-bignum_nonzero_6:
-_bignum_nonzero_6:
+S2N_BN_SYMBOL(bignum_nonzero_6):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_optneg_p384.S
@@ -25,9 +25,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_optneg_p384
-        .globl  _bignum_optneg_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p384)
+
         .text
 
 #define z %rdi
@@ -43,8 +45,7 @@
 
 #define n0short %eax
 
-bignum_optneg_p384:
-_bignum_optneg_p384:
+S2N_BN_SYMBOL(bignum_optneg_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_sub_p384.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_sub_p384
-        .globl  _bignum_sub_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p384)
+
         .text
 
 #define z %rdi
@@ -49,8 +51,7 @@
 
 
 
-bignum_sub_p384:
-_bignum_sub_p384:
+S2N_BN_SYMBOL(bignum_sub_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_tomont_p384
-        .globl  _bignum_tomont_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p384)
+
         .text
 
 #define z %rdi
@@ -94,8 +96,7 @@
         addq    %rdx, d6 ;                                        \
         adcq    $0, d7
 
-bignum_tomont_p384:
-_bignum_tomont_p384:
+S2N_BN_SYMBOL(bignum_tomont_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_tomont_p384_alt.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_tomont_p384_alt
-        .globl  _bignum_tomont_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p384_alt)
+
         .text
 
 #define z %rdi
@@ -112,8 +114,7 @@
         addq    %rbx, d6 ;                                        \
         adcq    $0, d7
 
-bignum_tomont_p384_alt:
-_bignum_tomont_p384_alt:
+S2N_BN_SYMBOL(bignum_tomont_p384_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384.S
@@ -27,9 +27,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_triple_p384
-        .globl  _bignum_triple_p384
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p384)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p384)
+
         .text
 
 #define z %rdi
@@ -49,8 +51,7 @@
 #define ashort %eax
 #define qshort %edx
 
-bignum_triple_p384:
-_bignum_triple_p384:
+S2N_BN_SYMBOL(bignum_triple_p384):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
+++ b/third_party/s2n-bignum/x86_att/p384/bignum_triple_p384_alt.S
@@ -27,9 +27,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_triple_p384_alt
-        .globl  _bignum_triple_p384_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p384_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p384_alt)
+
         .text
 
 #define z %rdi
@@ -52,8 +54,7 @@
 #define qshort %ecx
 #define dshort %edx
 
-bignum_triple_p384_alt:
-_bignum_triple_p384_alt:
+S2N_BN_SYMBOL(bignum_triple_p384_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_add_p521.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_add_p521
-        .globl  _bignum_add_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p521)
+
         .text
 
 #define z %rdi
@@ -49,8 +51,7 @@
 
 
 
-bignum_add_p521:
-_bignum_add_p521:
+S2N_BN_SYMBOL(bignum_add_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521.S
@@ -25,9 +25,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_cmul_p521
-        .globl  _bignum_cmul_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p521)
+
         .text
 
 #define z %rdi
@@ -61,8 +63,7 @@
 
 #define h d9
 
-bignum_cmul_p521:
-_bignum_cmul_p521:
+S2N_BN_SYMBOL(bignum_cmul_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_cmul_p521_alt.S
@@ -25,9 +25,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_cmul_p521_alt
-        .globl  _bignum_cmul_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p521_alt)
+
         .text
 
 #define z %rdi
@@ -65,8 +67,7 @@
 
 #define h d9
 
-bignum_cmul_p521_alt:
-_bignum_cmul_p521_alt:
+S2N_BN_SYMBOL(bignum_cmul_p521_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_deamont_p521.S
@@ -27,9 +27,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_deamont_p521
-        .globl  _bignum_deamont_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p521)
+
         .text
 
 #define z %rdi
@@ -49,8 +51,7 @@
 #define d7 %r13
 #define d8 %rbp
 
-bignum_deamont_p521:
-_bignum_deamont_p521:
+S2N_BN_SYMBOL(bignum_deamont_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_demont_p521.S
@@ -27,9 +27,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_demont_p521
-        .globl  _bignum_demont_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p521)
+
         .text
 
 #define z %rdi
@@ -49,8 +51,7 @@
 #define d7 %rcx
 #define d8 %rdx
 
-bignum_demont_p521:
-_bignum_demont_p521:
+S2N_BN_SYMBOL(bignum_demont_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_double_p521.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_double_p521
-        .globl  _bignum_double_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p521)
+
         .text
 
 #define z %rdi
@@ -37,8 +39,7 @@
 
 
 
-bignum_double_p521:
-_bignum_double_p521:
+S2N_BN_SYMBOL(bignum_double_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_fromlebytes_p521.S
@@ -28,17 +28,18 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_fromlebytes_p521
-        .globl  _bignum_fromlebytes_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_fromlebytes_p521)
+
         .text
 
 #define z %rdi
 #define x %rsi
 #define a %rax
 
-bignum_fromlebytes_p521:
-_bignum_fromlebytes_p521:
+S2N_BN_SYMBOL(bignum_fromlebytes_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_half_p521.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_half_p521
-        .globl  _bignum_half_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p521)
+
         .text
 
 #define z %rdi
@@ -48,8 +50,7 @@
 
 
 
-bignum_half_p521:
-_bignum_half_p521:
+S2N_BN_SYMBOL(bignum_half_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9.S
@@ -26,9 +26,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_n521_9
-        .globl  _bignum_mod_n521_9
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n521_9)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n521_9)
+
         .text
 
 #define z %rdi
@@ -49,8 +51,7 @@
 #define cshort %ecx
 #define qshort %edx
 
-bignum_mod_n521_9:
-_bignum_mod_n521_9:
+S2N_BN_SYMBOL(bignum_mod_n521_9):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_n521_9_alt.S
@@ -26,9 +26,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_n521_9_alt
-        .globl  _bignum_mod_n521_9_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n521_9_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n521_9_alt)
+
         .text
 
 #define z %rdi
@@ -49,8 +51,7 @@
 #define cshort %ecx
 #define qshort %edx
 
-bignum_mod_n521_9_alt:
-_bignum_mod_n521_9_alt:
+S2N_BN_SYMBOL(bignum_mod_n521_9_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mod_p521_9.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mod_p521_9
-        .globl  _bignum_mod_p521_9
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p521_9)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p521_9)
+
         .text
 
 #define z %rdi
@@ -48,8 +50,7 @@
 
 #define d7 %rsi
 
-bignum_mod_p521_9:
-_bignum_mod_p521_9:
+S2N_BN_SYMBOL(bignum_mod_p521_9):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521.S
@@ -29,9 +29,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montmul_p521
-        .globl  _bignum_montmul_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p521)
+
         .text
 
 #define z %rdi
@@ -50,8 +52,7 @@
         adcxq   %rax, low ;               \
         adoxq   %rbx, high
 
-bignum_montmul_p521:
-_bignum_montmul_p521:
+S2N_BN_SYMBOL(bignum_montmul_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montmul_p521_alt.S
@@ -29,9 +29,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montmul_p521_alt
-        .globl  _bignum_montmul_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p521_alt)
+
         .text
 
 #define z %rdi
@@ -67,8 +69,7 @@
         addq    %rax, l ;                         \
         adcq    %rdx, h
 
-bignum_montmul_p521_alt:
-_bignum_montmul_p521_alt:
+S2N_BN_SYMBOL(bignum_montmul_p521_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521.S
@@ -29,9 +29,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montsqr_p521
-        .globl  _bignum_montsqr_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p521)
+
         .text
 
 #define z %rdi
@@ -61,8 +63,7 @@
         adcxq   %rax, low ;               \
         adoxq   zero, high
 
-bignum_montsqr_p521:
-_bignum_montsqr_p521:
+S2N_BN_SYMBOL(bignum_montsqr_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_montsqr_p521_alt.S
@@ -29,9 +29,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_montsqr_p521_alt
-        .globl  _bignum_montsqr_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p521_alt)
+
         .text
 
 // Input arguments
@@ -96,8 +98,7 @@
         adcq    %rdx, h ;                         \
         adcq    $0, c
 
-bignum_montsqr_p521_alt:
-_bignum_montsqr_p521_alt:
+S2N_BN_SYMBOL(bignum_montsqr_p521_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mul_p521
-        .globl  _bignum_mul_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p521)
+
         .text
 
 #define z %rdi
@@ -45,8 +47,7 @@
         adcxq   %rax, low ;               \
         adoxq   %rbx, high
 
-bignum_mul_p521:
-_bignum_mul_p521:
+S2N_BN_SYMBOL(bignum_mul_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_mul_p521_alt.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_mul_p521_alt
-        .globl  _bignum_mul_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p521_alt)
+
         .text
 
 #define z %rdi
@@ -62,8 +64,7 @@
         addq    %rax, l ;                         \
         adcq    %rdx, h
 
-bignum_mul_p521_alt:
-_bignum_mul_p521_alt:
+S2N_BN_SYMBOL(bignum_mul_p521_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_neg_p521.S
@@ -23,9 +23,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_neg_p521
-        .globl  _bignum_neg_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p521)
+
         .text
 
 #define z %rdi
@@ -39,8 +41,7 @@
 #define d4 %r10
 #define d5 %r11
 
-bignum_neg_p521:
-_bignum_neg_p521:
+S2N_BN_SYMBOL(bignum_neg_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_optneg_p521.S
@@ -25,9 +25,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_optneg_p521
-        .globl  _bignum_optneg_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p521)
+
         .text
 
 #define z %rdi
@@ -41,8 +43,7 @@
 #define d3 %r10
 #define d4 %r11
 
-bignum_optneg_p521:
-_bignum_optneg_p521:
+S2N_BN_SYMBOL(bignum_optneg_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521.S
@@ -23,9 +23,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_sqr_p521
-        .globl  _bignum_sqr_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p521)
+
         .text
 
 #define z %rdi
@@ -55,8 +57,7 @@
         adcxq   %rax, low ;               \
         adoxq   zero, high
 
-bignum_sqr_p521:
-_bignum_sqr_p521:
+S2N_BN_SYMBOL(bignum_sqr_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sqr_p521_alt.S
@@ -23,9 +23,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_sqr_p521_alt
-        .globl  _bignum_sqr_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p521_alt)
+
         .text
 
 // Input arguments
@@ -90,8 +92,7 @@
         adcq    %rdx, h ;                         \
         adcq    $0, c
 
-bignum_sqr_p521_alt:
-_bignum_sqr_p521_alt:
+S2N_BN_SYMBOL(bignum_sqr_p521_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_sub_p521.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_sub_p521
-        .globl  _bignum_sub_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p521)
+
         .text
 
 #define z %rdi
@@ -48,8 +50,7 @@
 
 
 
-bignum_sub_p521:
-_bignum_sub_p521:
+S2N_BN_SYMBOL(bignum_sub_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tolebytes_p521.S
@@ -28,17 +28,18 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_tolebytes_p521
-        .globl  _bignum_tolebytes_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tolebytes_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tolebytes_p521)
+
         .text
 
 #define z %rdi
 #define x %rsi
 #define a %rax
 
-bignum_tolebytes_p521:
-_bignum_tolebytes_p521:
+S2N_BN_SYMBOL(bignum_tolebytes_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_tomont_p521.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_tomont_p521
-        .globl  _bignum_tomont_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p521)
+
         .text
 
 #define z %rdi
@@ -48,8 +50,7 @@
 
 #define d7 %rsi
 
-bignum_tomont_p521:
-_bignum_tomont_p521:
+S2N_BN_SYMBOL(bignum_tomont_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_triple_p521
-        .globl  _bignum_triple_p521
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p521)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p521)
+
         .text
 
 #define z %rdi
@@ -49,8 +51,7 @@
 
 
 
-bignum_triple_p521:
-_bignum_triple_p521:
+S2N_BN_SYMBOL(bignum_triple_p521):
 
 #if WINDOWS_ABI
         pushq   %rdi

--- a/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
+++ b/third_party/s2n-bignum/x86_att/p521/bignum_triple_p521_alt.S
@@ -24,9 +24,11 @@
 // Microsoft x64 ABI:   RCX = z, RDX = x
 // ----------------------------------------------------------------------------
 
+#include "_internal_s2n_bignum.h"
 
-        .globl  bignum_triple_p521_alt
-        .globl  _bignum_triple_p521_alt
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p521_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p521_alt)
+
         .text
 
 #define z %rdi
@@ -50,8 +52,7 @@
 #define a %rax
 #define d %rdx
 
-bignum_triple_p521_alt:
-_bignum_triple_p521_alt:
+S2N_BN_SYMBOL(bignum_triple_p521_alt):
 
 #if WINDOWS_ABI
         pushq   %rdi


### PR DESCRIPTION
### Description of changes: 
Merge the latest from s2n-bignum.

### Call-outs:
This change does NOT hide the s2n-bignum symbols in AWS-LC.  I want to keep this change focused on purely merging from upstream, with a minor tweak to our build script so that it succeeds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
