### PR TITLE
Revert suppressed warning in gcc-11

### DIFF
--- a/crypto/bytestring/cbs.c
+++ b/crypto/bytestring/cbs.c
@@ -482,16 +482,6 @@ int CBS_get_asn1_uint64(CBS *cbs, uint64_t *out) {
   return 1;
 }
 
-// Adding warning suppression as temporary fix for gcc11 ARM build issue
-// https://github.com/awslabs/aws-lc/issues/184
-// First two warnings are turned on to avoid incompatibilites with older compilers.
-#if defined(__GNUC__) && __GNUC__ == 11 // gcc x 11
-
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wstringop-overflow"
-
-#endif // __GNUC__
-
 int CBS_get_asn1_int64(CBS *cbs, int64_t *out) {
   int is_negative;
   CBS bytes;
@@ -515,11 +505,6 @@ int CBS_get_asn1_int64(CBS *cbs, int64_t *out) {
   *out = u.i;
   return 1;
 }
-#if defined(__GNUC__) && __GNUC__ == 11 // gcc x 11
-
-# pragma GCC diagnostic pop
-
-#endif // __GNUC__
 
 int CBS_get_asn1_bool(CBS *cbs, int *out) {
   CBS bytes;


### PR DESCRIPTION
### Description of changes: 
When gcc-11 was first released, there was a false positive warning that we had to suppress: https://github.com/awslabs/aws-lc/commit/0c52a41d3210bb50188e16da5d280fb047364f0b. GCC-11 has been around for a while now and the bug seems to be fixed, so we're reverting that change. 


### Call-outs:
N/A

### Testing:
tested on local with our gcc11 docker image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
