### PR TITLE
Enable cryptofuzz on arm.

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
@@ -31,11 +31,10 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: X86_ECR_REPO_PLACEHOLDER:ubuntu-20.04_cryptofuzz_latest
 
-# Turn off the ARM Cryptofuzz, fix is tracked in CryptoAlg-742
-#    - identifier: ubuntu2004_clang10_arm_cryptofuzz
-#      buildspec: ./tests/ci/codebuild/linux-x86/run_cryptofuzz.yml
-#      env:
-#        type: ARM_CONTAINER
-#        privileged-mode: true
-#        compute-type: BUILD_GENERAL1_LARGE
-#        image: ARM_ECR_REPO_PLACEHOLDER:ubuntu-20.04_cryptofuzz_latest
+   - identifier: ubuntu2004_clang10_arm_cryptofuzz
+     buildspec: ./tests/ci/codebuild/linux-x86/run_cryptofuzz.yml
+     env:
+       type: ARM_CONTAINER
+       privileged-mode: true
+       compute-type: BUILD_GENERAL1_LARGE
+       image: ARM_ECR_REPO_PLACEHOLDER:ubuntu-20.04_cryptofuzz_latest


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-742

### Description of changes: 
This PR enabled CryptoFuzz on arm.

### Call-outs:
* This PR will get merged when the change to upstream is merged.
   * `CryptoAlg-742?selectedConversation=cf7166be-9e00-44e7-9264-5719a6db038b` has the diffs.

### Testing:
#### Step 1: apply below diff in forked CryptoFuzz repo.

```sh
diff --git a/util.cpp b/util.cpp
index 2248f5e..76700fc 100644
--- a/util.cpp
+++ b/util.cpp
@@ -12,7 +12,9 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/algorithm/hex.hpp>
+#if defined(__x86_64__) || defined(__amd64__)
 #include "third_party/cpu_features/include/cpuinfo_x86.h"
+#endif
 #include "mutatorpool.h"
 #include "config.h"

@@ -535,9 +537,13 @@ void free(void* ptr) {
 }

 bool HaveSSE42(void) {
+#if defined(__x86_64__) || defined(__amd64__)
     const cpu_features::X86Info info = cpu_features::GetX86Info();
     const auto features = info.features;
     return features.sse4_2;
+#else
+    return false;
+#endif
 }
```

### step 2: run in the target docker img
```
docker run -it -v `pwd`:`pwd` -w `pwd` ubuntu-20.04-aarch:cryptofuzz

rm -rf nohup.out && bash -c "nohup sh -c './tests/ci/run_cryptofuzz.sh' &"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
