### PR TITLE
Remove the 32 consecutive KeyUpdate limit for TLS 1.3

### DIFF
--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2725,9 +2725,6 @@ struct SSL3_STATE {
   // received.
   uint8_t warning_alert_count = 0;
 
-  // key_update_count is the number of consecutive KeyUpdates received.
-  uint8_t key_update_count = 0;
-
   // ech_status indicates whether ECH was accepted by the server.
   ssl_ech_status_t ech_status = ssl_ech_none;
 

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -1000,7 +1000,6 @@ static int ssl_read_impl(SSL *ssl) {
     }
     if (!retry) {
       assert(!ssl->s3->pending_app_data.empty());
-      ssl->s3->key_update_count = 0;
     }
   }
 

--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -3045,14 +3045,13 @@ read alert 1 0
 			expectedLocalError: "remote error: illegal parameter",
 		},
 		{
-			name: "TooManyKeyUpdates",
+			name: "LotsOfKeyUpdates",
 			config: Config{
 				MaxVersion: VersionTLS13,
 			},
-			sendKeyUpdates:   33,
+			sendKeyUpdates:   100,
 			keyUpdateRequest: keyUpdateNotRequested,
-			shouldFail:       true,
-			expectedError:    ":TOO_MANY_KEY_UPDATES:",
+			shouldFail:       false,
 		},
 		{
 			name: "EmptySessionID",


### PR DESCRIPTION
### Issues:
Resolves V728984594 and D52012438

### Description of changes: 
AWS-LC currently only allows 32 consecutive key updates before closing the connection. This is a reasonable behavior because a client and server should be sending application data and not just doing key updates for fun. However, OpenSSL and s2n-tls do not restrict consecutive key updates and this breaks some clients when migrating to AWS-LC. 

### Call-outs:
Reviewed internally in V728984594. I decided not to remove `SSL_R_TOO_MANY_KEY_UPDATES` from ssl.h because some customers might be using the define and we may continue to tweak this restriction in the future.

### Testing:
Updated the lots of key updates tests to expect it to pass and not fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
