### PR TITLE
Revert "Use O_CLOEXEC instead of fcntl(FD_CLOEXEC)"

### DIFF
--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -265,7 +265,7 @@ static void init_once(void) {
 
   int fd;
   do {
-    fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+    fd = open("/dev/urandom", O_RDONLY);
   } while (fd == -1 && errno == EINTR);
 
   if (fd < 0) {
@@ -273,6 +273,20 @@ static void init_once(void) {
     abort();
   }
 
+  int flags = fcntl(fd, F_GETFD);
+  if (flags == -1) {
+    // Native Client doesn't implement |fcntl|.
+    if (errno != ENOSYS) {
+      perror("failed to get flags from urandom fd");
+      abort();
+    }
+  } else {
+    flags |= FD_CLOEXEC;
+    if (fcntl(fd, F_SETFD, flags) == -1) {
+      perror("failed to set FD_CLOEXEC on urandom fd");
+      abort();
+    }
+  }
   *urandom_fd_bss_get() = fd;
 }
 


### PR DESCRIPTION
This reverts commit 35301400bfaf635057d5840267e45cadfa1f75f4.

We need to revert this to support the 2.6.18 kernel. It might be worth putting this back in with preprocessor directives in the future

### Issues:
Resolves AWS-LC-93

### Description of changes: 
Drops O_CLOEXEC since it doesn't work on very old linux kernels

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
`ninja-build run tests`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
