### PR TITLE
Added endianess checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ if(MSVC)
 endif()
 
 include(sources.cmake)
+include(TestBigEndian)
 
 if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW) #option does nothing when a normal variable of the same name exists.
@@ -625,6 +626,11 @@ if(NOT OPENSSL_NO_ASM AND CMAKE_OSX_ARCHITECTURES)
   list(GET CMAKE_OSX_ARCHITECTURES 0 CMAKE_SYSTEM_PROCESSOR)
 endif()
 
+TEST_BIG_ENDIAN(BIG_ENDIAN)
+if(BIG_ENDIAN)
+  message(FATAL_ERROR "Big Endian is not supported.")
+endif()
+
 if(OPENSSL_NO_SSE2_FOR_TESTING)
   add_definitions(-DOPENSSL_NO_SSE2_FOR_TESTING)
 endif()
@@ -648,13 +654,10 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64.*|ARM64|aarch64")
   set(ARCH "aarch64")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm*")
   set(ARCH "arm")
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "mips")
-  # Just to avoid the “unknown processor” error.
-  set(ARCH "generic")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "powerpc64le|ppc64le")
   set(ARCH "ppc64le")
 else()
-  message(FATAL_ERROR "Unknown processor:" ${CMAKE_SYSTEM_PROCESSOR})
+  set(ARCH "generic")
 endif()
 
 if(ANDROID AND NOT ANDROID_NDK_REVISION AND ARCH STREQUAL "arm")


### PR DESCRIPTION
### Issues:
Resolves #557 
### Description of changes: 
Currently we have a list of allowed architectures to prevent people from trying to build on Big Endian systems since we don't support them. It's simpler to instead explicitly disallow Big Endian systems and have unknown architectures compile as generic builds.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
Used https://github.com/dockcross/dockcross to verify that this fails for Big Endian mips. Also checked that mipsel builds despite not being explicitly allowed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
