### PR TITLE
Enable XTS fuzz.

### DIFF
--- a/tests/ci/run_cryptofuzz.sh
+++ b/tests/ci/run_cryptofuzz.sh
@@ -18,9 +18,23 @@ cmake -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DBORINGSSL_ALLOW_
   -GNinja -DBUILD_TESTING=OFF -DBUILD_LIBSSL=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo ../
 ninja
 cd ../
-export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_BORINGSSL"
+
+# CRYPTOFUZZ_AWSLC will enable AES_256_XTS in upstream code. See `V610453347`.
+# TODO: remove CRYPTOFUZZ_BORINGSSL when CRYPTOFUZZ_AWSLC is fully integrated.
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_BORINGSSL -DCRYPTOFUZZ_AWSLC"
 export OPENSSL_INCLUDE_PATH=`realpath include/`
 export OPENSSL_LIBCRYPTO_A_PATH=`realpath ${BUILD_ROOT}/crypto/libcrypto.a`
+
+# For cryptofuzz development only, override CRYPTOFUZZ_SRC with CUSTOM_CRYPTOFUZZ_REPO_DIR.
+CUSTOM_CRYPTOFUZZ_REPO_DIR=''
+if [[ -z "${CUSTOM_CRYPTOFUZZ_REPO_DIR}" ]]; then
+  echo "CUSTOM_CRYPTOFUZZ_REPO_DIR is empty."
+else
+  export CRYPTOFUZZ_SRC="${CUSTOM_CRYPTOFUZZ_REPO_DIR}"
+  cd "$CRYPTOFUZZ_SRC"
+  # This step is to generate required header and cpp files.
+  python3 gen_repository.py
+fi
 
 # Build the common OpenSSL module with AWS-LC
 cd "${CRYPTOFUZZ_SRC}/modules/openssl"
@@ -30,14 +44,20 @@ export CFLAGS="${CFLAGS} -I $OPENSSL_INCLUDE_PATH"
 export CXXFLAGS="${CXXFLAGS} -I $OPENSSL_INCLUDE_PATH"
 export LIBFUZZER_LINK="-fsanitize=fuzzer"
 
-# Build the overall cryptofuzz binary
+# Build the overall cryptofuzz and generate_corpus binary
 cd "$CRYPTOFUZZ_SRC"
-make "-j${NUM_CPU_THREADS}" cryptofuzz
+rm -rf cryptofuzz
+rm -rf generate_corpus
+make "-j${NUM_CPU_THREADS}" cryptofuzz generate_corpus
 
 # Common AWS-LC fuzzing setup, the cryptofuzz binary is in this folder so FUZZ_TEST_PATH=FUZZ_NAME
 FUZZ_NAME="cryptofuzz"
 FUZZ_TEST_PATH="${CRYPTOFUZZ_SRC}/${FUZZ_NAME}"
 SRC_CORPUS="$CRYPTOFUZZ_SEED_CORPUS"
+
+# For cryptofuzz development only, uncomment below code to generate new corpus.
+# rm -rf "$CRYPTOFUZZ_SEED_CORPUS" && mkdir "$CRYPTOFUZZ_SEED_CORPUS"
+# ./generate_corpus "$CRYPTOFUZZ_SEED_CORPUS"
 
 # Perform the actual fuzzing. We want the total build time to be about an 45 minutes:
 # 5 minutes for building AWS-LC and Cryptofuzz


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-1136

### Description of changes: 
This PR enabled XTS fuzz by passing `CRYPTOFUZZ_AWSLC`. The macro functionality is is similar to `CRYPTOFUZZ_BORINGSSL`, which tells if the target library provides some cipher APIs(e.g. `EVP_aes_256_xts`). When the target API is provided, `cryptofuzz` tool can start fuzzing the code.

### Call-outs:
* `CRYPTOFUZZ_AWSLC` will be available in upstream after the approval of `V610453347`. In testing, a forked cryptofuzz repo is used.
* Some `cryptofuzz development` related commands are needed by runbook.

### Testing:
```sh
docker run -it -v `pwd`:`pwd` -w `pwd` ubuntu-20.04:cryptofuzz
rm -rf nohup.out && bash -c "nohup sh -c './tests/ci/run_cryptofuzz.sh' &"

# After 4 hours, the debug statements |code_block| added inside `aes_xts_cipher` were print out.
cat nohup.out | grep 'code_block' | sort | uniq
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
