### PR TITLE
Bump version number to 1.2.0 and api version number to 19

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2621,6 +2621,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.1.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.2.0");
 }
 #endif // AWSLC_FIPS

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2578,7 +2578,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.1.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.2.0");
 }
 
 #else

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -205,9 +205,7 @@ extern "C" {
 // against multiple revisions of BoringSSL at the same time. It is not
 // recommended to do so for longer than is necessary.
 
-// Bump version from 17 to 18.
-//   - Import new APIs |EVP_aes_128/256_cbc_hmac_sha1/256| from OpenSSL.
-#define AWSLC_API_VERSION 18
+#define AWSLC_API_VERSION 19
 
 // This string tracks the most current production release version on Github
 // https://github.com/awslabs/aws-lc/releases.
@@ -215,7 +213,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.1.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.2.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 

Prepare new release by bumping release version number string to `1.2.0`. Also bump API version to 19 because of (e.g.) additions of new ciphers.

### Testing:

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
