### PR TITLE
Bump cmake version requirement in BUILDING doc

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -49,8 +49,8 @@ most recent stable version of each tool.
 
 ## Building
 
-We use CMake to manage the build process. Note that the CMake executable name
-for version 3.0 and later differs depending on the OS. For example, on Amazon
+We use CMake to manage the build process. Note that the executable name for
+CMake version 3.0 and later differs depending on the OS. For example, on Amazon
 Linux 2 the executable name is `cmake3` while on Ubuntu 20.04 the executable
 name is `cmake`. Modify command snippets below accordingly.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -10,7 +10,7 @@ Unless otherwise noted, build tools must at most five years old, matching
 [Abseil guidelines](https://abseil.io/about/compatibility). If in doubt, use the
 most recent stable version of each tool.
 
-  * [CMake](https://cmake.org/download/) 2.8.12 or later is required.
+  * [CMake](https://cmake.org/download/) 3.0 or later is required.
 
   * A recent version of Perl is required. On Windows,
     [Active State Perl](http://www.activestate.com/activeperl/) has been
@@ -48,6 +48,11 @@ most recent stable version of each tool.
     assembly more thoroughly.
 
 ## Building
+
+We use CMake to manage the build process. Note that the CMake executable name
+for version 3.0 and later differs depending on the OS. For example, on Amazon
+Linux 2 the executable name is `cmake3` while on Ubuntu 20.04 the executable
+name is `cmake`. Modify command snippets below accordingly.
 
 Using Ninja (note the 'N' is capitalized in the cmake invocation):
 


### PR DESCRIPTION
### Description of changes: 

https://github.com/awslabs/aws-lc/pull/538 bumped minimal CMake version to 3.0 at least. https://github.com/awslabs/aws-lc/pull/549 pointed out that some documentation does not reflect this change.

Modify existing documentation to cater for the CMake version bump. Also call out CMake executable name differences

### Testing:

I could not identify other places that needs to cater for `cmake`/`cmake3` differences (through grepping) or the CMake version requirement bump.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
