### PR TITLE
Fixed a typo. Should have been all_tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cmake3 -GNinja \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX=../aws-lc-install \
     ../aws-lc
-ninja-build run_tests && ninja-build install
+ninja-build all_tests && ninja-build install
 cd ../aws-lc-install/
 ls *
 ```


### PR DESCRIPTION
Possibly a documentation issue: `ninja-build run_tests` didn't work. I changed to `all_tests` and it worked fine.