### PR TITLE
Add |SSL_CTX_set_ciphersuites| impl.

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1539,6 +1539,7 @@ OPENSSL_EXPORT int SSL_CTX_set_strict_cipher_list(SSL_CTX *ctx,
 // garbage inputs, unless an empty cipher list results.
 //
 // Note: this API only sets the TLSv1.2 and below ciphers.
+// Use |SSL_CTX_set_ciphersuites| to configure TLS 1.3 specific ciphers.
 OPENSSL_EXPORT int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str);
 
 // SSL_set_strict_cipher_list configures the cipher list for |ssl|, evaluating
@@ -1546,7 +1547,8 @@ OPENSSL_EXPORT int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str);
 // meaningless. It returns one on success and zero on failure.
 OPENSSL_EXPORT int SSL_set_strict_cipher_list(SSL *ssl, const char *str);
 
-// SSL_CTX_set_ciphersuites does nothing and returns one.
+// SSL_CTX_set_ciphersuites configure the available TLSv1.3 ciphersuites for |ctx|,
+// evaluating |str| as a cipher string. It returns one on success and zero on failure.
 OPENSSL_EXPORT int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str);
 
 // SSL_set_cipher_list configures the cipher list for |ssl|, evaluating |str| as

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -461,7 +461,6 @@ class GrowableArray {
 // CBBFinishArray behaves like |CBB_finish| but stores the result in an Array.
 OPENSSL_EXPORT bool CBBFinishArray(CBB *cbb, Array<uint8_t> *out);
 
-
 // Protocol versions.
 //
 // Due to DTLS's historical wire version differences, we maintain two notions of
@@ -675,10 +674,11 @@ bool ssl_cipher_requires_server_key_exchange(const SSL_CIPHER *cipher);
 size_t ssl_cipher_get_record_split_len(const SSL_CIPHER *cipher);
 
 // ssl_choose_tls13_cipher returns an |SSL_CIPHER| corresponding with the best
-// available from |cipher_suites| compatible with |version| and |group_id|. It
-// returns NULL if there isn't a compatible cipher.
+// available from |cipher_suites| compatible with |version|, |group_id| and
+// configured |tls13_ciphers|. It returns NULL if there isn't a compatible cipher.
 const SSL_CIPHER *ssl_choose_tls13_cipher(CBS cipher_suites, uint16_t version,
-                                          uint16_t group_id);
+                                          uint16_t group_id,
+                                          const STACK_OF(SSL_CIPHER) *tls13_ciphers);
 
 
 // Transcript layer.
@@ -3458,7 +3458,12 @@ struct ssl_ctx_st {
   // quic_method is the method table corresponding to the QUIC hooks.
   const SSL_QUIC_METHOD *quic_method = nullptr;
 
+  // Currently, cipher_list holds the tls1.2 and below ciphersuites.
+  // TODO: move |tls13_cipher_list| to |cipher_list| during cipher configuration.
   bssl::UniquePtr<bssl::SSLCipherPreferenceList> cipher_list;
+
+  // tls13_cipher_list holds the tls1.3 and above ciphersuites.
+  bssl::UniquePtr<bssl::SSLCipherPreferenceList> tls13_cipher_list;
 
   X509_STORE *cert_store = nullptr;
   LHASH_OF(SSL_SESSION) *sessions = nullptr;

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2014,7 +2014,8 @@ int SSL_set_cipher_list(SSL *ssl, const char *str) {
 }
 
 int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str) {
-  return 1;
+  return ssl_create_cipher_list(&ctx->tls13_cipher_list, str, false /* not strict */,
+                                true /* only configure TLSv1.3 ciphers */);
 }
 
 int SSL_set_strict_cipher_list(SSL *ssl, const char *str) {

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -399,6 +399,105 @@ static const CipherTest kCipherTests[] = {
     },
 };
 
+// In kTLSv13RuleOnly, |rule| of each CipherTest can only match TLSv1.3 ciphers.
+// e.g. kTLSv13RuleOnly does not have rule "AESGCM+AES128", which can match
+// some TLSv1.2 ciphers.
+static const CipherTest kTLSv13RuleOnly[] = {
+    // Selecting individual ciphers should work.
+    {
+        "TLS_AES_256_GCM_SHA384:"
+        "TLS_CHACHA20_POLY1305_SHA256:"
+        "TLS_AES_128_GCM_SHA256",
+        {
+            {TLS1_CK_AES_256_GCM_SHA384, 0},
+            {TLS1_CK_CHACHA20_POLY1305_SHA256, 0},
+            {TLS1_CK_AES_128_GCM_SHA256, 0},
+        },
+        false,
+    },
+    // + reorders selected ciphers to the end, keeping their relative order.
+    {
+        "TLS_AES_256_GCM_SHA384:"
+        "TLS_CHACHA20_POLY1305_SHA256:"
+        "TLS_AES_128_GCM_SHA256:"
+        "+AES",
+        {
+            {TLS1_CK_CHACHA20_POLY1305_SHA256, 0},
+            {TLS1_CK_AES_256_GCM_SHA384, 0},
+            {TLS1_CK_AES_128_GCM_SHA256, 0},
+        },
+        false,
+    },
+    // ! banishes ciphers from future selections.
+    {
+        "!CHACHA20:"
+        "TLS_AES_256_GCM_SHA384:"
+        "TLS_CHACHA20_POLY1305_SHA256:"
+        "TLS_AES_128_GCM_SHA256:"
+        "TLS_CHACHA20_POLY1305_SHA256",
+        {
+            {TLS1_CK_AES_256_GCM_SHA384, 0},
+            {TLS1_CK_AES_128_GCM_SHA256, 0},
+        },
+        false,
+    },
+    // Square brackets specify equi-preference groups.
+    {
+        "[TLS_AES_128_GCM_SHA256|TLS_AES_256_GCM_SHA384]:"
+        "TLS_CHACHA20_POLY1305_SHA256",
+        {
+            {TLS1_CK_AES_128_GCM_SHA256, 1},
+            {TLS1_CK_AES_256_GCM_SHA384, 0},
+            {TLS1_CK_CHACHA20_POLY1305_SHA256, 0},
+        },
+        false,
+    },
+    // Spaces, semi-colons and commas are separators.
+    {
+        "TLS_AES_256_GCM_SHA384 ; "
+        "TLS_CHACHA20_POLY1305_SHA256 , "
+        "TLS_AES_128_GCM_SHA256",
+        {
+            {TLS1_CK_AES_256_GCM_SHA384, 0},
+            {TLS1_CK_CHACHA20_POLY1305_SHA256, 0},
+            {TLS1_CK_AES_128_GCM_SHA256, 0},
+        },
+        false,
+    },
+};
+
+// Besides kTLSv13RuleOnly, additional rules can match TLSv1.3 ciphers.
+static const CipherTest kTLSv13CipherTests[] = {
+    // Multiple masks can be ANDed in a single rule.
+    {
+        "AESGCM+AES128",
+        {
+            {TLS1_CK_AES_128_GCM_SHA256, 0},
+        },
+        false,
+    },
+    // - removes selected ciphers, but preserves their order for future
+    // selections. Select AES_128_GCM, but order the key exchanges RSA,
+    // ECDHE_RSA.
+    {
+        "ALL:-AES",
+        {
+            {TLS1_CK_CHACHA20_POLY1305_SHA256, 0},
+        },
+        false,
+    },
+    // Unknown selectors or TLSv1.2 ciphers are no-ops.
+    {
+        "TLS_CHACHA20_POLY1305_SHA256:"
+        "ECDHE-RSA-CHACHA20-POLY1305:"
+        "BOGUS1",
+        {
+            {TLS1_CK_CHACHA20_POLY1305_SHA256, 0},
+        },
+        true,
+    },
+};
+
 static const char *kBadRules[] = {
   // Invalid brackets.
   "[ECDHE-RSA-CHACHA20-POLY1305|ECDHE-RSA-AES128-GCM-SHA256",
@@ -437,6 +536,13 @@ static const char *kMustNotIncludeNull[] = {
   "SSLv3",
   "TLSv1",
   "TLSv1.2",
+};
+
+static const char *kTLSv13MustNotIncludeNull[] = {
+  "ALL",
+  "DEFAULT",
+  "HIGH",
+  "FIPS",
 };
 
 static const CurveTest kCurveTests[] = {
@@ -480,13 +586,30 @@ static const char *kBadCurvesLists[] = {
   ":X25519:P-256",
 };
 
-static std::string CipherListToString(SSL_CTX *ctx) {
+static STACK_OF(SSL_CIPHER) *tls13_ciphers(const SSL_CTX *ctx) {
+  return ctx->tls13_cipher_list->ciphers.get();
+}
+
+// TODO: replace this helper function with |SSL_CTX_cipher_in_group|
+// after moving |tls13_cipher_list| to |cipher_list|.
+static int cipher_in_group(const SSL_CTX *ctx, size_t i, bool tlsv13_ciphers) {
+  if (!tlsv13_ciphers) {
+    return SSL_CTX_cipher_in_group(ctx, i);
+  }
+  if (i >= sk_SSL_CIPHER_num(tls13_ciphers(ctx))) {
+    return 0;
+  }
+  return ctx->tls13_cipher_list->in_group_flags[i];
+}
+
+static std::string CipherListToString(SSL_CTX *ctx, bool tlsv13_ciphers) {
   bool in_group = false;
   std::string ret;
-  const STACK_OF(SSL_CIPHER) *ciphers = SSL_CTX_get_ciphers(ctx);
+  const STACK_OF(SSL_CIPHER) *ciphers = tlsv13_ciphers ? 
+    tls13_ciphers(ctx) : SSL_CTX_get_ciphers(ctx);
   for (size_t i = 0; i < sk_SSL_CIPHER_num(ciphers); i++) {
     const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(ciphers, i);
-    if (!in_group && SSL_CTX_cipher_in_group(ctx, i)) {
+    if (!in_group && cipher_in_group(ctx, i, tlsv13_ciphers)) {
       ret += "\t[\n";
       in_group = true;
     }
@@ -496,7 +619,7 @@ static std::string CipherListToString(SSL_CTX *ctx) {
     }
     ret += SSL_CIPHER_get_name(cipher);
     ret += "\n";
-    if (in_group && !SSL_CTX_cipher_in_group(ctx, i)) {
+    if (in_group && !cipher_in_group(ctx, i, tlsv13_ciphers)) {
       ret += "\t]\n";
       in_group = false;
     }
@@ -505,8 +628,10 @@ static std::string CipherListToString(SSL_CTX *ctx) {
 }
 
 static bool CipherListsEqual(SSL_CTX *ctx,
-                             const std::vector<ExpectedCipher> &expected) {
-  const STACK_OF(SSL_CIPHER) *ciphers = SSL_CTX_get_ciphers(ctx);
+                             const std::vector<ExpectedCipher> &expected,
+                             bool tlsv13_ciphers) {
+  STACK_OF(SSL_CIPHER) *ciphers = tlsv13_ciphers ? 
+    tls13_ciphers(ctx) : SSL_CTX_get_ciphers(ctx);
   if (sk_SSL_CIPHER_num(ciphers) != expected.size()) {
     return false;
   }
@@ -514,7 +639,7 @@ static bool CipherListsEqual(SSL_CTX *ctx,
   for (size_t i = 0; i < expected.size(); i++) {
     const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(ciphers, i);
     if (expected[i].id != SSL_CIPHER_get_id(cipher) ||
-        expected[i].in_group_flag != !!SSL_CTX_cipher_in_group(ctx, i)) {
+        expected[i].in_group_flag != !!cipher_in_group(ctx, i, tlsv13_ciphers)) {
       return false;
     }
   }
@@ -663,18 +788,18 @@ TEST(SSLTest, CipherRules) {
 
     // Test lax mode.
     ASSERT_TRUE(SSL_CTX_set_cipher_list(ctx.get(), t.rule));
-    EXPECT_TRUE(CipherListsEqual(ctx.get(), t.expected))
+    EXPECT_TRUE(CipherListsEqual(ctx.get(), t.expected, false /* not TLSv1.3 only */))
         << "Cipher rule evaluated to:\n"
-        << CipherListToString(ctx.get());
+        << CipherListToString(ctx.get(), false /* not TLSv1.3 only */);
 
     // Test strict mode.
     if (t.strict_fail) {
       EXPECT_FALSE(SSL_CTX_set_strict_cipher_list(ctx.get(), t.rule));
     } else {
       ASSERT_TRUE(SSL_CTX_set_strict_cipher_list(ctx.get(), t.rule));
-      EXPECT_TRUE(CipherListsEqual(ctx.get(), t.expected))
+      EXPECT_TRUE(CipherListsEqual(ctx.get(), t.expected, false /* not TLSv1.3 only */))
           << "Cipher rule evaluated to:\n"
-          << CipherListToString(ctx.get());
+          << CipherListToString(ctx.get(), false /* not TLSv1.3 only */);
     }
   }
 
@@ -687,6 +812,20 @@ TEST(SSLTest, CipherRules) {
     ERR_clear_error();
   }
 
+  // kTLSv13RuleOnly are valid test cases for |SSL_CTX_set_ciphersuites|,
+  // which configures only TLSv1.3 ciphers.
+  // |SSL_CTX_set_cipher_list| only supports TLSv1.2 and below ciphers configuration.
+  // Accordingly, kTLSv13RuleOnly result in |SSL_R_NO_CIPHER_MATCH|.
+  for (const CipherTest &t : kTLSv13RuleOnly) {
+    SCOPED_TRACE(t.rule);
+    bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+    ASSERT_TRUE(ctx);
+
+    EXPECT_FALSE(SSL_CTX_set_cipher_list(ctx.get(), t.rule));
+    ASSERT_EQ(ERR_GET_REASON(ERR_get_error()), SSL_R_NO_CIPHER_MATCH);
+    ERR_clear_error();
+  }
+
   for (const char *rule : kMustNotIncludeNull) {
     SCOPED_TRACE(rule);
     bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
@@ -696,6 +835,75 @@ TEST(SSLTest, CipherRules) {
     for (const SSL_CIPHER *cipher : SSL_CTX_get_ciphers(ctx.get())) {
       EXPECT_NE(NID_undef, SSL_CIPHER_get_cipher_nid(cipher));
     }
+  }
+}
+
+static std::vector<CipherTest> combine_tests(const CipherTest *c1, size_t size_1,
+  const CipherTest *c2, size_t size_2) {
+  std::vector<CipherTest> ret(size_1 + size_2);
+  size_t j = 0;
+  for (size_t i = 0; i < size_1; i++) {
+    ret[j++] = c1[i];
+  }
+  for (size_t i = 0; i < size_2; i++) {
+    ret[j++] = c2[i];
+  }
+  return ret;
+}
+
+TEST(SSLTest, TLSv13CipherRules) {
+  std::vector<CipherTest> cipherRules = combine_tests(kTLSv13RuleOnly,
+    OPENSSL_ARRAY_SIZE(kTLSv13RuleOnly), kTLSv13CipherTests, OPENSSL_ARRAY_SIZE(kTLSv13CipherTests));
+  for (const CipherTest &t : cipherRules) {
+    SCOPED_TRACE(t.rule);
+    bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+    ASSERT_TRUE(ctx);
+
+    // Test lax mode.
+    ASSERT_TRUE(SSL_CTX_set_ciphersuites(ctx.get(), t.rule));
+    EXPECT_TRUE(CipherListsEqual(ctx.get(), t.expected, true /* TLSv1.3 only */))
+        << "Cipher rule evaluated to:\n"
+        << CipherListToString(ctx.get(), true /* TLSv1.3 only */);
+
+    // TODO: add |SSL_CTX_set_strict_ciphersuites| and test strict mode.
+  }
+
+  for (const char *rule : kBadRules) {
+    SCOPED_TRACE(rule);
+    bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+    ASSERT_TRUE(ctx);
+
+    EXPECT_FALSE(SSL_CTX_set_ciphersuites(ctx.get(), rule));
+    ERR_clear_error();
+  }
+
+  for (const char *rule : kTLSv13MustNotIncludeNull) {
+    SCOPED_TRACE(rule);
+    bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+    ASSERT_TRUE(ctx);
+
+    ASSERT_TRUE(SSL_CTX_set_ciphersuites(ctx.get(), rule));
+    // Currenly, only three TLSv1.3 ciphers are supported.
+    EXPECT_EQ(3u, sk_SSL_CIPHER_num(tls13_ciphers(ctx.get())));
+    for (const SSL_CIPHER *cipher : tls13_ciphers(ctx.get())) {
+      EXPECT_NE(NID_undef, SSL_CIPHER_get_cipher_nid(cipher));
+    }
+  }
+
+  // kCipherTests are valid test cases for |SSL_CTX_set_cipher_list|,
+  // which configures only TLSv1.2 and below ciphers.
+  // |SSL_CTX_set_ciphersuites| only supports TLSv1.3 ciphers configuration.
+  // Accordingly, kCipherTests result in |SSL_R_NO_CIPHER_MATCH|.
+  // If kCipherTests starts to include rules that can match TLSv1.3 ciphers,
+  // kCipherTests should get splitted.
+  for (const CipherTest &t : kCipherTests) {
+    SCOPED_TRACE(t.rule);
+    bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+    ASSERT_TRUE(ctx);
+
+    EXPECT_FALSE(SSL_CTX_set_ciphersuites(ctx.get(), t.rule));
+    ASSERT_EQ(ERR_GET_REASON(ERR_get_error()), SSL_R_NO_CIPHER_MATCH);
+    ERR_clear_error();
   }
 }
 
@@ -4595,6 +4803,10 @@ TEST(SSLTest, EmptyCipherList) {
 
   // Configuring the empty cipher list fails.
   EXPECT_FALSE(SSL_CTX_set_cipher_list(ctx.get(), ""));
+  ERR_clear_error();
+
+  // Configuring the empty cipher list fails.
+  EXPECT_FALSE(SSL_CTX_set_ciphersuites(ctx.get(), ""));
   ERR_clear_error();
 
   // But the cipher list is still updated to empty.

--- a/ssl/test/bssl_shim.cc
+++ b/ssl/test/bssl_shim.cc
@@ -611,7 +611,15 @@ static bool CheckHandshakeProperties(SSL *ssl, bool is_resume,
   }
 
   uint16_t cipher_id = SSL_CIPHER_get_protocol_id(SSL_get_current_cipher(ssl));
-  if (config->expect_cipher_aes != 0 &&
+  if (!config->tls13_ciphersuites.empty() &&
+      config->expect_cipher != cipher_id) {
+    fprintf(stderr, "Cipher ID was %04x, wanted %04x\n",
+            cipher_id, config->expect_cipher_aes);
+    return false;
+  }
+
+  if (config->tls13_ciphersuites.empty() &&
+      config->expect_cipher_aes != 0 &&
       EVP_has_aes_hardware() &&
       config->expect_cipher_aes != cipher_id) {
     fprintf(stderr, "Cipher ID was %04x, wanted %04x (has AES hardware)\n",
@@ -619,7 +627,8 @@ static bool CheckHandshakeProperties(SSL *ssl, bool is_resume,
     return false;
   }
 
-  if (config->expect_cipher_no_aes != 0 &&
+  if (config->tls13_ciphersuites.empty() &&
+      config->expect_cipher_no_aes != 0 &&
       !EVP_has_aes_hardware() &&
       config->expect_cipher_no_aes != cipher_id) {
     fprintf(stderr, "Cipher ID was %04x, wanted %04x (no AES hardware)\n",

--- a/ssl/test/test_config.cc
+++ b/ssl/test/test_config.cc
@@ -388,6 +388,7 @@ std::vector<Flag> SortedFlags() {
       BoolFlag("-check-ssl-transfer", &TestConfig::check_ssl_transfer),
       BoolFlag("-do-ssl-transfer", &TestConfig::do_ssl_transfer),
       StringFlag("-ssl-fuzz-seed-path-prefix", &TestConfig::ssl_fuzz_seed_path_prefix),
+      StringFlag("-tls13-ciphersuites", &TestConfig::tls13_ciphersuites),
   };
   std::sort(flags.begin(), flags.end(), [](const Flag &a, const Flag &b) {
     return strcmp(a.name, b.name) < 0;
@@ -1399,6 +1400,10 @@ bssl::UniquePtr<SSL_CTX> TestConfig::SetupCtx(SSL_CTX *old_ctx) const {
     SSL_CTX_set_options(ssl_ctx.get(), SSL_OP_CIPHER_SERVER_PREFERENCE);
   }
   if (!SSL_CTX_set_strict_cipher_list(ssl_ctx.get(), cipher_list.c_str())) {
+    return nullptr;
+  }
+  if (!tls13_ciphersuites.empty()
+     && !SSL_CTX_set_ciphersuites(ssl_ctx.get(), tls13_ciphersuites.c_str())) {
     return nullptr;
   }
 

--- a/ssl/test/test_config.h
+++ b/ssl/test/test_config.h
@@ -201,6 +201,8 @@ struct TestConfig {
   // When not empty, this prefix with random suffix is used to create a file
   // stores the output of |SSL_to_bytes|.
   std::string ssl_fuzz_seed_path_prefix;
+  // When not empty, the value is passed to |SSL_CTX_set_ciphersuites|.
+  std::string tls13_ciphersuites;
 
   int argc;
   char **argv;

--- a/ssl/tls13_server.cc
+++ b/ssl/tls13_server.cc
@@ -116,7 +116,14 @@ static const SSL_CIPHER *choose_tls13_cipher(
 
   const uint16_t version = ssl_protocol_version(ssl);
 
-  return ssl_choose_tls13_cipher(cipher_suites, version, group_id);
+  STACK_OF(SSL_CIPHER) *tls13_ciphers = nullptr;
+  if (ssl->ctx->tls13_cipher_list &&
+      ssl->ctx->tls13_cipher_list.get()->ciphers &&
+      sk_SSL_CIPHER_num(ssl->ctx->tls13_cipher_list.get()->ciphers.get()) > 0) {
+    tls13_ciphers = ssl->ctx->tls13_cipher_list.get()->ciphers.get();
+  }
+
+  return ssl_choose_tls13_cipher(cipher_suites, version, group_id, tls13_ciphers);
 }
 
 static bool add_new_session_tickets(SSL_HANDSHAKE *hs, bool *out_sent_tickets) {


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-1073

### Description of changes: 
For now, the configured `tls13_cipher_list` does not participate in other APIs(e.g. handoff, |SSL_CTX_get_ciphers|, |SSL_CTX_cipher_in_group| and so on).

### Call-outs:
* Related PR https://github.com/awslabs/aws-lc/pull/560

### Testing:

ssl/ssl_test.cc
ssl/test/runner/runner.go

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
