### PR TITLE
Use new gcc-11 Docker image.

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -22,13 +22,13 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-8x_latest
 
-    - identifier: ubuntu2004_gcc11x_aarch
+    - identifier: ubuntu2204_gcc11x_aarch
       buildspec: ./tests/ci/codebuild/linux-aarch/run_posix_tests.yml
       env:
         type: ARM_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-11x_latest
+        image: ECR_REPO_PLACEHOLDER:ubuntu-22.04_gcc-11x_latest
 
     - identifier: ubuntu2004_clang7x_aarch
       buildspec: ./tests/ci/codebuild/linux-aarch/run_posix_tests.yml


### PR DESCRIPTION
### Description of changes: 
https://github.com/awslabs/aws-lc/commit/dc5ad88a1f131aa39c2b19fb3134bd2c49f41629 rebuilt the gcc-11 Docker image. Accordingly, the related ECR tag should get changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
