### PR TITLE
Allow prefix headers to be parameter for build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,12 +123,15 @@ foreach(VAR CMAKE_C_FLAGS CMAKE_CXX_FLAGS CMAKE_ASM_FLAGS)
          "${${VAR}_RELEASE}")
 endforeach()
 
-if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
+if(BORINGSSL_PREFIX)
   add_definitions(-DBORINGSSL_PREFIX=${BORINGSSL_PREFIX})
   # CMake automatically connects include_directories to the NASM command-line,
   # but not add_definitions.
   set(CMAKE_ASM_NASM_FLAGS "${CMAKE_ASM_NASM_FLAGS} -DBORINGSSL_PREFIX=${BORINGSSL_PREFIX}")
   set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -DBORINGSSL_PREFIX=${BORINGSSL_PREFIX}")
+endif()
+
+if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
 
   # Use "symbol_prefix_include" to store generated header files
   include_directories(${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include)
@@ -156,6 +159,15 @@ if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
             symbol_prefix_include/boringssl_prefix_symbols_asm.h
             symbol_prefix_include/boringssl_prefix_symbols_nasm.inc)
   add_dependencies(global_target boringssl_prefix_symbols)
+elseif(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_HEADERS)
+
+  if(IS_ABSOLUTE ${BORINGSSL_PREFIX_HEADERS})
+    set(BORINGSSL_PREFIX_HEADERS_PATH ${BORINGSSL_PREFIX_HEADERS})
+  else()
+    set(BORINGSSL_PREFIX_HEADERS_PATH ${CMAKE_BINARY_DIR}/${BORINGSSL_PREFIX_HEADERS})
+  endif()
+
+  include_directories(${BORINGSSL_PREFIX_HEADERS_PATH})
 elseif(BORINGSSL_PREFIX OR BORINGSSL_PREFIX_SYMBOLS)
   message(FATAL_ERROR "Must specify both or neither of BORINGSSL_PREFIX and BORINGSSL_PREFIX_SYMBOLS")
 elseif((BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS) AND NOT GO_EXECUTABLE)


### PR DESCRIPTION
### Description of changes: 
Currently, the prefix build requires a list of symbols be provided. These symbols are only used to generate the header files containing preprocessor macros.

This change allows for the header files to be prepared prior to the build and their location passed in as a parameter.

### Testing:
I tested on both a Mac (x64) and AmazonLinux (ARM). 

1) Ran the standard build.
2) Generated the symbol files:
```
$ go run read_symbols.go -out ../../symbols1.txt ../../AWS-LC-BUILD/crypto/libcrypto.a
$ go run read_symbols.go -out ../../symbols2.txt ../../AWS-LC-BUILD/ssl/libssl.a
$ cat symbols1.txt symbols2.txt |sort | uniq > symbols-combined.txt
```
3) Generated the header files:
```
$ mkdir -p symbol_prefix_include
$ go run ../aws-lc/util/make_prefix_headers.go -out symbol_prefix_include ../symbols-combined.txt
```
4) Ran the prefix symbols build with new parameter passing in the generated headers:
```
$ cmake "-DBORINGSSL_PREFIX=aws_lc_1_1_0" "-DBORINGSSL_PREFIX_HEADERS=./symbol_prefix_include" ../aws-lc
$ cmake --build . --target ssl
```
5) Verified symbols were prefixed:
```
$ nm --extern-only --defined-only crypto/libcrypto.a
$ nm --extern-only --defined-only crypto/libcrypto.a 2>/dev/null | grep -v aws_lc | grep -v -e '\.o)\?:' |sort |uniq 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
