### PR TITLE
Fix analytic build sizes by not defining CMake build flags (FIPS, SMALL, NO_ASM) when they should be off

### DIFF
--- a/tests/ci/run_analytics.sh
+++ b/tests/ci/run_analytics.sh
@@ -40,16 +40,21 @@ for FOLDER_PATH in "$SRC_ROOT"/*/ ; do
 done
 
 function run_build_and_collect_metrics {
+  cmake_build_flags=("-DCMAKE_BUILD_TYPE=Release")
   if [[ "$small" == "ON" ]]; then
     build_size="Small"
+    cmake_build_flags+=("-DOPENSSL_SMALL=1")
   else
     build_size="Large"
   fi
   if [[ "$no_assembly" == "ON" ]]; then
     assembly="NoAsm"
+    cmake_build_flags+=("-DOPENSSL_NO_ASM=1")
   else
     assembly="Asm"
   fi
+
+  cmake_build_flags+=("-DBUILD_SHARED_LIBS=${shared_library}")
   if [[ "$shared_library" == "ON" ]]; then
     linking="Shared"
     lib_extension="so"
@@ -59,17 +64,14 @@ function run_build_and_collect_metrics {
   fi
   if [[ "$fips" == "ON" ]]; then
     fips_mode="FIPS"
+    cmake_build_flags+=("-DFIPS=1")
   else
     fips_mode="NotFIPS"
   fi
   size_common_dimensions="${common_dimensions},Optimization=Release,BuildSize=${build_size},Assembly=${assembly},CPU=${PLATFORM},Linking=${linking},FIPS=${fips_mode}"
 
   build_start=$(date +%s)
-  run_build -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_SHARED_LIBS="$shared_library" \
-      -DOPENSSL_SMALL="$small" \
-      -DOPENSSL_NO_ASM="$no_assembly" \
-      -DFIPS="$fips"
+  run_build "${cmake_build_flags[@]}"
   build_end=$(date +%s)
   build_time=$((build_end-build_start))
   put_metric --metric-name BuildTime --value "$build_time" --unit Seconds --dimensions "$size_common_dimensions"


### PR DESCRIPTION
### Issues:
Resolves issue from dashboard review.

### Description of changes: 
Previously the analytics build defined these flags as 0 or 1. However, our C code uses `if defined(SMALL/FIPS/NO_ASM)` which is true as they are defined when the preprocessor runs. This change now only defines the macros when we expect to test that build flavor. I checked `run_posix_tests.sh` and that script does not have this issue.

### Call-outs:
This wont fix historical data and we will see a sudden drop in these metrics.

### Testing:
Run the script locally with logging, CodeBuild defines the branch for us automatically and my desktop doesn't have that:
```
cmake -DCMAKE_BUILD_TYPE=Release -DOPENSSL_SMALL=1 -DOPENSSL_NO_ASM=1 -DBUILD_SHARED_LIBS=ON -GNinja /home/ANT.AMAZON.COM/andhop/workplace/oss/aws-lc
aws cloudwatch put-metric-data --timestamp 1661874519 --namespace AWS-LC --metric-name BuildTime --value 0 --unit Seconds --dimensions Branch=,Optimization=Release,BuildSize=Small,Assembly=NoAsm,CPU=x86_64,Linking=Shared,FIPS=NotFIPS
cmake -DCMAKE_BUILD_TYPE=Release -DOPENSSL_SMALL=1 -DBUILD_SHARED_LIBS=ON -GNinja /home/ANT.AMAZON.COM/andhop/workplace/oss/aws-lc
aws cloudwatch put-metric-data --timestamp 1661874519 --namespace AWS-LC --metric-name BuildTime --value 0 --unit Seconds --dimensions Branch=,Optimization=Release,BuildSize=Small,Assembly=Asm,CPU=x86_64,Linking=Shared,FIPS=NotFIPS
cmake -DCMAKE_BUILD_TYPE=Release -DOPENSSL_NO_ASM=1 -DBUILD_SHARED_LIBS=ON -GNinja /home/ANT.AMAZON.COM/andhop/workplace/oss/aws-lc
aws cloudwatch put-metric-data --timestamp 1661874519 --namespace AWS-LC --metric-name BuildTime --value 0 --unit Seconds --dimensions Branch=,Optimization=Release,BuildSize=Large,Assembly=NoAsm,CPU=x86_64,Linking=Shared,FIPS=NotFIPS
cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -GNinja /home/ANT.AMAZON.COM/andhop/workplace/oss/aws-lc
aws cloudwatch put-metric-data --timestamp 1661874519 --namespace AWS-LC --metric-name BuildTime --value 0 --unit Seconds --dimensions Branch=,Optimization=Release,BuildSize=Large,Assembly=Asm,CPU=x86_64,Linking=Shared,FIPS=NotFIPS
cmake -DCMAKE_BUILD_TYPE=Release -DOPENSSL_SMALL=1 -DOPENSSL_NO_ASM=1 -DBUILD_SHARED_LIBS=OFF -GNinja /home/ANT.AMAZON.COM/andhop/workplace/oss/aws-lc
aws cloudwatch put-metric-data --timestamp 1661874519 --namespace AWS-LC --metric-name BuildTime --value 0 --unit Seconds --dimensions Branch=,Optimization=Release,BuildSize=Small,Assembly=NoAsm,CPU=x86_64,Linking=Static,FIPS=NotFIPS
cmake -DCMAKE_BUILD_TYPE=Release -DOPENSSL_SMALL=1 -DBUILD_SHARED_LIBS=OFF -GNinja /home/ANT.AMAZON.COM/andhop/workplace/oss/aws-lc
aws cloudwatch put-metric-data --timestamp 1661874519 --namespace AWS-LC --metric-name BuildTime --value 0 --unit Seconds --dimensions Branch=,Optimization=Release,BuildSize=Small,Assembly=Asm,CPU=x86_64,Linking=Static,FIPS=NotFIPS
cmake -DCMAKE_BUILD_TYPE=Release -DOPENSSL_NO_ASM=1 -DBUILD_SHARED_LIBS=OFF -GNinja /home/ANT.AMAZON.COM/andhop/workplace/oss/aws-lc
aws cloudwatch put-metric-data --timestamp 1661874519 --namespace AWS-LC --metric-name BuildTime --value 0 --unit Seconds --dimensions Branch=,Optimization=Release,BuildSize=Large,Assembly=NoAsm,CPU=x86_64,Linking=Static,FIPS=NotFIPS
cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -GNinja /home/ANT.AMAZON.COM/andhop/workplace/oss/aws-lc
aws cloudwatch put-metric-data --timestamp 1661874519 --namespace AWS-LC --metric-name BuildTime --value 0 --unit Seconds --dimensions Branch=,Optimization=Release,BuildSize=Large,Assembly=Asm,CPU=x86_64,Linking=Static,FIPS=NotFIPS
cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DFIPS=1 -GNinja /home/ANT.AMAZON.COM/andhop/workplace/oss/aws-lc
aws cloudwatch put-metric-data --timestamp 1661874519 --namespace AWS-LC --metric-name BuildTime --value 0 --unit Seconds --dimensions Branch=,Optimization=Release,BuildSize=Large,Assembly=Asm,CPU=x86_64,Linking=Shared,FIPS=FIPS

```

You can see above that when the metric is `BuildSize=Small` the build contains ` -DOPENSSL_NO_ASM=1`, and when  `BuildSize=Large` the build doesn't have `OPENSSL_NO_ASM`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
