### PR TITLE
Adjusted the sensativity of the benchmarking CI

### DIFF
--- a/tests/ci/benchmark_framework/compare_results.py
+++ b/tests/ci/benchmark_framework/compare_results.py
@@ -65,8 +65,8 @@ def main():
     # Put both dataframes side by side for comparison
     dfs = pd.concat([df1, df2], axis=1)
 
-    # Filter out entries with a +10% regression
-    compared = np.where(((df2_avg_time / df1_avg_time) - 1) >= 0.10, df1.iloc[:, 0], np.nan)
+    # Filter out entries with a +15% regression
+    compared = np.where(((df2_avg_time / df1_avg_time) - 1) >= 0.15, df1.iloc[:, 0], np.nan)
 
     compared_df = dfs.loc[dfs.iloc[:, 0].isin(compared)]
 


### PR DESCRIPTION
The benchmarking CI has been giving spurious failures frequently because
the sensitivity was set too high. We expected to have to make
adjustments to this, and it seems like 10% was too low a cutoff for
detecting regressions. Adjusting that number to 15% so we will see fewer
spurious failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
