### PR TITLE
Add to approved list for FIPS

### DIFF
--- a/crypto/fipsmodule/self_check/fips.c
+++ b/crypto/fipsmodule/self_check/fips.c
@@ -46,12 +46,15 @@ int FIPS_query_algorithm_status(const char *algorithm) {
     "AES-GCM",
     "AES-KW",
     "AES-KWP",
+    "AES-XTS",
     "ctrDRBG",
     "ECC-SSC",
     "ECDSA-sign",
     "ECDSA-verify",
     "FFC-SSC",
     "HMAC",
+    "HKDF"
+    "PBKDF"
     "RSA-sign",
     "RSA-verify",
     "SHA-1",


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1284`

### Description of changes: 
Adding XTS to approved list for FIPS. We're in the process of verifying with our FIPS vendor if a CAST `self_check` is needed or not.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
