### PR TITLE
Fix Unused statements for fiat

### DIFF
--- a/third_party/fiat/p384_32.h
+++ b/third_party/fiat/p384_32.h
@@ -24,11 +24,11 @@ typedef signed char fiat_p384_int1;
 #endif
 
 // TODO: if we regenerate the Fiat-crypto files with only the needed functions, no need for these declarations.
-OPENSSL_UNUSED static void fiat_p384_opp(uint32_t out1[6], const uint32_t arg1[6]);
-OPENSSL_UNUSED static void fiat_p384_set_one(uint32_t out1[6]);
-OPENSSL_UNUSED static void fiat_p384_msat(uint32_t out1[7]);
-OPENSSL_UNUSED static void fiat_p384_divstep(uint32_t* out1, uint32_t out2[7], uint32_t out3[7], uint32_t out4[6], uint32_t out5[6], uint32_t arg1, const uint32_t arg2[7], const uint32_t arg3[7], const uint32_t arg4[6], const uint32_t arg5[6]);
-OPENSSL_UNUSED static void fiat_p384_divstep_precomp(uint32_t out1[6]);
+OPENSSL_UNUSED static void fiat_p384_opp(uint32_t out1[12], const uint32_t arg1[12]);
+OPENSSL_UNUSED static void fiat_p384_set_one(uint32_t out1[12]);
+OPENSSL_UNUSED static void fiat_p384_msat(uint32_t out1[13]);
+OPENSSL_UNUSED static void fiat_p384_divstep(uint32_t* out1, uint32_t out2[13], uint32_t out3[13], uint32_t out4[12], uint32_t out5[12], uint32_t arg1, const uint32_t arg2[13], const uint32_t arg3[13], const uint32_t arg4[12], const uint32_t arg5[12]);
+OPENSSL_UNUSED static void fiat_p384_divstep_precomp(uint32_t out1[12]);
 OPENSSL_UNUSED static void fiat_p384_selectznz(uint32_t out1[12], fiat_p384_uint1 arg1, const uint32_t arg2[12], const uint32_t arg3[12]);
 
 /*


### PR DESCRIPTION
We have `OPENSSL_UNUSED` statements for our fiat header files in order
to prevent errors for functions that we don't use. There was a mistake
that used the 64-bit function definitions for the 32-bit header file. On
some platforms this would cause a compilation error.

### Issues:
Potential fix for https://github.com/awslabs/aws-lc/issues/487

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
