### PR TITLE
Fix incorrect return type description in evp.h

### DIFF
--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -243,15 +243,13 @@ OPENSSL_EXPORT int EVP_marshal_private_key(CBB *cbb, const EVP_PKEY *key);
 // prefix of |ED25519_sign|'s 64-byte private key.
 
 // EVP_PKEY_new_raw_private_key returns a newly allocated |EVP_PKEY| wrapping a
-// private key of the specified type. It returns one on success and zero on
-// error.
+// private key of the specified type. It returns NULL on error.
 OPENSSL_EXPORT EVP_PKEY *EVP_PKEY_new_raw_private_key(int type, ENGINE *unused,
                                                       const uint8_t *in,
                                                       size_t len);
 
 // EVP_PKEY_new_raw_public_key returns a newly allocated |EVP_PKEY| wrapping a
-// public key of the specified type. It returns one on success and zero on
-// error.
+// public key of the specified type. It returns NULL on error.
 OPENSSL_EXPORT EVP_PKEY *EVP_PKEY_new_raw_public_key(int type, ENGINE *unused,
                                                      const uint8_t *in,
                                                      size_t len);


### PR DESCRIPTION
The documentation for EVP_PKEY_new_raw_private_key and EVP_PKEY_new_raw_public_key states that it returns 1 on success and 0 on error. It in fact returns the |EVP_PKEY| on success and NULL on error.

### Description of changes: 
Fix description of EVP_PKEY_new_raw_private_key and EVP_PKEY_new_raw_public_key

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
