### PR TITLE
import Jitter@3.4.0

### DIFF
--- a/third_party/jitterentropy/LICENSE
+++ b/third_party/jitterentropy/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2017 - 2021, Stephan Mueller <smueller@chronox.de>
+Copyright (C) 2017 - 2022, Stephan Mueller <smueller@chronox.de>
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/third_party/jitterentropy/arch/jitterentropy-base-windows.h
+++ b/third_party/jitterentropy/arch/jitterentropy-base-windows.h
@@ -1,7 +1,7 @@
 /*
  * Non-physical true random number generator based on timing jitter.
  *
- * Copyright Stephan Mueller <smueller@chronox.de>, 2013 - 2021
+ * Copyright Stephan Mueller <smueller@chronox.de>, 2013 - 2022
  *
  * License
  * =======

--- a/third_party/jitterentropy/arch/jitterentropy-base-x86.h
+++ b/third_party/jitterentropy/arch/jitterentropy-base-x86.h
@@ -1,7 +1,7 @@
 /*
  * Non-physical true random number generator based on timing jitter.
  *
- * Copyright Stephan Mueller <smueller@chronox.de>, 2013 - 2021
+ * Copyright Stephan Mueller <smueller@chronox.de>, 2013 - 2022
  *
  * License
  * =======

--- a/third_party/jitterentropy/jitterentropy-base-user.h
+++ b/third_party/jitterentropy/jitterentropy-base-user.h
@@ -1,7 +1,7 @@
 /*
  * Non-physical true random number generator based on timing jitter.
  *
- * Copyright Stephan Mueller <smueller@chronox.de>, 2013 - 2021
+ * Copyright Stephan Mueller <smueller@chronox.de>, 2013 - 2022
  *
  * License
  * =======

--- a/third_party/jitterentropy/jitterentropy-base.c
+++ b/third_party/jitterentropy/jitterentropy-base.c
@@ -1,7 +1,7 @@
 /*
  * Non-physical true random number generator based on timing jitter.
  *
- * Copyright Stephan Mueller <smueller@chronox.de>, 2014 - 2021
+ * Copyright Stephan Mueller <smueller@chronox.de>, 2014 - 2022
  *
  * Design
  * ======

--- a/third_party/jitterentropy/jitterentropy-base.h
+++ b/third_party/jitterentropy/jitterentropy-base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy-gcd.c
+++ b/third_party/jitterentropy/jitterentropy-gcd.c
@@ -1,7 +1,7 @@
 /* Jitter RNG: GCD health test
  *
- * Copyright (C) 2021, Joshua E. Hill <josh@keypair.us>
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Joshua E. Hill <josh@keypair.us>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy-gcd.h
+++ b/third_party/jitterentropy/jitterentropy-gcd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy-health.c
+++ b/third_party/jitterentropy/jitterentropy-health.c
@@ -1,7 +1,7 @@
 /* Jitter RNG: Health Tests
  *
- * Copyright (C) 2021, Joshua E. Hill <josh@keypair.us>
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Joshua E. Hill <josh@keypair.us>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy-health.h
+++ b/third_party/jitterentropy/jitterentropy-health.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy-noise.c
+++ b/third_party/jitterentropy/jitterentropy-noise.c
@@ -1,6 +1,6 @@
 /* Jitter RNG: Noise Sources
  *
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy-noise.h
+++ b/third_party/jitterentropy/jitterentropy-noise.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy-sha3.c
+++ b/third_party/jitterentropy/jitterentropy-sha3.c
@@ -1,6 +1,6 @@
 /* Jitter RNG: SHA-3 Implementation
  *
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy-sha3.h
+++ b/third_party/jitterentropy/jitterentropy-sha3.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy-timer.c
+++ b/third_party/jitterentropy/jitterentropy-timer.c
@@ -1,6 +1,6 @@
 /* Jitter RNG: Internal timer implementation
  *
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy-timer.h
+++ b/third_party/jitterentropy/jitterentropy-timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
  *
  * License: see LICENSE file in root directory
  *

--- a/third_party/jitterentropy/jitterentropy.h
+++ b/third_party/jitterentropy/jitterentropy.h
@@ -1,7 +1,7 @@
 /*
  * Non-physical true random number generator based on timing jitter.
  *
- * Copyright Stephan Mueller <smueller@chronox.de>, 2014 - 2021
+ * Copyright Stephan Mueller <smueller@chronox.de>, 2014 - 2022
  *
  * License
  * =======


### PR DESCRIPTION
### Issues:

CryptoAlg-1195

### Description of changes: 

Import [jitterentropy version 3.4.0](https://github.com/smuellerDD/jitterentropy-library/releases/tag/v3.4.0). The import contains all the special changes and omission we originally did. In particular, the only commit imported is a copyright change:
* https://github.com/smuellerDD/jitterentropy-library/commit/2e5019cfe63038faaa405ce53715effe4ea580e4

### Call-outs:

See SIM for reasoning.

### Testing:

See SIM for testing and validation performed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
