### PR TITLE
Fixed typo that was causing CI to fail

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -96,7 +96,7 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-9x-sanitizer_latest
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-9x_sanitizer_latest
 
     # BoringSSL has 7k+ ssl runner tests, and the total number of the runner tests keep increasing.
     # When ASAN enabled, the tests take more than 1 hour to finish. The cause relates to https://github.com/google/sanitizers/issues/1331

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -128,7 +128,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-9x-sanitizer_latest
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_clang-9x_sanitizer_latest
 
     - identifier: ubuntu2004_clang10x_x86_64
       buildspec: ./tests/ci/codebuild/linux-x86/run_posix_tests.yml


### PR DESCRIPTION
### Description of changes: 
A typo in https://github.com/awslabs/aws-lc/pull/577 caused the CI to fail, this fixes that

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
This is a simple typo, and the images generated by the CI are present in my personal account. Their names match the name I changed these tests to point to.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
