### PR TITLE
Move C++11 fwd-declared enum to ssl.h

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -329,24 +329,6 @@ extern "C" {
 #endif
 #endif  // OPENSSL_ASM_INCOMPATIBLE
 
-#if defined(__cplusplus)
-// enums can be predeclared, but only in C++ and only if given an explicit type.
-// C doesn't support setting an explicit type for enums thus a #define is used
-// to do this only for C++. However, the ABI type between C and C++ need to have
-// equal sizes, which is confirmed in a unittest.
-#define BORINGSSL_ENUM_INT : int
-enum ssl_early_data_reason_t BORINGSSL_ENUM_INT;
-enum ssl_encryption_level_t BORINGSSL_ENUM_INT;
-enum ssl_private_key_result_t BORINGSSL_ENUM_INT;
-enum ssl_renegotiate_mode_t BORINGSSL_ENUM_INT;
-enum ssl_select_cert_result_t BORINGSSL_ENUM_INT;
-enum ssl_select_cert_result_t BORINGSSL_ENUM_INT;
-enum ssl_ticket_aead_result_t BORINGSSL_ENUM_INT;
-enum ssl_verify_result_t BORINGSSL_ENUM_INT;
-#else
-#define BORINGSSL_ENUM_INT
-#endif
-
 // CRYPTO_THREADID is a dummy value.
 typedef int CRYPTO_THREADID;
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -171,6 +171,24 @@ struct timeval;
 extern "C" {
 #endif
 
+#if defined(__cplusplus)
+// enums can be predeclared, but only in C++ and only if given an explicit type.
+// C doesn't support setting an explicit type for enums thus a #define is used
+// to do this only for C++. However, the ABI type between C and C++ need to have
+// equal sizes, which is confirmed in a unittest.
+#define BORINGSSL_ENUM_INT : int
+enum ssl_early_data_reason_t BORINGSSL_ENUM_INT;
+enum ssl_encryption_level_t BORINGSSL_ENUM_INT;
+enum ssl_private_key_result_t BORINGSSL_ENUM_INT;
+enum ssl_renegotiate_mode_t BORINGSSL_ENUM_INT;
+enum ssl_select_cert_result_t BORINGSSL_ENUM_INT;
+enum ssl_select_cert_result_t BORINGSSL_ENUM_INT;
+enum ssl_ticket_aead_result_t BORINGSSL_ENUM_INT;
+enum ssl_verify_result_t BORINGSSL_ENUM_INT;
+#else
+#define BORINGSSL_ENUM_INT
+#endif
+
 
 // SSL implementation.
 


### PR DESCRIPTION
### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 

AWS-LC's libcrypto library is standard C99, but there are a few
`#ifdef`'d forward-declared enums in `base.h`, which are exclusively
C++11 features. Further, they're C++11 features that are not supported
by GCC 4.1.2, which is the GCC installation on RHEL5. Since ACCP's
native library is C++, its CMake also tries to compile AWS-LC as C++,
triggering the `#if defined(__cplusplus)` macro and trying to compile
the forward-declared enums as C++. This fails on RHEL5 due to
aforementioned GCC version.

So, @htorben's solution is to simply move these forward declarations to
`ssl.h`, which is outside the object boundary of libcrypto. Both he and
I have confirmed that the resulting object compiles correctly with ACCP
under RHEL5 (RDE) environments.

### Call-outs:
n/a

### Testing:
 Standard CI was run as part of this PR workflow. Additionally, both @htorben and I have validated that ACCP can now build against and use AWS-LC on RHEL5 with GCC 4.1.2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
