### PR TITLE
Ci prefix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,5 @@ util/bot/yasm-win32.exe
 test_build_dir/
 cmake-build-debug/
 symbols.txt
-/.idea
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ util/bot/sde-win32.tar.xz
 util/bot/win_toolchain.json
 util/bot/yasm-win32.exe
 
-test_build_dir
+test_build_dir/
+cmake-build-debug/
+symbols.txt
+/.idea
 
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
            symbol_prefix_include/boringssl_prefix_symbols_asm.h
            symbol_prefix_include/boringssl_prefix_symbols_nasm.inc
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include
-    COMMAND ${GO_EXECUTABLE} run ${CMAKE_CURRENT_SOURCE_DIR}/util/make_prefix_headers.go -out ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include ${BORINGSSL_PREFIX_SYMBOLS}
+    COMMAND ${GO_EXECUTABLE} run ${CMAKE_CURRENT_SOURCE_DIR}/util/make_prefix_headers.go -out ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include ${BORINGSSL_PREFIX_SYMBOLS_PATH}
     DEPENDS util/make_prefix_headers.go
             ${BORINGSSL_PREFIX_SYMBOLS_PATH})
 

--- a/tests/ci/cdk/README.md
+++ b/tests/ci/cdk/README.md
@@ -65,23 +65,23 @@ Note: `GITHUB_REPO_OWNER` specifies the GitHub repo targeted by this CI setup.
 
 To set up AWS-LC CI, run command:
 ```
-./run-cdk.sh --github-repo-owner=${GITHUB_REPO_OWNER} --action deploy-ci
+./run-cdk.sh --github-repo-owner ${GITHUB_REPO_OWNER} --action deploy-ci --aws-account ${AWS_ACCOUNT_ID}
 ```
 
 To update AWS-LC CI, run command:
 ```
-./run-cdk.sh --github-repo-owner=${GITHUB_REPO_OWNER} --action update-ci
+./run-cdk.sh --github-repo-owner ${GITHUB_REPO_OWNER} --action update-ci --aws-account ${AWS_ACCOUNT_ID}
 ```
 
 To create/update Linux Docker images, run command:
 ```
-./run-cdk.sh --github-repo-owner=${GITHUB_REPO_OWNER} --action build-linux-img
+./run-cdk.sh --github-repo-owner ${GITHUB_REPO_OWNER} --action build-linux-img --aws-account ${AWS_ACCOUNT_ID}
 ```
 
 To destroy AWS-LC CI resources created above, run command:
 ```
 # NOTE: this command will destroy all resources (AWS CodeBuild and ECR).
-./run-cdk.sh --github-repo-owner=${GITHUB_REPO_OWNER} --action destroy-ci
+./run-cdk.sh --github-repo-owner ${GITHUB_REPO_OWNER} --action destroy-ci --aws-account ${AWS_ACCOUNT_ID}
 ```
 
 For help, run command:

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -148,8 +148,24 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_latest
 
+    - identifier: ubuntu2004_clang10x_aarch_prefix
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_prefix_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-10x_latest
+
     - identifier: amazonlinux2_gcc7x_aarch
       buildspec: ./tests/ci/codebuild/linux-aarch/run_posix_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_latest
+
+    - identifier: amazonlinux2_gcc7x_aarch_prefix
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_prefix_tests.yml
       env:
         type: ARM_CONTAINER
         privileged-mode: false

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -62,7 +62,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-11x_latest
+        image: ECR_REPO_PLACEHOLDER:ubuntu-22.04_gcc-11x_latest
 
     - identifier: ubuntu2004_gcc11x_x86_64_prefix
       buildspec: ./tests/ci/codebuild/linux-x86/run_prefix_tests.yml
@@ -70,7 +70,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-11x_latest
+        image: ECR_REPO_PLACEHOLDER:ubuntu-22.04_gcc-11x_latest
 
     - identifier: ubuntu2004_clang7x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/run_posix_tests.yml

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -64,6 +64,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-11x_latest
 
+    - identifier: ubuntu2004_gcc11x_x86_64_prefix
+      buildspec: ./tests/ci/codebuild/linux-x86/run_prefix_tests.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-11x_latest
+
     - identifier: ubuntu2004_clang7x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/run_posix_tests.yml
       env:
@@ -158,6 +166,14 @@ batch:
 
     - identifier: amazonlinux2_clang7x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/run_posix_tests.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_clang-7x_latest
+
+    - identifier: amazonlinux2_clang7x_x86_64_prefix
+      buildspec: ./tests/ci/codebuild/linux-x86/run_prefix_tests.yml
       env:
         type: LINUX_CONTAINER
         privileged-mode: true

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -56,7 +56,7 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-8x_latest
 
-    - identifier: ubuntu2004_gcc11x_x86_64
+    - identifier: ubuntu2204_gcc11x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/run_posix_tests.yml
       env:
         type: LINUX_CONTAINER
@@ -64,7 +64,7 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-22.04_gcc-11x_latest
 
-    - identifier: ubuntu2004_gcc11x_x86_64_prefix
+    - identifier: ubuntu2204_gcc11x_x86_64_prefix
       buildspec: ./tests/ci/codebuild/linux-x86/run_prefix_tests.yml
       env:
         type: LINUX_CONTAINER

--- a/tests/ci/codebuild/linux-aarch/run_prefix_tests.yml
+++ b/tests/ci/codebuild/linux-aarch/run_prefix_tests.yml
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      # To use this build spec file, CMake environment variable CC and CXX compiler should be defined before build.
+      - if [[ -z "${CC+x}" || -z "${CC}" ]]; then echo "CC is not defined." && exit 1; else ${CC} --version && echo "Found correct CC."; fi
+      - if [[ -z "${CXX+x}" || -z "${CXX}" ]]; then echo "CXX is not defined." && exit 1; else ${CXX} --version && echo "Found correct CXX."; fi
+  build:
+    commands:
+      - ./tests/ci/run_prefix_tests.sh

--- a/tests/ci/codebuild/linux-x86/run_prefix_tests.yml
+++ b/tests/ci/codebuild/linux-x86/run_prefix_tests.yml
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      # To use this build spec file, CMake environment variable CC and CXX compiler should be defined before build.
+      - if [[ -z "${CC+x}" || -z "${CC}" ]]; then echo "CC is not defined." && exit 1; else ${CC} --version && echo "Found correct CC."; fi
+      - if [[ -z "${CXX+x}" || -z "${CXX}" ]]; then echo "CXX is not defined." && exit 1; else ${CXX} --version && echo "Found correct CXX."; fi
+  build:
+    commands:
+      - ./tests/ci/run_prefix_tests.sh

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -11,6 +11,8 @@ else
 fi
 echo "$SRC_ROOT"
 
+PREBUILD_CUSTOM_TARGET=""
+
 BUILD_ROOT="${SRC_ROOT}/test_build_dir"
 echo "$BUILD_ROOT"
 
@@ -50,6 +52,9 @@ function run_build {
   fi
 
   cmake "${cflags[@]}" "$SRC_ROOT"
+  if [[ "${PREBUILD_CUSTOM_TARGET}" != "" ]]; then
+    run_cmake_custom_target "${PREBUILD_CUSTOM_TARGET}"
+  fi
   $BUILD_COMMAND
   cd "$SRC_ROOT"
 }
@@ -88,7 +93,9 @@ function verify_symbols_prefixed {
 function build_prefix_and_test {
   run_build "$@"
   generate_symbols_file
+  PREBUILD_CUSTOM_TARGET="boringssl_prefix_symbols"
   run_build "$@" "-DBORINGSSL_PREFIX=aws_lc_1_1_0" "-DBORINGSSL_PREFIX_SYMBOLS=${SRC_ROOT}/symbols.txt"
+  PREBUILD_CUSTOM_TARGET=""
   verify_symbols_prefixed
   run_cmake_custom_target 'run_tests'
 }

--- a/tests/ci/docker_images/linux-x86/ubuntu-7.10_gcc-4.1x/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-7.10_gcc-4.1x/Dockerfile
@@ -7,6 +7,12 @@ COPY sources.list /etc/apt/sources.list
 
 CMD ["/bin/bash"]
 
+# The following hack is to avoid a problem where glibc update fails b/c kernel revision is >255
+# https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1962225
+RUN mv /bin/uname /bin/uname.orig
+RUN printf '#!/bin/bash\n\nif [[ "$1" == "-r" ]] ;then\n echo '4.9.250'\n exit\nelse\n uname.orig "$@"\nfi' > /bin/uname
+RUN chmod 755 /bin/uname
+
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \
     gcc-4.1 \

--- a/tests/ci/run_prefix_tests.sh
+++ b/tests/ci/run_prefix_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -exo pipefail
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+source tests/ci/common_posix_setup.sh
+
+print_system_and_dependency_information
+
+echo "Testing a prefix build of AWS-LC in debug mode."
+build_prefix_and_test
+
+echo "Testing a prefix build of AWS-LC in release mode."
+build_prefix_and_test -DCMAKE_BUILD_TYPE=Release
+
+echo "Testing a prefix build of AWS-LC small compilation."
+build_prefix_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release
+
+echo "Testing a prefix build of AWS-LC in no asm mode."
+build_prefix_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release

--- a/util/read_symbols.go
+++ b/util/read_symbols.go
@@ -186,7 +186,7 @@ func listSymbolsELF(contents []byte) ([]string, error) {
 			}
 		}
 	} else if err != elf.ErrNoSymbols {
-	// When `OPENSSL_NO_ASM` build flag is set, some assembly files will produce object files w/o a Symbols section
+		// When `OPENSSL_NO_ASM` build flag is set, some assembly files will produce object files w/o a Symbols section
 		return nil, err
 	}
 	return names, nil

--- a/util/read_symbols.go
+++ b/util/read_symbols.go
@@ -175,17 +175,19 @@ func listSymbolsELF(contents []byte) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	syms, err := f.Symbols()
-	if err != nil {
-		return nil, err
-	}
 
 	var names []string
-	for _, sym := range syms {
-		// Only include exported, defined symbols
-		if elf.ST_BIND(sym.Info) != elf.STB_LOCAL && sym.Section != elf.SHN_UNDEF {
-			names = append(names, sym.Name)
+	syms, err := f.Symbols()
+	if err == nil {
+		for _, sym := range syms {
+			// Only include exported, defined symbols
+			if elf.ST_BIND(sym.Info) != elf.STB_LOCAL && sym.Section != elf.SHN_UNDEF {
+				names = append(names, sym.Name)
+			}
 		}
+	} else if err != elf.ErrNoSymbols {
+	// When `OPENSSL_NO_ASM` build flag is set, some assembly files will produce object files w/o a Symbols section
+		return nil, err
 	}
 	return names, nil
 }


### PR DESCRIPTION
### Description of changes: 
Add prefix builds to our CI.

### Call-outs:
Also fixed a few related issues:
* CDK Readme showed commands that were incomplete, and wouldn't even work.
* Move Ubuntu's gcc-11x build to Ubuntu 22.04 to avoid Ubuntu glibc/kernel install issue: https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1962225.
* Patched Ubuntu-7.10/gcc-4.1x docker image to avoid same glibc/kernel install issue.
* Explicitly invokes the `boringssl_prefix_symbols` target prior to prefix build.  AL2/CMake2 hosts seemed to ignore this target dependency when building target `ssl`
* With certain build flags (like `OPENSSL_NO_ASM=1`) some object files would be w/o a "Symbols" section causing the `read_symbols.go` script to fail. Updated script to ignore object files not containing symbols.

### Testing:
* I synthesized the docker images and CDK into my personal account, and successfully tested the CI for both x86 and ARM.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
