### PR TITLE
Enable _alt s2n-bignum functions on iOS

### DIFF
--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -85,13 +85,13 @@ static inline uint8_t p384_use_s2n_bignum_alt(void) {
 // functions -- the default one and the alternative (suffixed _alt).
 // Depending on the architecture one version is faster than the other.
 // Generally, the "_alt" functions are faster on architectures with higher
-// multiplier throughput, for example, Graviton 3 and Apple's M1 chips.
+// multiplier throughput, for example, Graviton 3, Apple's M1 and iPhone chips.
 // Until we find a clear way to determine in runtime which architecture we
 // are running on we stick with the default s2n-bignum functions. Except in
-// the case of M1, because we know that if the OS is macOS and the CPU is
-// aarch64 then the CPU must be M1 so the "_alt" functions will be faster.
+// the case of Apple, because we know that on Apple's Arm chips the "_alt"
+// functions are faster.
 static inline uint8_t p384_use_s2n_bignum_alt(void) {
-#if defined(OPENSSL_MACOS)
+#if defined(OPENSSL_APPLE)
   return 1;
 #else
   return 0;

--- a/crypto/fipsmodule/ec/p521.c
+++ b/crypto/fipsmodule/ec/p521.c
@@ -88,13 +88,13 @@ static inline uint8_t p521_use_s2n_bignum_alt(void) {
 // functions -- the default one and the alternative (suffixed _alt).
 // Depending on the architecture one version is faster than the other.
 // Generally, the "_alt" functions are faster on architectures with higher
-// multiplier throughput, for example, Graviton 3 and Apple's M1 chips.
+// multiplier throughput, for example, Graviton 3, Apple's M1 and iPhone chips.
 // Until we find a clear way to determine in runtime which architecture we
 // are running on we stick with the default s2n-bignum functions. Except in
-// the case of M1, because we know that if the OS is macOS and the CPU is
-// aarch64 then the CPU must be M1 so the "_alt" functions will be faster.
+// the case of Apple, because we know that on Apple's Arm chips the "_alt"
+// functions are faster.
 static inline uint8_t p521_use_s2n_bignum_alt(void) {
-#if defined(OPENSSL_MACOS)
+#if defined(OPENSSL_APPLE)
   return 1;
 #else
   return 0;


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 

Enable `_alt` s2n-bignum functions in P-384 and P-521 implementation
on iOS. The speedups we get when using the "alternative" s2n-bignum
is shown in the table below. The measurements were done on an iPhone X
with A11 Bionic Arm chip.

```
| Operation           | Before(ops/sec) | After(ops/sec) | Improvement |
| ECDH P-384          |       3122      |      3345      |     1.07x   |
| ECDSA P-384 signing |       8715      |      9124      |     1.05x   |
| ECDSA P-384 verify  |       3431      |      3649      |     1.06x   |
------------------------------------------------------------------------
| ECDH P-521          |       1727      |      2453      |     1.42x   |
| ECDSA P-521 signing |       4363      |      5249      |     1.20x   |
| ECDSA P-521 verify  |       1725      |      2339      |     1.35x   |
```

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
