### PR TITLE
Add no-op |SSL_CTX_set_ciphersuites|.

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1544,6 +1544,9 @@ OPENSSL_EXPORT int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str);
 // meaningless. It returns one on success and zero on failure.
 OPENSSL_EXPORT int SSL_set_strict_cipher_list(SSL *ssl, const char *str);
 
+// SSL_CTX_set_ciphersuites does nothing and returns one.
+OPENSSL_EXPORT int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str);
+
 // SSL_set_cipher_list configures the cipher list for |ssl|, evaluating |str| as
 // a cipher string. It returns one on success and zero on failure.
 //

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2010,6 +2010,10 @@ int SSL_set_cipher_list(SSL *ssl, const char *str) {
                                 false /* not strict */);
 }
 
+int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str) {
+  return 1;
+}
+
 int SSL_set_strict_cipher_list(SSL *ssl, const char *str) {
   if (!ssl->config) {
     return 0;


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-1073

### Description of changes: 
This change unblocks [MySQL 8.0 tls-ciphersuites related build issue](https://github.com/mysql/mysql-server/blame/8d8c986e5716e38cb776b627a8eee9e92241b4ce/vio/viosslfactories.cc#L650-L666).
* `tls-ciphersuites`: https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_tls-ciphersuites

### Call-outs:
* [OpenSSL added `|SSL_CTX_set_ciphersuites|` to configure TLS 1.3 specific ciphersuites](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_ciphersuites.html). But the API is added in AWS-LC as no-op due to https://github.com/awslabs/aws-lc/commit/abbbee10ad4739648bcbf36a5ac52f23263a67dd. We can add related code in future if needed(e.g. compatible with OpenSSL). This is just 1st step to unblock the build.

### Testing:
No test is needed because the added impl does nothing but returns 1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
