### PR TITLE
Update speed.cc PrintWithBytes with nicer names

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -53,6 +53,13 @@ static inline void *BM_memset(void *dst, int c, size_t n) {
 // g_print_json is true if printed output is JSON formatted.
 static bool g_print_json = false;
 
+static std::string ChunkLenSuffix(size_t chunk_len) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), " (%zu byte%s)", chunk_len,
+           chunk_len != 1 ? "s" : "");
+  return buf;
+}
+
 // TimeResults represents the results of benchmarking a function.
 struct TimeResults {
   // num_calls is the number of function calls done in the time period.
@@ -76,7 +83,7 @@ struct TimeResults {
       PrintJSON(description, bytes_per_call);
     } else {
       printf("Did %u %s operations in %uus (%.1f ops/sec): %.1f MB/s\n",
-             num_calls, description.c_str(), us,
+             num_calls, (description + ChunkLenSuffix(bytes_per_call)).c_str(), us,
              (static_cast<double>(num_calls) / us) * 1000000,
              static_cast<double>(bytes_per_call * num_calls) / us);
     }
@@ -359,13 +366,6 @@ static bool SpeedRSAKeyGen(const std::string &selected) {
   return true;
 }
 
-static std::string ChunkLenSuffix(size_t chunk_len) {
-  char buf[32];
-  snprintf(buf, sizeof(buf), " (%zu byte%s)", chunk_len,
-           chunk_len != 1 ? "s" : "");
-  return buf;
-}
-
 static bool SpeedAESGCMChunk(const EVP_CIPHER *cipher, std::string name,
                              size_t chunk_byte_len, size_t ad_len) {
   int len;
@@ -395,7 +395,7 @@ static bool SpeedAESGCMChunk(const EVP_CIPHER *cipher, std::string name,
 
   BM_NAMESPACE::UniquePtr<EVP_CIPHER_CTX> ctx(EVP_CIPHER_CTX_new());
 
-  std::string encryptName = name + " Encrypt" + ChunkLenSuffix(chunk_byte_len);
+  std::string encryptName = name + " Encrypt";
   TimeResults encryptResults;
 
   // Call EVP_EncryptInit_ex once with the cipher, in the benchmark loop reuse the cipher
@@ -417,7 +417,7 @@ static bool SpeedAESGCMChunk(const EVP_CIPHER *cipher, std::string name,
   }
 
   encryptResults.PrintWithBytes(encryptName, chunk_byte_len);
-  std::string decryptName = name + " Decrypt" + ChunkLenSuffix(chunk_byte_len);
+  std::string decryptName = name + " Decrypt";
   TimeResults decryptResults;
   // Call EVP_DecryptInit_ex once with the cipher, in the benchmark loop reuse the cipher
   if (!EVP_DecryptInit_ex(ctx.get(), cipher, NULL, key.get(), nonce.get())){
@@ -462,7 +462,6 @@ static bool SpeedAEADChunk(const EVP_AEAD *aead, std::string name,
                            evp_aead_direction_t direction) {
   static const unsigned kAlignment = 16;
 
-  name += ChunkLenSuffix(chunk_len);
   BM_NAMESPACE::ScopedEVP_AEAD_CTX ctx;
   const size_t key_len = EVP_AEAD_key_length(aead);
   const size_t nonce_len = EVP_AEAD_nonce_length(aead);
@@ -749,7 +748,7 @@ static bool SpeedAES256XTS(const std::string &name, //const size_t in_len,
       fprintf(stderr, "AES-256-XTS initialisation or encryption failed.\n");
       return false;
     }
-    results.PrintWithBytes(name + ChunkLenSuffix(in_len) + " init and encrypt",
+    results.PrintWithBytes(name + " init and encrypt",
                            in_len);
   }
 
@@ -772,7 +771,7 @@ static bool SpeedAES256XTS(const std::string &name, //const size_t in_len,
       fprintf(stderr, "AES-256-XTS initialisation or decryption failed.\n");
       return false;
     }
-    results.PrintWithBytes(name + ChunkLenSuffix(in_len) + " init and decrypt",
+    results.PrintWithBytes(name + " init and decrypt",
                            in_len);
   }
 
@@ -794,7 +793,6 @@ static bool SpeedHashChunk(const EVP_MD *md, std::string name,
     return false;
   }
 
-  name += ChunkLenSuffix(chunk_len);
   TimeResults results;
   if (!TimeFunction(&results, [&ctx, md, chunk_len, &input]() -> bool {
         uint8_t digest[EVP_MAX_MD_SIZE];
@@ -862,7 +860,6 @@ static bool SpeedHmacChunk(const EVP_MD *md, std::string name,
   if (!HMAC_Init_ex(ctx.get(), key.get(), key_len, md, NULL /* ENGINE */)) {
     fprintf(stderr, "Failed to create HMAC_CTX.\n");
   }
-  name += ChunkLenSuffix(chunk_len);
   TimeResults results;
   if (!TimeFunction(&results, [&ctx, chunk_len, &scratch]() -> bool {
         uint8_t digest[EVP_MAX_MD_SIZE];
@@ -907,7 +904,6 @@ static bool SpeedHmacChunkOneShot(const EVP_MD *md, std::string name,
     return false;
   }
 
-  name += ChunkLenSuffix(chunk_len);
   TimeResults results;
   if (!TimeFunction(&results, [&key, key_len, md, chunk_len, &scratch]() -> bool {
 
@@ -947,7 +943,6 @@ static bool SpeedRandomChunk(std::string name, size_t chunk_len) {
     return false;
   }
 
-  name += ChunkLenSuffix(chunk_len);
   TimeResults results;
   if (!TimeFunction(&results, [chunk_len, &scratch]() -> bool {
         RAND_bytes(scratch, chunk_len);
@@ -1398,7 +1393,7 @@ static bool SpeedSipHash(const std::string &selected) {
       ERR_print_errors_fp(stderr);
       return false;
     }
-    results.PrintWithBytes("SipHash-2-4" + ChunkLenSuffix(len), len);
+    results.PrintWithBytes("SipHash-2-4", len);
   }
 
   return true;


### PR DESCRIPTION
### Description of changes: 
PrintWithBytes has two options: text output and JSON output. In JSON output mode it emits a field "numberOfBytes" and also put the number of bytes in the "description" field. This made it hard to aggregate the algorithms without lots of partial matching and was redundant. 

### Testing:
Before:
```
➜  build git:(main) ✗ ./tool/bssl speed -filter EVP-AES-128-GCM
Did 4468000 EVP-AES-128-GCM Encrypt (16 bytes) operations in 1000106us (4467526.4 ops/sec): 71.5 MB/s
Did 4060000 EVP-AES-128-GCM Decrypt (16 bytes) operations in 1000156us (4059366.7 ops/sec): 64.9 MB/s
....
➜  build git:(main) ✗ ./tool/bssl speed -filter EVP-AES-128-GCM -json
[
{"description": "EVP-AES-128-GCM Encrypt (16 bytes)", "numCalls": 4496000, "microseconds": 1000038, "bytesPerCall": 16},
{"description": "EVP-AES-128-GCM Decrypt (16 bytes)", "numCalls": 4073000, "microseconds": 1000210, "bytesPerCall": 16},

```

After, notice the only change is for the json output and removing `(16 bytes)`
```
➜  build git:(benchmark_names) ✗ ./tool/bssl speed -filter EVP-AES-128-GCM             
Did 4453000 EVP-AES-128-GCM Encrypt (16 bytes) operations in 1000029us (4452870.9 ops/sec): 71.2 MB/s
Did 4101000 EVP-AES-128-GCM Decrypt (16 bytes) operations in 1000002us (4100991.8 ops/sec): 65.6 MB/s
...
➜  build git:(benchmark_names) ✗ ./tool/bssl speed -filter EVP-AES-128-GCM -json
[
{"description": "EVP-AES-128-GCM Encrypt", "numCalls": 4489000, "microseconds": 1000046, "bytesPerCall": 16},
{"description": "EVP-AES-128-GCM Decrypt", "numCalls": 4061000, "microseconds": 1000171, "bytesPerCall": 16},

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
