### PR TITLE
Correct source script path

### DIFF
--- a/tests/ci/build_run_benchmarks.sh
+++ b/tests/ci/build_run_benchmarks.sh
@@ -18,7 +18,7 @@ cd ..
 AWSLC_PR_ROOT=$(pwd)/"${PR_FOLDER_NAME}"
 AWSLC_PROD_ROOT=$(pwd)/aws-lc-prod
 
-source tests/ci/common_posix_setup.sh
+source ${AWSLC_PR_ROOT}/tests/ci/common_posix_setup.sh
 
 # clone the various repositories we need (we already have aws-lc-pr since we need it to run this script)
 git clone https://github.com/awslabs/aws-lc.git aws-lc-prod


### PR DESCRIPTION
### Description of changes: 

https://github.com/awslabs/aws-lc/pull/538 uncovered a bug in the benchmark CI script: the path used to source the script `common_posix_setup.sh` is wrong because of a prior `cd ..` before sourcing.

```
+ source tests/ci/common_posix_setup.sh
./tests/ci/build_run_benchmarks.sh: line 21: tests/ci/common_posix_setup.sh: No such file or directory
+ git clone https://github.com/awslabs/aws-lc.git aws-lc-prod
```

This has been silently failing since the refactor in https://github.com/awslabs/aws-lc/pull/435.

Remedy this by utilising the already defined `AWSLC_PR_ROOT`.

### Call-outs:

Could maybe have moved up the sourcing. But for sake of keeping the order the same, used `AWSLC_PR_ROOT` instead.

A third solution would be to remove it, because clearly it has no use. But I need the definitions in the sourced script in a future PR.

### Testing:

CI - check that the error above disappears.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
