### PR TITLE
Support Rust Address Sanitizer; Prefix KYBER symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,9 +151,9 @@ if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
     COMMAND ${GO_EXECUTABLE} run ${CMAKE_CURRENT_SOURCE_DIR}/util/make_prefix_headers.go -out ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include ${BORINGSSL_PREFIX_SYMBOLS_PATH}
     # Temporary exclude all Kyber symbols.
     # TODO(dkostic): fix the prefix build to work with Kyber source code.
-    COMMAND sed -i '/kyber/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols.h
-    COMMAND sed -i '/kyber/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols_asm.h
-    COMMAND sed -i '/kyber/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols_nasm.inc
+    COMMAND sed -i.bak '/kyber/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols.h
+    COMMAND sed -i.bak '/kyber/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols_asm.h
+    COMMAND sed -i.bak '/kyber/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols_nasm.inc
     DEPENDS util/make_prefix_headers.go
             ${BORINGSSL_PREFIX_SYMBOLS_PATH})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,9 +151,9 @@ if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
     COMMAND ${GO_EXECUTABLE} run ${CMAKE_CURRENT_SOURCE_DIR}/util/make_prefix_headers.go -out ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include ${BORINGSSL_PREFIX_SYMBOLS_PATH}
     # Temporary exclude all Kyber symbols.
     # TODO(dkostic): fix the prefix build to work with Kyber source code.
-    COMMAND sed -i.bak '/kyber/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols.h
-    COMMAND sed -i.bak '/kyber/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols_asm.h
-    COMMAND sed -i.bak '/kyber/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols_nasm.inc
+    COMMAND sed -i.bak '/pqcrystals/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols.h
+    COMMAND sed -i.bak '/pqcrystals/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols_asm.h
+    COMMAND sed -i.bak '/pqcrystals/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols_nasm.inc
     DEPENDS util/make_prefix_headers.go
             ${BORINGSSL_PREFIX_SYMBOLS_PATH})
 

--- a/bindings/rust/aws-lc-sys-template/Cargo.toml
+++ b/bindings/rust/aws-lc-sys-template/Cargo.toml
@@ -22,9 +22,12 @@ include = [
     "tests/**/*.rs",
 ]
 
+[features]
+asan = []
+
 [build-dependencies]
 cmake = "0.1.48"
-bindgen = "0.60.1"
+bindgen = "0.61"
 regex = "1"
 dunce = "1.0"
 

--- a/bindings/rust/aws-lc-sys-template/build.rs
+++ b/bindings/rust/aws-lc-sys-template/build.rs
@@ -114,7 +114,10 @@ fn prepare_bindings_builder(manifest_dir: &Path, build_prefix: Option<&str>) -> 
         .derive_eq(true)
         .allowlist_file(".*/openssl/[^/]+\\.h")
         .allowlist_file(".*/rust_wrapper\\.h")
-        .default_enum_style(bindgen::EnumVariation::NewType { is_bitfield: false })
+        .default_enum_style(bindgen::EnumVariation::NewType {
+            is_bitfield: false,
+            is_global: true,
+        })
         .default_macro_constant_type(bindgen::MacroTypeVariation::Signed)
         .generate_comments(true)
         .fit_macro_constants(false)

--- a/crypto/kyber/kem_kyber.h
+++ b/crypto/kyber/kem_kyber.h
@@ -13,6 +13,12 @@
 #define KYBER512_CIPHERTEXT_BYTES 768
 #define KYBER512_SHARED_SECRET_BYTES 32
 
+#ifdef BORINGSSL_PREFIX
+#define kyber512_keypair BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, kyber512_keypair)
+#define kyber512_encapsulate BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, kyber512_encapsulate)
+#define kyber512_decapsulate BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, kyber512_decapsulate)
+#endif
+
 int kyber512_keypair(uint8_t *public_key /* OUT */,
                      uint8_t *secret_key /* OUT */);
 

--- a/crypto/kyber/kem_kyber.h
+++ b/crypto/kyber/kem_kyber.h
@@ -13,12 +13,6 @@
 #define KYBER512_CIPHERTEXT_BYTES 768
 #define KYBER512_SHARED_SECRET_BYTES 32
 
-#ifdef BORINGSSL_PREFIX
-#define kyber512_keypair BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, kyber512_keypair)
-#define kyber512_encapsulate BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, kyber512_encapsulate)
-#define kyber512_decapsulate BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, kyber512_decapsulate)
-#endif
-
 int kyber512_keypair(uint8_t *public_key /* OUT */,
                      uint8_t *secret_key /* OUT */);
 

--- a/crypto/kyber/pqcrystals-kyber_kyber512_ref/fips202.h
+++ b/crypto/kyber/pqcrystals-kyber_kyber512_ref/fips202.h
@@ -3,13 +3,21 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <openssl/base.h>
 
 #define SHAKE128_RATE 168
 #define SHAKE256_RATE 136
 #define SHA3_256_RATE 136
 #define SHA3_512_RATE 72
 
-#define FIPS202_NAMESPACE(s) pqcrystals_kyber_fips202_ref_##s
+#define FIPS202_PREFIX(s) pqcrystals_kyber_fips202_ref_ ## s
+
+#ifdef BORINGSSL_PREFIX
+#define FIPS202_NAMESPACE(s) BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, FIPS202_PREFIX(s))
+#else
+#define FIPS202_NAMESPACE(s) FIPS202_PREFIX(s)
+#endif
+
 
 typedef struct {
   uint64_t s[25];

--- a/crypto/kyber/pqcrystals-kyber_kyber512_ref/params.h
+++ b/crypto/kyber/pqcrystals-kyber_kyber512_ref/params.h
@@ -1,6 +1,8 @@
 #ifndef PARAMS_H
 #define PARAMS_H
 
+#include <openssl/base.h>
+
 #define KYBER_K 2	/* Change this for different security strengths */
 
 //#define KYBER_90S	/* Uncomment this if you want the 90S variant */
@@ -8,25 +10,32 @@
 /* Don't change parameters below this line */
 #if   (KYBER_K == 2)
 #ifdef KYBER_90S
-#define KYBER_NAMESPACE(s) pqcrystals_kyber512_90s_ref_##s
+#define KYBER_VARIANT(s) pqcrystals_kyber512_90s_ref_##s
 #else
-#define KYBER_NAMESPACE(s) pqcrystals_kyber512_ref_##s
+#define KYBER_VARIANT(s) pqcrystals_kyber512_ref_##s
 #endif
 #elif (KYBER_K == 3)
 #ifdef KYBER_90S
-#define KYBER_NAMESPACE(s) pqcrystals_kyber768_90s_ref_##s
+#define KYBER_VARIANT(s) pqcrystals_kyber768_90s_ref_##s
 #else
-#define KYBER_NAMESPACE(s) pqcrystals_kyber768_ref_##s
+#define KYBER_VARIANT(s) pqcrystals_kyber768_ref_##s
 #endif
 #elif (KYBER_K == 4)
 #ifdef KYBER_90S
-#define KYBER_NAMESPACE(s) pqcrystals_kyber1024_90s_ref_##s
+#define KYBER_VARIANT(s) pqcrystals_kyber1024_90s_ref_##s
 #else
-#define KYBER_NAMESPACE(s) pqcrystals_kyber1024_ref_##s
+#define KYBER_VARIANT(s) pqcrystals_kyber1024_ref_##s
 #endif
 #else
 #error "KYBER_K must be in {2,3,4}"
 #endif
+
+#ifdef BORINGSSL_PREFIX
+#define KYBER_NAMESPACE(s) BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, KYBER_VARIANT(s))
+#else
+#define KYBER_NAMESPACE(s) KYBER_VARIANT(s)
+#endif
+
 
 #define KYBER_N 256
 #define KYBER_Q 3329

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -91,9 +91,6 @@ function verify_symbols_prefixed {
   go run "$SRC_ROOT"/util/read_symbols.go -out "$BUILD_ROOT"/symbols_final_crypto.txt "$BUILD_ROOT"/crypto/libcrypto.a
   go run "$SRC_ROOT"/util/read_symbols.go -out "$BUILD_ROOT"/symbols_final_ssl.txt "$BUILD_ROOT"/ssl/libssl.a
   cat "$BUILD_ROOT"/symbols_final_crypto.txt  "$BUILD_ROOT"/symbols_final_ssl.txt | grep -v -e '^_\?bignum' >  "$SRC_ROOT"/symbols_final.txt
-  # Kyber symbols are temporarly excluded from prefixing.
-  # TODO(dkostic): remove the sed once Kyber source is fixed and can be prefixed.
-  sed -i '/kyber/d' "$SRC_ROOT"/symbols_final.txt
   if [ $(grep -c -v ${CUSTOM_PREFIX}  "$SRC_ROOT"/symbols_final.txt) -ne 0 ]; then
     echo "Symbol(s) missing prefix!"
     exit 1

--- a/tests/ci/docker_images/rust/build_images.sh
+++ b/tests/ci/docker_images/rust/build_images.sh
@@ -6,6 +6,9 @@
 # Build images from AWS-LC GitHub repo #
 ########################################
 
+# Ubuntu systems might not have "jq" installed:
+# sudo apt-get install jq
+
 # Log Docker hub limit https://docs.docker.com/docker-hub/download-rate-limit/#how-can-i-check-my-current-rate
 TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
 curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* AWS-LC supports an address sanitizer (ASAN) build.  This change allows ASAN to be used when building the `aws-lc-sys` crate.
* The prefix build on Mac was broken.  (On Mac, "sed" requires an extension when performing in-place file modifications.)
* Update headers for Kyber to support prefixing.
* Update to the latest Rust-bindgen version.

### Call-outs:
N/A

### Testing:
I manually ran the `aws-lc-sys` crate generation scripts since these are not yet integrated with our CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
