### PR TITLE
Open ssl3.0 benchmark

### DIFF
--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 add_executable(
   bssl
 
@@ -66,13 +65,29 @@ if(AWSLC_INSTALL_DIR)
   endif()
 endif()
 
-# This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in build/
+# This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/
 if(OPENSSL_INSTALL_DIR)
-  build_benchmark(ossl_bm ${OPENSSL_INSTALL_DIR}/include ${OPENSSL_INSTALL_DIR}/build/lib/libcrypto.a)
+  build_benchmark(ossl_bm ${OPENSSL_INSTALL_DIR}/include ${OPENSSL_INSTALL_DIR}/lib/libcrypto.a)
 
   target_compile_options(ossl_bm PUBLIC -DOPENSSL_BENCHMARK)
   if(NOT MSVC AND NOT ANDROID)
     target_link_libraries(ossl_bm pthread dl)
+  endif()
+endif()
+
+# This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/ or lib64/
+if(OPENSSL3_INSTALL_DIR)
+  add_definitions("-Wno-deprecated-declarations")
+  if(NOT EXISTS ${OPENSSL3_INSTALL_DIR}/lib/libcrypto.a)
+    build_benchmark(ossl3_bm ${OPENSSL3_INSTALL_DIR}/include ${OPENSSL3_INSTALL_DIR}/lib64/libcrypto.a)
+  else()
+    build_benchmark(ossl3_bm ${OPENSSL3_INSTALL_DIR}/include ${OPENSSL3_INSTALL_DIR}/lib/libcrypto.a)
+  endif()
+
+
+  target_compile_options(ossl3_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL3_BENCHMARK)
+  if(NOT MSVC AND NOT ANDROID)
+    target_link_libraries(ossl3_bm pthread dl)
   endif()
 endif()
 

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -77,6 +77,8 @@ endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/ or lib64/
 if(OPENSSL3_INSTALL_DIR)
+  # The low-level function calls are deprecated for OpenSSL 3.0. We should revisit using these in the future, 
+  # but disabling the warnings works for now
   add_definitions("-Wno-deprecated-declarations")
   if(NOT EXISTS ${OPENSSL3_INSTALL_DIR}/lib/libcrypto.a)
     build_benchmark(ossl3_bm ${OPENSSL3_INSTALL_DIR}/include ${OPENSSL3_INSTALL_DIR}/lib64/libcrypto.a)

--- a/tool/README.md
+++ b/tool/README.md
@@ -27,6 +27,7 @@ In order to build the above-mentioned benchmarking tools, absolute paths to each
 | awslc_bm | -DAWSLC_INSTALL_DIR |
 | bssl_bm | -DBORINGSSL_INSTALL_DIR |
 | ossl_bm | -DOPENSSL_INSTALL_DIR |
+| ossl3_bm | -DOPENSSL3_INSTALL_DIR |
 
 ### Expected Directory Structure
 Additionally, the benchmarking tools expects specific directory structures for the provided install locations for each library. Namely, each library must be built into a folder called `build` located in the base directory of the library.
@@ -46,11 +47,27 @@ Additionally, the benchmarking tools expects specific directory structures for t
 ----libcrypto.a
 ```
 
-**OpenSSL**
+**OpenSSL1.x**
 ```
 -openssl_install_dir/
 --include/
---build/
----lib/
-----libcrypto.a
+--lib/
+---libcrypto.a
+```
+
+**OpenSSL3.0**
+```
+-openssl_install_dir/
+--include/
+--lib/
+---libcrypto.a
+```
+or
+
+**OpenSSL3.0**
+```
+-openssl_install_dir/
+--include/
+--lib64/
+---libcrypto.a
 ```

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1585,7 +1585,10 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedAESBlock("AES-192", 192, selected) ||
      !SpeedAESBlock("AES-256", 256, selected) ||
      !SpeedAES256XTS("AES-256-XTS", selected) ||
+     // OpenSSL 3.0 doesn't allow MD4 calls
+#if !defined(OPENSSL3_BENCHMARK)
      !SpeedHash(EVP_md4(), "MD4", selected) ||
+#endif
      !SpeedHash(EVP_md5(), "MD5", selected) ||
      !SpeedHash(EVP_sha1(), "SHA-1", selected) ||
      !SpeedHash(EVP_sha224(), "sha-224", selected) ||


### PR DESCRIPTION
### Issues:


### Description of changes: 
Changes what we expect the openssl install directory to look like for openssl 1.x and adds support for openssl3.0

### Call-outs:
We disable warnings for deprecated code on openssl3.0 since the low level functions used in this tool are deprecated in openssl3.0. We also disable testing for MD4 for similar reasons.
### Testing:
Built on 64 and 32 bit systems to verify that this wasn't platform specific

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
