### PR TITLE
Fix jitterentropy linking

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -226,8 +226,8 @@ else()
 endif()
 
 add_library(
-  crypto
-
+  crypto_objects
+  OBJECT
   asn1/a_bitstr.c
   asn1/a_bool.c
   asn1/a_d2i_fp.c
@@ -455,16 +455,16 @@ add_library(
   ${CRYPTO_FIPS_OBJECTS}
 )
 
-target_compile_definitions(crypto PRIVATE BORINGSSL_IMPLEMENTATION)
+target_compile_definitions(crypto_objects PRIVATE BORINGSSL_IMPLEMENTATION)
 
 # For the prefix build, the object files need the prefix header files to build.
-add_dependencies(crypto global_target)
+add_dependencies(crypto_objects global_target)
 
 function(build_libcrypto name module_source)
   if(FIPS)
-    add_library(${name} $<TARGET_OBJECTS:crypto> ${CRYPTO_FIPS_OBJECTS} ${module_source} $<TARGET_OBJECTS:jitterentropy>)
+    add_library(${name} $<TARGET_OBJECTS:crypto_objects> ${CRYPTO_FIPS_OBJECTS} ${module_source} $<TARGET_OBJECTS:jitterentropy>)
   else()
-    add_library(${name} $<TARGET_OBJECTS:crypto> ${CRYPTO_FIPS_OBJECTS} ${module_source})
+    add_library(${name} $<TARGET_OBJECTS:crypto_objects> ${CRYPTO_FIPS_OBJECTS} ${module_source})
   endif()
 
   add_dependencies(${name}  global_target)
@@ -486,6 +486,7 @@ function(build_libcrypto name module_source)
 endfunction()
 
 if(FIPS_SHARED)
+  build_libcrypto(crypto $<TARGET_OBJECTS:fipsmodule>)
   # Rewrite libcrypto.so to inject the correct module hash value. This assumes
   # UNIX-style library naming, but we only support FIPS mode on Linux anyway.
   add_custom_command(
@@ -514,10 +515,6 @@ if(WIN32)
 endif()
 if(NOT WIN32 AND NOT ANDROID)
   target_link_libraries(crypto PUBLIC pthread)
-endif()
-
-if(FIPS)
-  target_link_libraries(crypto PRIVATE jitterentropy)
 endif()
 
 # Every target depends on crypto, so we add libcxx as a dependency here to

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -449,10 +449,7 @@ add_library(
   x509v3/v3_skey.c
   x509v3/v3_utl.c
 
-  $<TARGET_OBJECTS:fipsmodule>
-
   ${CRYPTO_ARCH_SOURCES}
-  ${CRYPTO_FIPS_OBJECTS}
 )
 
 target_compile_definitions(crypto_objects PRIVATE BORINGSSL_IMPLEMENTATION)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -500,6 +500,8 @@ if(FIPS_SHARED)
     DEPENDS ../util/fipstools/inject_hash/inject_hash.go
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   )
+else()
+  build_libcrypto(crypto $<TARGET_OBJECTS:fipsmodule>)
 endif()
 
 add_dependencies(crypto global_target)


### PR DESCRIPTION
### Issues:
Resolves PR620 breaking s2n-tls's CI.

### Description of changes: 
PR620 depended on some additional build changes; this PR makes those changes.

### Call-outs:
n/a

### Testing:
Compiled non-FIPS and FIPS mode on: macOS (FIPS mode fails as expected there), x86 AL2, ARM AL2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
