### PR TITLE
Bump minimal cmake version to 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0)
 
 # Defer enabling C and CXX languages.
 project(AWSLC NONE)

--- a/tests/ci/build_run_benchmarks.sh
+++ b/tests/ci/build_run_benchmarks.sh
@@ -26,7 +26,7 @@ git clone https://github.com/awslabs/aws-lc.git aws-lc-prod
 # build AWSLC pr
 mkdir -p "${PR_FOLDER_NAME}"/build
 mkdir -p "${PR_FOLDER_NAME}"/install
-cmake -B"${PR_FOLDER_NAME}"/build -H"${PR_FOLDER_NAME}" -GNinja -DCMAKE_BUILD_TYPE=Release \
+${CMAKE_COMMAND} -B"${PR_FOLDER_NAME}"/build -H"${PR_FOLDER_NAME}" -GNinja -DCMAKE_BUILD_TYPE=Release \
   -DAWSLC_INSTALL_DIR="${AWSLC_PR_ROOT}"/install \
   -DCMAKE_INSTALL_PREFIX="${AWSLC_PR_ROOT}"/install \
   -DBUILD_TESTING=OFF
@@ -35,19 +35,19 @@ ninja -C "${PR_FOLDER_NAME}"/build
 # build FIPS compliant version of AWSLC pr
 mkdir -p "${PR_FOLDER_NAME}"/fips_build
 mkdir -p "${PR_FOLDER_NAME}"/fips_install
-cmake -B"${PR_FOLDER_NAME}"/fips_build -H"${PR_FOLDER_NAME}" -GNinja -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DAWSLC_INSTALL_DIR="${AWSLC_PR_ROOT}"/fips_install -DBUILD_SHARED_LIBS=TRUE -DCMAKE_INSTALL_PREFIX="${AWSLC_PR_ROOT}"/fips_install
+${CMAKE_COMMAND} -B"${PR_FOLDER_NAME}"/fips_build -H"${PR_FOLDER_NAME}" -GNinja -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DAWSLC_INSTALL_DIR="${AWSLC_PR_ROOT}"/fips_install -DBUILD_SHARED_LIBS=TRUE -DCMAKE_INSTALL_PREFIX="${AWSLC_PR_ROOT}"/fips_install
 ninja -C "${PR_FOLDER_NAME}"/fips_build
 
 # build AWSLC prod
 mkdir -p aws-lc-prod/build
 mkdir -p aws-lc-prod/install
-cmake -Baws-lc-prod/build -Haws-lc-prod -GNinja -DCMAKE_BUILD_TYPE=Release -DAWSLC_INSTALL_DIR="${AWSLC_PROD_ROOT}/install" -DCMAKE_INSTALL_PREFIX="${AWSLC_PROD_ROOT}/install" -DBUILD_TESTING=OFF
+${CMAKE_COMMAND} -Baws-lc-prod/build -Haws-lc-prod -GNinja -DCMAKE_BUILD_TYPE=Release -DAWSLC_INSTALL_DIR="${AWSLC_PROD_ROOT}/install" -DCMAKE_INSTALL_PREFIX="${AWSLC_PROD_ROOT}/install" -DBUILD_TESTING=OFF
 ninja -C aws-lc-prod/build
 
 #build FIPS compliant version of AWSLC prod
 mkdir -p aws-lc-prod/fips_build
 mkdir -p aws-lc-prod/fips_install
-cmake -Baws-lc-prod/fips_build -Haws-lc-prod -GNinja -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DAWSLC_INSTALL_DIR="${AWSLC_PROD_ROOT}/fips_install" -DBUILD_SHARED_LIBS=TRUE -DCMAKE_INSTALL_PREFIX="${AWSLC_PROD_ROOT}/fips_install"
+${CMAKE_COMMAND} -Baws-lc-prod/fips_build -Haws-lc-prod -GNinja -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DAWSLC_INSTALL_DIR="${AWSLC_PROD_ROOT}/fips_install" -DBUILD_SHARED_LIBS=TRUE -DCMAKE_INSTALL_PREFIX="${AWSLC_PROD_ROOT}/fips_install"
 ninja -C aws-lc-prod/fips_build
 
 ./"${PR_FOLDER_NAME}"/build/tool/awslc_bm -timeout 1 -json > aws-lc-pr_bm.json

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -28,33 +28,26 @@ fi
 
 PLATFORM=$(uname -m)
 
-function determine_build_command {
-  if [[ -x "$(command -v ninja)" ]]; then
-    echo "Using Ninja build system (ninja)."
-    BUILD_COMMAND="ninja"
-    cflags+=(-GNinja)
-  elif [[ -x "$(command -v ninja-build)" ]]; then
-    echo "Using Ninja build system (ninja-build)."
-    BUILD_COMMAND="ninja-build"
-    cflags+=(-GNinja)
-  else
-    echo "Using Make."
-    BUILD_COMMAND="make -j${NUM_CPU_THREADS}"
-  fi
-}
+if [[ -x "$(command -v ninja)" ]]; then
+  echo "Using Ninja build system (ninja)."
+  BUILD_COMMAND="ninja"
+  cflags+=(-GNinja)
+elif [[ -x "$(command -v ninja-build)" ]]; then
+  echo "Using Ninja build system (ninja-build)."
+  BUILD_COMMAND="ninja-build"
+  cflags+=(-GNinja)
+else
+  echo "Using Make."
+  BUILD_COMMAND="make -j${NUM_CPU_THREADS}"
+fi
 
-function determine_cmake_command {
-  # Pick cmake3 if possible. This will capture Amazon Linux 2. We don't know of
-  # any OS that installs a cmake3 executable that is not at least version 3.0.
-  if [[ -x "$(command -v cmake3)" ]] ; then
-    CMAKE_COMMAND="cmake3"
-  else
-    CMAKE_COMMAND="cmake"
-  fi
-}
-
-determine_cmake_command
-determine_build_command
+# Pick cmake3 if possible. This will capture Amazon Linux 2. We don't know of
+# any OS that installs a cmake3 executable that is not at least version 3.0.
+if [[ -x "$(command -v cmake3)" ]] ; then
+  CMAKE_COMMAND="cmake3"
+else
+  CMAKE_COMMAND="cmake"
+fi
 
 function run_build {
   local cflags=("$@")

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -53,6 +53,9 @@ function determine_cmake_command {
   fi
 }
 
+determine_cmake_command
+determine_build_command
+
 function run_build {
   local cflags=("$@")
   rm -rf "$BUILD_ROOT"
@@ -62,9 +65,6 @@ function run_build {
   if [[ "${AWSLC_32BIT}" == "1" ]]; then
     cflags+=("-DCMAKE_TOOLCHAIN_FILE=${SRC_ROOT}/util/32-bit-toolchain.cmake")
   fi
-
-  determine_cmake_command
-  determine_build_command
 
   ${CMAKE_COMMAND} "${cflags[@]}" "$SRC_ROOT"
   if [[ "${PREBUILD_CUSTOM_TARGET}" != "" ]]; then

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -28,19 +28,6 @@ fi
 
 PLATFORM=$(uname -m)
 
-if [[ -x "$(command -v ninja)" ]]; then
-  echo "Using Ninja build system (ninja)."
-  BUILD_COMMAND="ninja"
-  cflags+=(-GNinja)
-elif [[ -x "$(command -v ninja-build)" ]]; then
-  echo "Using Ninja build system (ninja-build)."
-  BUILD_COMMAND="ninja-build"
-  cflags+=(-GNinja)
-else
-  echo "Using Make."
-  BUILD_COMMAND="make -j${NUM_CPU_THREADS}"
-fi
-
 # Pick cmake3 if possible. This will capture Amazon Linux 2. We don't know of
 # any OS that installs a cmake3 executable that is not at least version 3.0.
 if [[ -x "$(command -v cmake3)" ]] ; then
@@ -57,6 +44,19 @@ function run_build {
 
   if [[ "${AWSLC_32BIT}" == "1" ]]; then
     cflags+=("-DCMAKE_TOOLCHAIN_FILE=${SRC_ROOT}/util/32-bit-toolchain.cmake")
+  fi
+
+  if [[ -x "$(command -v ninja)" ]]; then
+    echo "Using Ninja build system (ninja)."
+    BUILD_COMMAND="ninja"
+    cflags+=(-GNinja)
+  elif [[ -x "$(command -v ninja-build)" ]]; then
+    echo "Using Ninja build system (ninja-build)."
+    BUILD_COMMAND="ninja-build"
+    cflags+=(-GNinja)
+  else
+    echo "Using Make."
+    BUILD_COMMAND="make -j${NUM_CPU_THREADS}"
   fi
 
   ${CMAKE_COMMAND} "${cflags[@]}" "$SRC_ROOT"

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -28,8 +28,8 @@ fi
 
 PLATFORM=$(uname -m)
 
-# Pick cmake3 if possible. This will capture Amazon Linux 2. We don't know of
-# any OS that installs a cmake3 executable that is not at least version 3.0.
+# Pick cmake3 if possible. We don't know of any OS that installs a cmake3
+# executable that is not at least version 3.0.
 if [[ -x "$(command -v cmake3)" ]] ; then
   CMAKE_COMMAND="cmake3"
 else

--- a/tests/ci/run_cryptofuzz.sh
+++ b/tests/ci/run_cryptofuzz.sh
@@ -14,7 +14,7 @@ mkdir -p "$BUILD_ROOT"
 cd "$BUILD_ROOT"
 
 # Build AWS-LC based on https://github.com/guidovranken/cryptofuzz/blob/master/docs/openssl.md
-cmake -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DBORINGSSL_ALLOW_CXX_RUNTIME=1 \
+${CMAKE_COMMAND} -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DBORINGSSL_ALLOW_CXX_RUNTIME=1 \
   -GNinja -DBUILD_TESTING=OFF -DBUILD_LIBSSL=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo ../
 ninja
 cd ../

--- a/tests/ci/run_s2n_integration.sh
+++ b/tests/ci/run_s2n_integration.sh
@@ -44,14 +44,14 @@ function fail() {
 }
 
 function aws_lc_build() {
-	cmake ${AWS_LC_DIR} -GNinja "-B${AWS_LC_BUILD_FOLDER}" "-DCMAKE_INSTALL_PREFIX=${AWS_LC_INSTALL_FOLDER}" "$@"
+	${CMAKE_COMMAND} ${AWS_LC_DIR} -GNinja "-B${AWS_LC_BUILD_FOLDER}" "-DCMAKE_INSTALL_PREFIX=${AWS_LC_INSTALL_FOLDER}" "$@"
 	ninja -C ${AWS_LC_BUILD_FOLDER} install
 	ls -R ${AWS_LC_INSTALL_FOLDER}
 	rm -rf ${AWS_LC_BUILD_FOLDER}/*
 }
 
 function s2n_tls_build() {
-	cmake s2n-tls -GNinja "-B${S2N_TLS_BUILD_FOLDER}" "-DCMAKE_PREFIX_PATH=${AWS_LC_INSTALL_FOLDER}" "$@"
+	${CMAKE_COMMAND} s2n-tls -GNinja "-B${S2N_TLS_BUILD_FOLDER}" "-DCMAKE_PREFIX_PATH=${AWS_LC_INSTALL_FOLDER}" "$@"
 	ninja -C ${S2N_TLS_BUILD_FOLDER}
 	ls -R ${S2N_TLS_BUILD_FOLDER}
 }


### PR DESCRIPTION
### Issues:

CryptoAlg-1137

### Description of changes: 

Bump minimal cmake version to 3.0.

To cater for non-unique executable names. First check whether `cmake3` is present. If not, pick `cmake` as executable name. This assumes that `cmake3` is actually at least version 3.0, but I don't know of any OS where this is not the case (covering all the OS's we claim to support).

### Call-outs:

There are a bunch of inconsistencies in our scripts. I tried using `CMAKE_COMMAND` everywhere. But the same is not true for e.g. `ninja` vs `ninja-build`. Maybe we can fix this in a future PR.

### Testing:

Tried grepping for additional occurrences of using `cmake`:
```
$ pwd
[...]/aws-lc/tests

$ grep -r "cmake " ./ 
.//ci/common_posix_setup.sh:  if command -v cmake &> /dev/null
.//ci/common_posix_setup.sh:    cmake --version
.//ci/run_windows_tests.bat:@echo  LOG: %date%-%time% %1 %2 build started with cmake generation started
.//ci/run_windows_tests.bat:cmake -GNinja -DCMAKE_BUILD_TYPE=%~1 %~2 %SRC_ROOT% || goto error
.//ci/run_windows_tests.bat:@echo  LOG: %date%-%time% %1 %2 cmake generation complete, starting build
.//ci/android/AWSLCAndroidTestRunner/app/build.gradle:            cmake {
.//ci/android/AWSLCAndroidTestRunner/app/build.gradle:        cmake {
.//ci/docker_images/linux-x86/ubuntu-20.04_base/Dockerfile:    cmake \
.//ci/docker_images/linux-x86/ubuntu-7.10_gcc-4.1x/Dockerfile:# Pull cmake as an external source since the wget version
.//ci/docker_images/linux-x86/ubuntu-7.10_gcc-4.1x/Dockerfile:# on this image is too old to access the cmake repo.
.//ci/docker_images/linux-x86/ubuntu-16.04_gcc-5x/Dockerfile:    cmake \
.//ci/docker_images/linux-x86/build_legacy_image.sh:# download the cmake version from source, so we predownload the 
.//ci/docker_images/linux-x86/fedora-31_clang-9x/Dockerfile:    cmake \
.//ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile:    cmake \
.//ci/docker_images/linux-x86/amazonlinux-2_base/Dockerfile:    cmake \
.//ci/docker_images/linux-x86/ubuntu-18.04_base/Dockerfile:    cmake \
.//ci/docker_images/linux-x86/centos-7_gcc-4x/Dockerfile:    cmake \
.//ci/docker_images/windows/windows_base/Dockerfile:choco install cmake --version 3.15.4 --installargs 'ADD_CMAKE_TO_PATH=""System""' -y
.//ci/docker_images/linux-aarch/ubuntu-20.04_base/Dockerfile:    cmake \
.//ci/docker_images/linux-aarch/ubuntu-22.04_base/Dockerfile:    cmake \
.//ci/docker_images/linux-aarch/amazonlinux-2_base/Dockerfile:    cmake \
.//ci/run_s2n_integration.sh:# s2n-tls's FindLibCrypto.cmake expects to find both the static and shared
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
