### PR TITLE
Install bssl as well

### DIFF
--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -43,7 +43,7 @@ else()
 endif()
 
 install(TARGETS bssl
-        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 function(build_benchmark target_name additional_include_dir lib_crypto)
   message("-- Building ${target_name} benchmark using header files from ${additional_include_dir} and libcrypto from ${lib_crypto}.")

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -42,6 +42,9 @@ else()
   endif()
 endif()
 
+install(TARGETS bssl
+        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
 function(build_benchmark target_name additional_include_dir lib_crypto)
   message("-- Building ${target_name} benchmark using header files from ${additional_include_dir} and libcrypto from ${lib_crypto}.")
   add_executable(


### PR DESCRIPTION
### Description of changes: 

`bssl` tool is not installed. Hence, we don't distribute it.

This change adds an install target to install `bssl` on (e.g.) `ninja-build install`, in turn, making it easier to distribute.

### Call-outs:

Right now, just installed in root of install directory. That is:

```
% pwd
[...]/aws-lc/awslc-install/lib64

% ls
bssl  /crypto  libcrypto.a  libssl.a  /ssl
```

### Testing:

Ran `ninja-build install` on AL2 instance. Got the output you see in "Call-outs".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
