### PR TITLE
Retry InvalidChannelIDSignature-TLS13-TLS-Sync-SplitHandshakeRecords.

### DIFF
--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -1258,6 +1258,9 @@ type shimProcess struct {
 	waitChan       chan error
 	listener       *net.TCPListener
 	stdout, stderr bytes.Buffer
+	// default value is false.
+	// This is marked as true in |(s *shimProcess) wait()|.
+	idled          bool
 }
 
 // newShimProcess starts a new shim with the specified executable, flags, and
@@ -1295,7 +1298,7 @@ func newShimProcess(shimPath string, flags []string, env []string) (*shimProcess
 		shim.listener.Close()
 		return nil, err
 	}
-
+	shim.idled = false
 	shim.waitChan = make(chan error, 1)
 	go func() { shim.waitChan <- shim.cmd.Wait() }()
 	return shim, nil
@@ -1337,6 +1340,13 @@ func (s *shimProcess) wait() error {
 
 	if !useDebugger() {
 		waitTimeout := time.AfterFunc(*idleTimeout, func() {
+			// Enable below code to debug why the shimProcess is idle.
+			// time.Sleep(20 * time.Minute)
+			// stderr := strings.Replace(s.stderr.String(), "\r\n", "\n", -1)
+			// fmt.Fprintf(os.Stderr, "idleTimeout reached. Process %d is idled with output %s", s.cmd.Process.Pid, stderr)
+			// Mark the bssl_shim process as idled.
+			// The further action is to retry the test case.
+			s.idled = true
 			s.cmd.Process.Kill()
 		})
 		defer waitTimeout.Stop()
@@ -1651,6 +1661,18 @@ func runTest(statusChan chan statusMsg, test *testCase, shimPath string, mallocN
 
 	localErr := doExchanges(test, shim, resumeCount, &transcripts)
 	childErr := shim.wait()
+
+	// shim is marked as idled only when |idleTimeout| is reached.
+	// This retry fix is scoped with "InvalidChannelIDSignature-TLS13-TLS-Sync-SplitHandshakeRecords".
+	if shim.idled && test.name == "InvalidChannelIDSignature-TLS13-TLS-Sync-SplitHandshakeRecords" {
+		shim, err = newShimProcess(shimPath, flags, env)
+		if err != nil {
+			return err
+		}
+		defer shim.close()
+		localErr = doExchanges(test, shim, resumeCount, &transcripts)
+		childErr = shim.wait()
+	}
 
 	// Now that the shim has exited, all the settings files have been
 	// written. Append the saved transcripts.


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-1040

[InvalidChannelIDSignature-TLS13-TLS-Sync-SplitHandshakeRecords](https://github.com/awslabs/aws-lc/blob/59eccdf959c93a4543b8cb4ae7af01e7be265d3e/ssl/test/runner/runner.go#L5859-L5872) expects `CHANNEL_ID_SIGNATURE_INVALID` is put in [the error stacks of the `bssl_shim`](https://github.com/awslabs/aws-lc/blame/59eccdf959c93a4543b8cb4ae7af01e7be265d3e/ssl/test/bssl_shim.cc#L1337-L1341), which has [SSL_R_CHANNEL_ID_SIGNATURE_INVALID](https://github.com/awslabs/aws-lc/blame/6c57dafb2498e138f983415fb7654557f04760f2/ssl/extensions.cc#L4169) added.

However, the test fails sometimes with below error message on GitHub MacOS CI.
```
FAILED (InvalidChannelIDSignature-TLS13-TLS-Sync-SplitHandshakeRecords)
bad error (wanted ':CHANNEL_ID_SIGNATURE_INVALID:' / ''): local error 'channel ID unexpectedly negotiated', child error 'signal: killed', stdout:

stderr:
SSL error: SSL
```

This test failed because [the bssl_shim process state became `interruptible sleep` and then killed by the runner.go after the timed out(15 seconds)](https://github.com/awslabs/aws-lc/blob/59eccdf959c93a4543b8cb4ae7af01e7be265d3e/ssl/test/runner/runner.go#L1333-L1336). This can be further verified by comparing the error stacks between good and this flacky case. With the comparision, we can find the `ERR_print_errors_fp` is not executed.

Below is the captured process state. `WCHAN` does not tell what the process is waiting for. This can be another investigation direction.

```
ps -p 58506 -l
UID        PID   PPID F    CPU PRI NI SZ      RSS  WCHAN S ADDR TTY TIME CMD
106449524 58506 58504 4006 0   31   0 4293484 2824 - S+ 0 ttys000 0:00.02 /Users/xxx/workplace/xxx/aws-lc/test_build_dir/ssl/test/bssl_shim
```

#### Reproduce steps
env: MacOS Big Sur 11.6.5 (20G527)
```sh
#!/bin/bash
set -exo pipefail

source tests/ci/common_posix_setup.sh

# In runner.go, filter out other tests to speed up reproducing this issue.
run_build
for i in {1..1000}
do
   run_cmake_custom_target 'run_ssl_runner_tests'
done
```
### Description of changes: 
* This PR added retry on `InvalidChannelIDSignature-TLS13-TLS-Sync-SplitHandshakeRecords`.

### Call-outs:
* The sleeping process cannot be resumed via `kill -SIGCONT {pid}`. And the resume fix can be more complicate so the retry path is implemented.

### Testing:
Without this PR change, the issue can be reproduced within 500 iterations.
With this fix, the issue is not reproducible after 3700 iterations, which retried the test case 12 times.
```
$ less nohup.out | grep 'idleTimeout reached' | wc -l
      12
$ less nohup.out | grep 'PASS' | wc -l
    3700
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
