### PR TITLE
Add support for GCC-12 in CI

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -30,6 +30,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-22.04_gcc-11x_latest
 
+    - identifier: ubuntu2204_gcc12x_aarch
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_posix_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-22.04_gcc-12x_latest
+
     - identifier: ubuntu2004_clang7x_aarch
       buildspec: ./tests/ci/codebuild/linux-aarch/run_posix_tests.yml
       env:

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -64,6 +64,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-22.04_gcc-11x_latest
 
+    - identifier: ubuntu2204_gcc12x_x86_64
+      buildspec: ./tests/ci/codebuild/linux-x86/run_posix_tests.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-22.04_gcc-12x_latest
+
     - identifier: ubuntu2204_gcc11x_x86_64_prefix
       buildspec: ./tests/ci/codebuild/linux-x86/run_prefix_tests.yml
       env:

--- a/tests/ci/docker_images/linux-aarch/build_images.sh
+++ b/tests/ci/docker_images/linux-aarch/build_images.sh
@@ -19,5 +19,6 @@ docker build -t ubuntu-20.04-aarch:clang-10x ubuntu-20.04_clang-10x
 docker build -t ubuntu-20.04-aarch:clang-7x-bm-framework ubuntu-20.04_clang-7x-bm-framework
 docker build -t ubuntu-22.04-aarch:base ubuntu-22.04_base
 docker build -t ubuntu-22.04-aarch:gcc-11x ubuntu-22.04_gcc-11x
+docker build -t ubuntu-22.04-aarch:gcc-12x ubuntu-22.04_gcc-12x
 # This passes in the Dockerfile in the folder but uses the parent directory for the context so it has access to cryptofuzz_data.zip
 docker build -t ubuntu-20.04-aarch:cryptofuzz -f ubuntu-20.04_cryptofuzz/Dockerfile ../

--- a/tests/ci/docker_images/linux-aarch/push_images.sh
+++ b/tests/ci/docker_images/linux-aarch/push_images.sh
@@ -26,3 +26,4 @@ tag_and_push_img 'ubuntu-20.04-aarch:clang-10x' "${ECS_REPO}:ubuntu-20.04_clang-
 tag_and_push_img 'ubuntu-20.04-aarch:clang-7x-bm-framework' "${ECS_REPO}:ubuntu-20.04_clang-7x-bm-framework"
 tag_and_push_img 'ubuntu-20.04-aarch:cryptofuzz' "${ECS_REPO}:ubuntu-20.04_cryptofuzz"
 tag_and_push_img 'ubuntu-22.04-aarch:gcc-11x' "${ECS_REPO}:ubuntu-22.04_gcc-11x"
+tag_and_push_img 'ubuntu-22.04-aarch:gcc-12x' "${ECS_REPO}:ubuntu-22.04_gcc-12x"

--- a/tests/ci/docker_images/linux-aarch/ubuntu-22.04_gcc-12x/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/ubuntu-22.04_gcc-12x/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu-22.04-aarch:base
+
+SHELL ["/bin/bash", "-c"]
+
+RUN set -ex && \
+    apt-get update && \
+    apt-get -y --no-install-recommends upgrade && \
+    apt-get -y --no-install-recommends install \
+    gcc-12 g++-12 && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+ENV CC=gcc-12
+ENV CXX=g++-12


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1100`

### Description of changes: 
We've recently fixed and added support for gcc-12: https://github.com/awslabs/aws-lc/issues/487
This PR adds a gcc-12 dimension to our CI to ensure we don't break support.

### Call-outs:
N/A

### Testing:
Tested in local fork: https://github.com/samuel40791765/aws-lc/pull/19 (android is expected to fail, because the targeted arn is for the team account)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
