### PR TITLE
Fix benchmarking behavior with other libcryptos

### DIFF
--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -8,11 +8,10 @@ install_dir="$(pwd)/../libcrypto_install_dir"
 openssl_url='https://github.com/openssl/openssl.git'
 openssl_1_1_branch='OpenSSL_1_1_1-stable'
 openssl_1_0_branch='OpenSSL_1_0_2-stable'
-openssl_3_0_branch='openssl-3.0'
 # OpenSSL 3.0 branch still isn't stable yet, so we lock down
-# a commit to prevent build failures that they introduced from
+# a tag to prevent build failures that they introduced from
 # failing our CI.
-openssl_3_0_commit='2db226ce01be804fbd2d60b019c897305a8f091e'
+openssl_3_0_branch='openssl-3.0.5'
 
 function build_openssl_1_0 {
     echo "building OpenSSL 1.0"
@@ -42,7 +41,6 @@ function build_openssl_3_0 {
     echo "building OpenSSL 3.0"
     git clone --branch "${openssl_3_0_branch}" "${openssl_url}" "../openssl-3.0"
     pushd "../openssl-3.0"
-    git checkout "${openssl_3_0_commit}"
     mkdir -p "${install_dir}/openssl-3.0"
     ./Configure --prefix="${install_dir}/openssl-3.0" --openssldir="${install_dir}/openssl-3.0"
     make "-j${NUM_CPU_THREADS}"

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -4,11 +4,15 @@
 
 source tests/ci/common_posix_setup.sh
 
-install_dir="$(pwd)/../librypto_install_dir"
+install_dir="$(pwd)/../libcrypto_install_dir"
 openssl_url='https://github.com/openssl/openssl.git'
 openssl_1_1_branch='OpenSSL_1_1_1-stable'
 openssl_1_0_branch='OpenSSL_1_0_2-stable'
 openssl_3_0_branch='openssl-3.0'
+# OpenSSL 3.0 branch still isn't stable yet, so we lock down
+# a commit to prevent build failures that they introduced from
+# failing our CI.
+openssl_3_0_commit='2db226ce01be804fbd2d60b019c897305a8f091e'
 
 function build_openssl_1_0 {
     echo "building OpenSSL 1.0"
@@ -38,18 +42,19 @@ function build_openssl_3_0 {
     echo "building OpenSSL 3.0"
     git clone --branch "${openssl_3_0_branch}" "${openssl_url}" "../openssl-3.0"
     pushd "../openssl-3.0"
+    git checkout "${openssl_3_0_commit}"
     mkdir -p "${install_dir}/openssl-3.0"
     ./Configure --prefix="${install_dir}/openssl-3.0" --openssldir="${install_dir}/openssl-3.0"
     make "-j${NUM_CPU_THREADS}"
     make install
     popd
-    rm -rf "../openssl-1.1"
+    rm -rf "../openssl-3.0"
 }
 
 # We build each tool individually so we can have more insight into what is failing
 mkdir -p "${install_dir}"
 echo "Testing awslc_bm"
-mkdir "${install_dir}/aws_lc"
+mkdir -p "${install_dir}/aws_lc"
 run_build -DAWSLC_INSTALL_DIR="${install_dir}/aws_lc"
 "${BUILD_ROOT}/tool/awslc_bm"
 

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -63,7 +63,6 @@ endfunction()
 if(AWSLC_INSTALL_DIR)
   build_benchmark(awslc_bm ${AWSLC_INSTALL_DIR}/include crypto)
 
-  target_compile_options(awslc_bm PUBLIC -DAWSLC_BENCHMARK)
   if(NOT CMAKE_BUILD_TYPE)
     target_compile_options(awslc_bm PUBLIC -DCMAKE_BUILD_TYPE_DEBUG)
   endif()

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -63,6 +63,7 @@ endfunction()
 if(AWSLC_INSTALL_DIR)
   build_benchmark(awslc_bm ${AWSLC_INSTALL_DIR}/include crypto)
 
+  target_compile_options(awslc_bm PUBLIC -DAWSLC_BENCHMARK)
   if(NOT CMAKE_BUILD_TYPE)
     target_compile_options(awslc_bm PUBLIC -DCMAKE_BUILD_TYPE_DEBUG)
   endif()

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -672,9 +672,12 @@ static bool SpeedHashChunk(const EVP_MD *md, std::string name,
 
 static bool SpeedHash(const EVP_MD *md, const std::string &name,
                       const std::string &selected) {
+  // This SHA3 API is AWS-LC specific.
+#if defined(AWSLC_BENCHMARK)
   if (name.find("SHA3") != std::string::npos) {
     EVP_MD_unstable_sha3_enable(true);
   }
+#endif
 
   if (!selected.empty() && name.find(selected) == std::string::npos) {
     return true;
@@ -686,7 +689,10 @@ static bool SpeedHash(const EVP_MD *md, const std::string &name,
     }
   }
 
+  // This SHA3 API is AWS-LC specific.
+#if defined(AWSLC_BENCHMARK)
   EVP_MD_unstable_sha3_enable(false);
+#endif
   return true;
 }
 
@@ -1627,7 +1633,10 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedHash(EVP_sha256(), "SHA-256", selected) ||
      !SpeedHash(EVP_sha384(), "SHA-384", selected) ||
      !SpeedHash(EVP_sha512(), "SHA-512", selected) ||
+     // OpenSSL 1.0 doesn't support SHA3.
+#if !defined(OPENSSL_1_0_BENCHMARK)
      !SpeedHash(EVP_sha3_256(), "SHA3-256", selected) ||
+#endif
      !SpeedHmac(EVP_md5(), "HMAC-MD5", selected) ||
      !SpeedHmac(EVP_sha1(), "HMAC-SHA1", selected) ||
      !SpeedHmac(EVP_sha256(), "HMAC-SHA256", selected) ||

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -673,7 +673,7 @@ static bool SpeedHashChunk(const EVP_MD *md, std::string name,
 static bool SpeedHash(const EVP_MD *md, const std::string &name,
                       const std::string &selected) {
   // This SHA3 API is AWS-LC specific.
-#if defined(AWSLC_BENCHMARK)
+#if defined(OPENSSL_IS_AWSLC)
   if (name.find("SHA3") != std::string::npos) {
     EVP_MD_unstable_sha3_enable(true);
   }
@@ -690,7 +690,7 @@ static bool SpeedHash(const EVP_MD *md, const std::string &name,
   }
 
   // This SHA3 API is AWS-LC specific.
-#if defined(AWSLC_BENCHMARK)
+#if defined(OPENSSL_IS_AWSLC)
   EVP_MD_unstable_sha3_enable(false);
 #endif
   return true;


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1093`

### Description of changes: 
Fix some of the broken benchmark framework behavior so it can properly work in our CI. The tip of the OpenSSL3.0 branch currently fails so I've chosen to lock down a commit.

### Call-outs:
N/A

### Testing:
Running `./tests/ci/run_benchmark_build_tests.sh` passes the build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
