### PR TITLE
Revert "Switch RSA_sign to size_t."

### DIFF
--- a/crypto/decrepit/rsa/rsa_decrepit.c
+++ b/crypto/decrepit/rsa/rsa_decrepit.c
@@ -61,7 +61,7 @@
 #include <openssl/bn.h>
 
 
-RSA *RSA_generate_key(int bits, uint64_t e_value, void *callback,
+RSA *RSA_generate_key(int bits, unsigned long e_value, void *callback,
                       void *cb_arg) {
   assert(callback == NULL);
   assert(cb_arg == NULL);
@@ -71,7 +71,7 @@ RSA *RSA_generate_key(int bits, uint64_t e_value, void *callback,
 
   if (rsa == NULL ||
       e == NULL ||
-      !BN_set_u64(e, e_value) ||
+      !BN_set_word(e, e_value) ||
       !RSA_generate_key_ex(rsa, bits, e, NULL)) {
     goto err;
   }

--- a/crypto/fipsmodule/rsa/internal.h
+++ b/crypto/fipsmodule/rsa/internal.h
@@ -148,7 +148,7 @@ int rsa_verify_raw_no_self_test(RSA *rsa, size_t *out_len, uint8_t *out,
                                 size_t in_len, int padding);
 
 int rsa_sign_no_self_test(int hash_nid, const uint8_t *digest,
-                          size_t digest_len, uint8_t *out, unsigned *out_len,
+                          unsigned digest_len, uint8_t *out, unsigned *out_len,
                           RSA *rsa);
 
 

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -530,14 +530,6 @@ int RSA_add_pkcs1_prefix(uint8_t **out_msg, size_t *out_msg_len,
 int rsa_sign_no_self_test(int hash_nid, const uint8_t *digest,
                           unsigned digest_len, uint8_t *out, unsigned *out_len,
                           RSA *rsa) {
-  if (rsa->meth->sign) {
-    // All supported digest lengths fit in |unsigned|.
-    assert(digest_len <= EVP_MAX_MD_SIZE);
-    OPENSSL_STATIC_ASSERT(EVP_MAX_MD_SIZE <= UINT_MAX, digest_too_long);
-    return rsa->meth->sign(hash_nid, digest, (unsigned)digest_len, out, out_len,
-                           rsa);
-  }
-
   const unsigned rsa_size = RSA_size(rsa);
   int ret = 0;
   uint8_t *signed_msg = NULL;

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -56,7 +56,6 @@
 
 #include <openssl/rsa.h>
 
-#include <assert.h>
 #include <limits.h>
 #include <string.h>
 
@@ -473,43 +472,18 @@ static const struct pkcs1_sig_prefix kPKCS1SigPrefixes[] = {
     },
 };
 
-static int rsa_check_digest_size(int hash_nid, size_t digest_len) {
+int RSA_add_pkcs1_prefix(uint8_t **out_msg, size_t *out_msg_len,
+                         int *is_alloced, int hash_nid, const uint8_t *digest,
+                         size_t digest_len) {
   if (hash_nid == NID_md5_sha1) {
+    // Special case: SSL signature, just check the length.
     if (digest_len != SSL_SIG_LENGTH) {
       OPENSSL_PUT_ERROR(RSA, RSA_R_INVALID_MESSAGE_LENGTH);
       return 0;
     }
-    return 1;
-  }
 
-  for (size_t i = 0; kPKCS1SigPrefixes[i].nid != NID_undef; i++) {
-    const struct pkcs1_sig_prefix *sig_prefix = &kPKCS1SigPrefixes[i];
-    if (sig_prefix->nid == hash_nid) {
-      if (digest_len != sig_prefix->hash_len) {
-        OPENSSL_PUT_ERROR(RSA, RSA_R_INVALID_MESSAGE_LENGTH);
-        return 0;
-      }
-      return 1;
-    }
-  }
-
-  OPENSSL_PUT_ERROR(RSA, RSA_R_UNKNOWN_ALGORITHM_TYPE);
-  return 0;
-
-}
-
-int RSA_add_pkcs1_prefix(uint8_t **out_msg, size_t *out_msg_len,
-                         int *is_alloced, int hash_nid, const uint8_t *digest,
-                         size_t digest_len) {
-  if (!rsa_check_digest_size(hash_nid, digest_len)) {
-    return 0;
-  }
-
-  if (hash_nid == NID_md5_sha1) {
-    // The length should already have been checked.
-    assert(digest_len == SSL_SIG_LENGTH);
     *out_msg = (uint8_t *)digest;
-    *out_msg_len = digest_len;
+    *out_msg_len = SSL_SIG_LENGTH;
     *is_alloced = 0;
     return 1;
   }
@@ -520,8 +494,11 @@ int RSA_add_pkcs1_prefix(uint8_t **out_msg, size_t *out_msg_len,
       continue;
     }
 
-    // The length should already have been checked.
-    assert(digest_len == sig_prefix->hash_len);
+    if (digest_len != sig_prefix->hash_len) {
+      OPENSSL_PUT_ERROR(RSA, RSA_R_INVALID_MESSAGE_LENGTH);
+      return 0;
+    }
+
     const uint8_t* prefix = sig_prefix->bytes;
     size_t prefix_len = sig_prefix->len;
     size_t signed_msg_len = prefix_len + digest_len;
@@ -551,12 +528,9 @@ int RSA_add_pkcs1_prefix(uint8_t **out_msg, size_t *out_msg_len,
 }
 
 int rsa_sign_no_self_test(int hash_nid, const uint8_t *digest,
-                          size_t digest_len, uint8_t *out, unsigned *out_len,
+                          unsigned digest_len, uint8_t *out, unsigned *out_len,
                           RSA *rsa) {
   if (rsa->meth->sign) {
-    if (!rsa_check_digest_size(hash_nid, digest_len)) {
-      return 0;
-    }
     // All supported digest lengths fit in |unsigned|.
     assert(digest_len <= EVP_MAX_MD_SIZE);
     OPENSSL_STATIC_ASSERT(EVP_MAX_MD_SIZE <= UINT_MAX, digest_too_long);
@@ -570,6 +544,11 @@ int rsa_sign_no_self_test(int hash_nid, const uint8_t *digest,
   size_t signed_msg_len = 0;
   int signed_msg_is_alloced = 0;
   size_t size_t_out_len;
+
+  if (rsa->meth->sign) {
+    return rsa->meth->sign(hash_nid, digest, digest_len, out, out_len, rsa);
+  }
+
   if (!RSA_add_pkcs1_prefix(&signed_msg, &signed_msg_len,
                             &signed_msg_is_alloced, hash_nid, digest,
                             digest_len) ||
@@ -594,7 +573,7 @@ err:
   return ret;
 }
 
-int RSA_sign(int hash_nid, const uint8_t *digest, size_t digest_len,
+int RSA_sign(int hash_nid, const uint8_t *digest, unsigned digest_len,
              uint8_t *out, unsigned *out_len, RSA *rsa) {
   boringssl_ensure_rsa_self_test();
 

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -301,8 +301,8 @@ OPENSSL_EXPORT int RSA_private_decrypt(size_t flen, const uint8_t *from,
 // |hash_nid|. Passing unhashed inputs will not result in a secure signature
 // scheme.
 OPENSSL_EXPORT int RSA_sign(int hash_nid, const uint8_t *digest,
-                            size_t digest_len, uint8_t *out, unsigned *out_len,
-                            RSA *rsa);
+                            unsigned digest_len, uint8_t *out,
+                            unsigned *out_len, RSA *rsa);
 
 // RSA_sign_pss_mgf1 signs |digest_len| bytes from |digest| with the public key
 // from |rsa| using RSASSA-PSS with MGF1 as the mask generation function. It
@@ -634,7 +634,7 @@ OPENSSL_EXPORT int RSA_blinding_on(RSA *rsa, BN_CTX *ctx);
 // should use instead. It returns NULL on error, or a newly-allocated |RSA| on
 // success. This function is provided for compatibility only. The |callback|
 // and |cb_arg| parameters must be NULL.
-OPENSSL_EXPORT RSA *RSA_generate_key(int bits, uint64_t e, void *callback,
+OPENSSL_EXPORT RSA *RSA_generate_key(int bits, unsigned long e, void *callback,
                                      void *cb_arg);
 
 // d2i_RSAPublicKey parses a DER-encoded RSAPublicKey structure (RFC 8017) from


### PR DESCRIPTION
This reverts commit da59eeb9ea33c24abab7af35c1fb2b75d7462d3a.

### Issues:
Down-stream customer's code requires the previous function signatures.

### Description of changes: 
Reverts changes to RSA function signatures.

### Testing:
Ran local tests in FIPS and non-FIPS modes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
