### PR TITLE
Specify the AWS region used by CLI.

### DIFF
--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -293,6 +293,7 @@ function export_global_variables() {
   fi
   if [[ -z "${CDK_DEPLOY_REGION+x}" || -z "${CDK_DEPLOY_REGION}" ]]; then
     export CDK_DEPLOY_REGION='us-west-2'
+    export AWS_DEFAULT_REGION="${CDK_DEPLOY_REGION}"
   fi
   if [[ -z "${GITHUB_REPO_OWNER+x}" || -z "${GITHUB_REPO_OWNER}" ]]; then
     export GITHUB_REPO_OWNER='awslabs'
@@ -328,6 +329,7 @@ function main() {
       ;;
     --aws-region)
       export CDK_DEPLOY_REGION="${2}"
+      export AWS_DEFAULT_REGION="${CDK_DEPLOY_REGION}"
       shift
       ;;
     --github-repo-owner)


### PR DESCRIPTION
### Description of changes: 
AWS CLI uses default region configured in `.aws/config`. The default region  in `.aws/config` can be different from the one set in our script and cause the `ResourceNotFoundException`. The change of this PR avoids the difference by exporting [AWS_DEFAULT_REGION](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-region)

### Call-outs:
TBD

### Testing:

#### Issue Reproduce
```sh
# aws-lc-ci-linux-x86 is created in us-west-2. 
# Modify region in `.aws/config` from us-west-2 to us-west-1.
$ aws codebuild update-webhook --project-name aws-lc-ci-linux-x86 --build-type BUILD_BATCH

An error occurred (ResourceNotFoundException) when calling the UpdateWebhook operation: Project does not exist
```

#### Fix issue
```sh
$ export AWS_DEFAULT_REGION=us-west-2
$ aws codebuild update-webhook --project-name aws-lc-ci-linux-x86 --build-type BUILD_BATCH

{
    "webhook": { ...}
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
