### PR TITLE
Removing the string literal from within the macro.

### DIFF
--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -4361,7 +4361,7 @@ TEST(X509Test, Print) {
   size_t data_len;
   ASSERT_TRUE(BIO_mem_contents(bio.get(), &data, &data_len));
   std::string print(reinterpret_cast<const char*>(data), data_len);
-  EXPECT_EQ(print, R"(Certificate:
+  static const char expected_certificate_string[] = R"(Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
@@ -4407,5 +4407,6 @@ TEST(X509Test, Print) {
          f5:0a:db:54:c4:d0:b0:c8:c5:fd:9a:d7:57:75:08:9c:39:f3:
          63:20:65:02:0f:93:8b:57:93:e0:1c:53:d1:2a:21:c7:8a:80:
          40:86
-)");
+)";
+  EXPECT_EQ(print, expected_certificate_string);
 }


### PR DESCRIPTION
To cater for gcc version 4.8.5 (Ubuntu 4.8.5-4ubuntu8).
Note that gcc version 4.8.5 20150623 (Red Hat 4.8.5-44)
doesn't complain.

### Issues:
A problem was reported with the usage of gcc version 4.8.5 (Ubuntu 4.8.5-4ubuntu8):
```
crypto/x509/x509_test.cc:4364:20: error: unterminated raw string
   EXPECT_EQ(print, R"(Certificate:
                    ^
```
### Description of changes: 
The string literal was put in a constant in order to avoid having it in a macro causing a problem like the following:
https://godbolt.org/z/Wc8TYaqbf

### Call-outs:
The version used in our CI in Centos-7 Docker image is gcc version 4.8.5 20150623 (Red Hat 4.8.5-44) which does not incur this error.

### Testing:
It's not tested with our CI so pending customer testing for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
