### PR TITLE
Remove macros unnecessarily added in Kyber

### DIFF
--- a/crypto/kyber/pqcrystals-kyber_kyber512_ref/symmetric.h
+++ b/crypto/kyber/pqcrystals-kyber_kyber512_ref/symmetric.h
@@ -26,10 +26,8 @@ void kyber_aes256ctr_prf(uint8_t *out, size_t outlen, const uint8_t key[32], uin
 
 #define hash_h(OUT, IN, INBYTES) sha256(OUT, IN, INBYTES)
 #define hash_g(OUT, IN, INBYTES) sha512(OUT, IN, INBYTES)
-#define xof_init(STATE)
 #define xof_absorb(STATE, SEED, X, Y) kyber_aes256xof_absorb(STATE, SEED, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
-#define xof_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) kyber_aes256ctr_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) sha256(OUT, IN, INBYTES)
 
@@ -52,10 +50,8 @@ void kyber_shake256_prf(uint8_t *out, size_t outlen, const uint8_t key[KYBER_SYM
 
 #define hash_h(OUT, IN, INBYTES) sha3_256(OUT, IN, INBYTES)
 #define hash_g(OUT, IN, INBYTES) sha3_512(OUT, IN, INBYTES)
-#define xof_init(STATE) shake128_inc_init(STATE)
 #define xof_absorb(STATE, SEED, X, Y) kyber_shake128_absorb(STATE, SEED, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
-#define xof_release(STATE) shake128_inc_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) kyber_shake256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) shake256(OUT, KYBER_SSBYTES, IN, INBYTES)
 

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -420,7 +420,6 @@ typedef struct hmac_ctx_st HMAC_CTX;
 typedef struct md4_state_st MD4_CTX;
 typedef struct md5_state_st MD5_CTX;
 typedef struct ossl_init_settings_st OPENSSL_INIT_SETTINGS;
-typedef struct ossl_param_st OSSL_PARAM;
 typedef struct pkcs12_st PKCS12;
 typedef struct pkcs8_priv_key_info_st PKCS8_PRIV_KEY_INFO;
 typedef struct private_key_st X509_PKEY;
@@ -462,14 +461,6 @@ typedef struct x509_store_st X509_STORE;
 typedef struct x509_trust_st X509_TRUST;
 
 typedef void *OPENSSL_BLOCK;
-
-struct ossl_param_st {
-  const char *key;             /* the name of the parameter */
-  unsigned int data_type;      /* declare what kind of content is in buffer */
-  void *data;                  /* value being passed in or out */
-  size_t data_size;            /* data size */
-  size_t return_size;          /* returned content size */
-}; /* OSSL_PARAM */
 
 #if defined(__cplusplus)
 }  // extern C


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
- Remove two macros that were added to the Kyber source code without any need (I don't know the reason for this addition).
- Remove the `ossl_params` struct that was part of the initial design of KEM support which was later changed to a new design that doesn't need `ossl_params`.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
