### PR TITLE
Install cmake3 in centos 7 docker image

### DIFF
--- a/tests/ci/docker_images/linux-x86/centos-7_gcc-4x/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/centos-7_gcc-4x/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex && \
     libstdc++-devel.x86_64 \
     libstdc++-devel.i686 \
     cmake \
+    cmake3 \
     ninja-build \
     perl \
     wget \


### PR DESCRIPTION
### Issues:

CryptoAlg-1137

### Description of changes: 

Same as https://github.com/awslabs/aws-lc/pull/534 but the Centos 7 image was missed.

### Testing:

Tested Docker image build works locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
