### PR TITLE
Update run_analytics.sh to skip ARM FIPS Static builds with GCC

### DIFF
--- a/tests/ci/run_analytics.sh
+++ b/tests/ci/run_analytics.sh
@@ -117,5 +117,8 @@ no_assembly=OFF
 fips=ON
 run_build_and_collect_metrics
 
-shared_library=OFF
-run_build_and_collect_metrics
+# The static FIPS build does not work on ARM with GCC, fix tracked in CryptoAlg-1399
+if [[ ("$(uname -s)" == 'Linux'*) && (("$(uname -p)" == 'x86_64'*) || (("$(uname -p)" == 'aarch64') && ("$CC" == 'clang'*))) ]]; then
+  shared_library=OFF
+  run_build_and_collect_metrics
+fi

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -8,7 +8,7 @@ echo "Testing AWS-LC shared library in FIPS Release mode."
 fips_build_and_test -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
 
 # Static FIPS build works only on x86_64 Linux platforms (both gcc and clang),
-# and on aarch64 Linux platforms with clang.
+# and on aarch64 Linux platforms with clang. Fix tracked in CryptoAlg-1399
 if [[ ("$(uname -s)" == 'Linux'*) && (("$(uname -p)" == 'x86_64'*) || (("$(uname -p)" == 'aarch64') && ("$CC" == 'clang'*))) ]]; then
   echo "Testing AWS-LC static library in FIPS Release mode."
   fips_build_and_test -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
### Description of changes: 
Fix an issue where the analytics build fails on the last build for ARM. Supporting the Static FIPS GCC ARM build is tracked in CryptoAlg-1399.

This will also address the false positive in https://github.com/awslabs/aws-lc/pull/677.

### Testing:
Existing CI tests skip the Static FIPS GCC ARM build, the Clang build is still tested.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
