### PR TITLE
Bump docker image cmake dependency to at least 3 0

### DIFF
--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -149,6 +149,12 @@ function print_system_and_dependency_information {
     echo "CMake version:"
     cmake --version
   fi
+  if command -v cmake3 &> /dev/null
+  then
+    echo ""
+    echo "CMake version (cmake3 executable):"
+    cmake3 --version
+  fi
   if command -v go &> /dev/null
   then
     echo ""

--- a/tests/ci/docker_images/linux-aarch/amazonlinux-2_base/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/amazonlinux-2_base/Dockerfile
@@ -15,6 +15,7 @@ ENV LLVM_PROJECT_HOME=${DEPENDENCIES_DIR}/llvm-project
 RUN set -ex && \
     yum -y update && yum install -y \
     cmake \
+    cmake3 \
     ninja-build \
     perl \
     golang \

--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_base/Dockerfile
@@ -15,6 +15,7 @@ ENV LLVM_PROJECT_HOME=${DEPENDENCIES_DIR}/llvm-project
 RUN set -ex && \
     yum -y update && yum install -y \
     cmake \
+    cmake3 \
     ninja-build \
     perl \
     golang \


### PR DESCRIPTION
### Issues:

CryptoAlg-1137

### Description of changes:

Prepare for bumping cmake dependency requirement to `3.0`.

Next step: deploying to CI infrastructure.

### Call-outs:
### Testing:

Verified docker image builds and that cmake3 can be executed during build
https://github.com/torben-hansen/aws-lc/pull/6

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
