### PR TITLE
Add more validation on CI deployment script.

### DIFF
--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -306,6 +306,11 @@ function export_global_variables() {
   export WIN_EC2_TAG_VALUE="aws-lc-windows-docker-image-build-${DATE_NOW}"
   export WIN_DOCKER_BUILD_SSM_DOCUMENT="windows-ssm-document-${DATE_NOW}"
   export IMG_BUILD_STATUS='unknown'
+  # 620771051181 is AWS-LC team AWS account.
+  if [[ "${CDK_DEPLOY_ACCOUNT}" != "620771051181" ]] && [[ "${GITHUB_REPO_OWNER}" == 'awslabs' ]]; then
+    echo "Only team account is allowed to create CI stacks on awslabs repo."
+    exit 1
+  fi
 }
 
 function main() {


### PR DESCRIPTION
### Description of changes: 
This PR added more validation on CI deployment script.

### Call-outs:
* Team account can still create CodeBuild to other GitHub repo. That means the creation will use GitHub access token instead of OAuth. Maybe we are also interested in disabling this path.

### Testing:
```sh
# Test the non-team account, expect the check is triggered.
./run-cdk.sh --aws-account 12345678 --github-repo-owner awslabs --github-source-version main --action build-linux-img

# Test the team account, expect the check is not triggered.
./run-cdk.sh --aws-account 620771051181 --github-repo-owner awslabs --github-source-version main --action build-linux-img

# Test default setting which uses team account, expect the check is not triggered.
./run-cdk.sh --github-repo-owner awslabs --github-source-version main --action build-linux-img
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
