### PR TITLE
Remove pthread_atfork fork detection mechanism

### DIFF
--- a/crypto/fipsmodule/rand/fork_detect.h
+++ b/crypto/fipsmodule/rand/fork_detect.h
@@ -42,10 +42,6 @@ OPENSSL_EXPORT uint64_t CRYPTO_get_fork_generation(void);
 // used for testing purposes.
 OPENSSL_EXPORT void CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing(void);
 
-// CRYPTO_fork_detect_ignore_pthread_atfork_for_testing is an internal detail
-// used for testing purposes.
-OPENSSL_EXPORT void CRYPTO_fork_detect_ignore_pthread_atfork_for_testing(void);
-
 #if defined(__cplusplus)
 }  // extern C
 #endif

--- a/crypto/fipsmodule/rand/fork_detect_test.cc
+++ b/crypto/fipsmodule/rand/fork_detect_test.cc
@@ -105,10 +105,6 @@ TEST(ForkDetect, Test) {
     CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing();
   }
 
-  if (getenv("BORINGSSL_IGNORE_PTHREAD_ATFORK")) {
-    CRYPTO_fork_detect_ignore_pthread_atfork_for_testing();
-  }
-
   const uint64_t start = CRYPTO_get_fork_generation();
   if (start == 0) {
     fprintf(stderr, "Fork detection not supported. Skipping test.\n");

--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -534,10 +534,6 @@ int main(int argc, char **argv) {
     CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing();
   }
 
-  if (getenv("BORINGSSL_IGNORE_PTHREAD_ATFORK")) {
-    CRYPTO_fork_detect_ignore_pthread_atfork_for_testing();
-  }
-
   return RUN_ALL_TESTS();
 }
 

--- a/crypto/rand_extra/rand_test.cc
+++ b/crypto/rand_extra/rand_test.cc
@@ -43,10 +43,6 @@ static void maybe_disable_some_fork_detect_mechanisms(void) {
   if (getenv("BORINGSSL_IGNORE_MADV_WIPEONFORK")) {
     CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing();
   }
-
-  if (getenv("BORINGSSL_IGNORE_PTHREAD_ATFORK")) {
-    CRYPTO_fork_detect_ignore_pthread_atfork_for_testing();
-  }
 #endif
 }
 

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -55,14 +55,14 @@
   {
     "comment": "No RDRAND and without fork detection",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x4000000000000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1", "BORINGSSL_IGNORE_PTHREAD_ATFORK=1"],
+    "env": ["OPENSSL_ia32cap=~0x4000000000000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
     "skip_valgrind": true,
     "target_arch": "x86"
   },
   {
     "comment": "Potentially with RDRAND, but not Intel, and without fork detection",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x0000000040000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1", "BORINGSSL_IGNORE_PTHREAD_ATFORK=1"],
+    "env": ["OPENSSL_ia32cap=~0x0000000040000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
     "skip_valgrind": true,
     "target_arch": "x86"
   },
@@ -72,25 +72,13 @@
     "skip_valgrind": true
   },
   {
-    "comment": "Run RAND test suite with only madv WIPEONFORK enabled",
-    "cmd": ["crypto/crypto_test", "--gtest_filter=RandTest.*"],
-    "env": ["BORINGSSL_IGNORE_PTHREAD_ATFORK=1"],
-    "skip_valgrind": true
-  },
-  {
-    "comment": "Run RAND test suite with only pthread_atfork enabled",
+    "comment": "Run RAND test suite without MADV_WIPEONFORK enabled",
     "cmd": ["crypto/crypto_test", "--gtest_filter=RandTest.*"],
     "env": ["BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
     "skip_valgrind": true
   },
   {
-    "comment": "Run fork detection test suite with only madv WIPEONFORK enabled",
-    "cmd": ["crypto/crypto_test", "--gtest_filter=ForkDetect.*"],
-    "env": ["BORINGSSL_IGNORE_PTHREAD_ATFORK=1"],
-    "skip_valgrind": true
-  },
-  {
-    "comment": "Run fork detection test suite with only pthread_atfork enabled",
+    "comment": "Run fork detection test suite without MADV_WIPEONFORK enabled",
     "cmd": ["crypto/crypto_test", "--gtest_filter=ForkDetect.*"],
     "env": ["BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
     "skip_valgrind": true


### PR DESCRIPTION
### Description of changes: 

#142 added `pthread_atfork()` as a secondary fork detection mechanism. However, we have observed several issues consuming AWS-LC artifacts due to the symbol `pthread_atfork` being handled differently in distributions (and in a non-portable way). This affects our ability to distribute AWS-LC to our intended places. See internal document for details.

Therefore, completely remove `pthread_atfork()` from the code-base.

### Call-outs:

This change is OK for two reasons:
* `MADV_WIPEONFORK` captures forks more broadly than `pthread_atfork()` (if supported). For example, the former captures forks through `clone()` while the latter does not.
* The decisional logic that determines whether prediction resistance should be disabled or not, depends on `MADV_WIPEONFORK` being supported before making the "disable" decision. That is, even if `phtread_atfork()` is supported, prediction resistance is only disabled if `MADV_WIPEONFORK` is also supported (and they both initialise without errors at run-time).
* No `pthread_atfork()` behaviour or functionality was ever exposed publicly, so we can remove this safely without consumer incompatibility issues. Neither does this PR change behaviour in how `RAND_bytes()` behaves from a public perspective.

### Testing:

Remove `pthread_atfork()` specific tests and replace with tests that forcefully disables `MADV_WIPEONFORK` to test those code-paths (which in the future could potentially be different from `--fork_unsafe_buffering`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
