### PR TITLE
Disable differential fuzzing in local development.

### DIFF
--- a/tests/ci/run_cryptofuzz.sh
+++ b/tests/ci/run_cryptofuzz.sh
@@ -31,6 +31,10 @@ if [[ -z "${CUSTOM_CRYPTOFUZZ_REPO_DIR}" ]]; then
   echo "CUSTOM_CRYPTOFUZZ_REPO_DIR is empty."
 else
   export CRYPTOFUZZ_SRC="${CUSTOM_CRYPTOFUZZ_REPO_DIR}"
+  # Local development does not need differential fuzzing.
+  # Remove these libs related build flags.
+  export CXXFLAGS="${CXXFLAGS// -DCRYPTOFUZZ_BOTAN/}"
+  export CXXFLAGS="${CXXFLAGS// -DCRYPTOFUZZ_CRYPTOPP/}"
   cd "$CRYPTOFUZZ_SRC"
   # This step is to generate required header and cpp files.
   python3 gen_repository.py


### PR DESCRIPTION
### Description of changes: 
Disable differential fuzzing in local development.

### Call-outs:
* Without this change, the build fails when `CUSTOM_CRYPTOFUZZ_REPO_DIR` is defined.
 
### Testing:
```sh
# step 1: define CUSTOM_CRYPTOFUZZ_REPO_DIR in run_cryptofuzz.sh

# step 2: run in the target docker img
docker run -it -v `pwd`:`pwd` -w `pwd` ubuntu-20.04-aarch:cryptofuzz

# step 3: run the script
rm -rf nohup.out && bash -c "nohup sh -c './tests/ci/run_cryptofuzz.sh' &"

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
