### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2960,7 +2960,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.2.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.3.0");
 }
 
 #else
@@ -3003,6 +3003,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.2.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.3.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -213,7 +213,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.2.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.3.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Issues:
Resolves P71418080

### Description of changes: 
Prepare new release by bumping release version number string to 1.3.0.

### Call-outs:
Not raising the API version. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
