### PR TITLE
Disable stitch code when AWSLC_FIPS is defined.

### DIFF
--- a/crypto/cipher_extra/internal.h
+++ b/crypto/cipher_extra/internal.h
@@ -70,7 +70,7 @@ extern "C" {
 #endif
 
 #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_X86_64) && \
-    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
+    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX) && !defined(AWSLC_FIPS)
 #define AES_CBC_HMAC_SHA_STITCH
 // TLS1_1_VERSION is also defined in ssl.h.
 #define TLS1_1_VERSION 0x0302


### PR DESCRIPTION
### Description of changes: 
Currently, it's unknown how to validate stitch APIs and if some customers use these ciphers in FIPS mode. `CryptoAlg-1155` is created to provide next steps.

### Testing:
* No test needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
