### PR TITLE
Install valgrind-devel.

### DIFF
--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_base/Dockerfile
@@ -24,7 +24,10 @@ RUN set -ex && \
     wget \
     llvm \
     llvm-devel \
+    # valgrind is just the application and core resources.
     valgrind \
+    # valgrind/memcheck.h is provided by the valgrind-devel package on AL2. see P63119011.
+    valgrind-devel \
     unzip && \
     # Based on https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-1067

### Description of changes: 
[`valgrind/memcheck.h`](https://github.com/awslabs/aws-lc/blob/e14e153cda6c0921a10209c78762de37707d48c4/crypto/internal.h#L121-L123) is provided by the `valgrind-devel` package on AL2. see `P63119011`.

### Call-outs:
* Valgrind is not enabled on arm because [the Arm tests hitting the 2 hour time out limit in Codebuild (track resolution in CryptoAlg-597)]( https://github.com/awslabs/aws-lc/pull/71).
* Next PR will be published to enable the build flag `CONSTANT_TIME_VALIDATION`.

### Testing:
* `CryptoAlg-1067?selectedConversation=6fd74357-b5ea-45d8-bff7-a411d24255e7`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
