### PR TITLE
Update benchmark to support externally built aws-lc

### DIFF
--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -15,7 +15,7 @@ openssl_3_0_branch='openssl-3.0.5'
 
 function build_aws_lc_fips {
   echo "building aws-lc in FIPS mode"
-  run_build -DCMAKE_INSTALL_PREFIX="${install_dir}/aws-lc-fips" -DFIPS=1
+  run_build -DCMAKE_INSTALL_PREFIX="${install_dir}/aws-lc-fips" -DFIPS=1 -DCMAKE_BUILD_TYPE=Release
   pushd "$BUILD_ROOT"
   ninja install
   popd
@@ -58,6 +58,12 @@ function build_openssl_3_0 {
 }
 
 # We build each tool individually so we can have more insight into what is failing
+
+# Building AWS-LC always builds bssl (which includes the speed tool) with the "local" libcrypto. We
+# also support building speed.cc with an "external" aws-lc libcrypto (and openssl). This is useful
+# when we want to compare the performance of a particular FIPS release against mainline if mainline
+# has changes in speed.cc that could affect the comparison of the FIPS to non-FIPS, or if new
+# algorithms have been added to speed.cc
 build_aws_lc_fips
 echo "Testing awslc_bm with AWS-LC FIPS"
 run_build -DAWSLC_INSTALL_DIR="${install_dir}/aws-lc-fips"

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -13,47 +13,54 @@ openssl_1_0_branch='OpenSSL_1_0_2-stable'
 # failing our CI.
 openssl_3_0_branch='openssl-3.0.5'
 
+function build_aws_lc_fips {
+  echo "building aws-lc in FIPS mode"
+  run_build -DCMAKE_INSTALL_PREFIX="${install_dir}/aws-lc-fips" -DFIPS=1
+  pushd "$BUILD_ROOT"
+  ninja install
+  popd
+}
+
 function build_openssl_1_0 {
     echo "building OpenSSL 1.0"
-    git clone --branch "${openssl_1_0_branch}" "${openssl_url}" "../openssl-1.0"
+    git clone --depth 1 --branch "${openssl_1_0_branch}" "${openssl_url}" "../openssl-1.0"
     pushd "../openssl-1.0"
     mkdir -p "${install_dir}/openssl-1.0"
     ./config --prefix="${install_dir}/openssl-1.0" --openssldir="${install_dir}/openssl-1.0"
-    make "-j${NUM_CPU_THREADS}"
-    make install
+    make "-j${NUM_CPU_THREADS}" > /dev/null
+    make install_sw
     popd
     rm -rf "../openssl-1.0"
 }
 
 function build_openssl_1_1 {
     echo "building OpenSSL 1.1"
-    git clone --branch "${openssl_1_1_branch}" "${openssl_url}" "../openssl-1.1"
+    git clone --depth 1 --branch "${openssl_1_1_branch}" "${openssl_url}" "../openssl-1.1"
     pushd "../openssl-1.1"
     mkdir -p "${install_dir}/openssl-1.1"
     ./config --prefix="${install_dir}/openssl-1.1" --openssldir="${install_dir}/openssl-1.1"
-    make "-j${NUM_CPU_THREADS}"
-    make install
+    make "-j${NUM_CPU_THREADS}" > /dev/null
+    make install_sw
     popd
     rm -rf "../openssl-1.1"
 }
 
 function build_openssl_3_0 {
     echo "building OpenSSL 3.0"
-    git clone --branch "${openssl_3_0_branch}" "${openssl_url}" "../openssl-3.0"
+    git clone --depth 1 --branch "${openssl_3_0_branch}" "${openssl_url}" "../openssl-3.0"
     pushd "../openssl-3.0"
     mkdir -p "${install_dir}/openssl-3.0"
     ./Configure --prefix="${install_dir}/openssl-3.0" --openssldir="${install_dir}/openssl-3.0"
-    make "-j${NUM_CPU_THREADS}"
-    make install
+    make "-j${NUM_CPU_THREADS}" > /dev/null
+    make install_sw
     popd
     rm -rf "../openssl-3.0"
 }
 
 # We build each tool individually so we can have more insight into what is failing
-mkdir -p "${install_dir}"
-echo "Testing awslc_bm"
-mkdir -p "${install_dir}/aws_lc"
-run_build -DAWSLC_INSTALL_DIR="${install_dir}/aws_lc"
+build_aws_lc_fips
+echo "Testing awslc_bm with AWS-LC FIPS"
+run_build -DAWSLC_INSTALL_DIR="${install_dir}/aws-lc-fips"
 "${BUILD_ROOT}/tool/awslc_bm"
 
 build_openssl_1_0

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -46,8 +46,9 @@ endif()
 install(TARGETS bssl
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-function(build_benchmark target_name additional_include_dir lib_crypto)
-  message("-- Building ${target_name} benchmark using header files from ${additional_include_dir} and libcrypto from ${lib_crypto}.")
+function(build_benchmark target_name install_path)
+  find_library(lib_crypto crypto PATHS ${install_path}/lib/ ${install_path}/lib64/ NO_DEFAULT_PATH)
+  message("-- Building ${target_name} benchmark using header files from ${install_path}/include and libcrypto from ${lib_crypto}.")
   add_executable(
           ${target_name}
           speed.cc
@@ -57,7 +58,7 @@ function(build_benchmark target_name additional_include_dir lib_crypto)
   )
   # Link with the internal tool directory for shared headers with the rest of the tool instead of the top level AWS-LC
   # include directory
-  target_include_directories(${target_name} PUBLIC ${additional_include_dir} ${AWSLC_INSTALL_DIR}/include/internal/tool)
+  target_include_directories(${target_name} PUBLIC ${install_path}/include ${AWSLC_INSTALL_DIR}/include/internal/tool)
   target_link_libraries(${target_name} ${lib_crypto} ${LIBRT_FLAG})
   if(NOT MSVC AND NOT ANDROID)
     target_link_libraries(${target_name} pthread dl)
@@ -66,40 +67,35 @@ function(build_benchmark target_name additional_include_dir lib_crypto)
 endfunction()
 
 if(AWSLC_INSTALL_DIR)
-  find_library(AWS_LC_LIB_PATH crypto PATHS ${AWSLC_INSTALL_DIR}/lib/ NO_DEFAULT_PATH)
-  build_benchmark(awslc_bm ${AWSLC_INSTALL_DIR}/include ${AWS_LC_LIB_PATH})
+  build_benchmark(awslc_bm ${AWSLC_INSTALL_DIR})
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/
 # Currently this is the default OpenSSL build we target so the "OPENSSL_1_1_BENCHMARK" flag isn't used, 
 # but we include this to maintain uniformity across OpenSSL versions
 if(OPENSSL_1_1_INSTALL_DIR)
-  find_library(OPENSSL_1_1_LIB_PATH crypto PATHS ${OPENSSL_1_1_INSTALL_DIR}/lib/ NO_DEFAULT_PATH)
-  build_benchmark(ossl_1_1_bm ${OPENSSL_1_1_INSTALL_DIR}/include ${OPENSSL_1_1_LIB_PATH})
+  build_benchmark(ossl_1_1_bm ${OPENSSL_1_1_INSTALL_DIR})
   target_compile_options(ossl_1_1_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_1_1_BENCHMARK)
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/
 if(OPENSSL_1_0_INSTALL_DIR)
-  find_library(OPENSSL_1_0_LIB_PATH crypto PATHS ${OPENSSL_1_0_INSTALL_DIR}/lib/ NO_DEFAULT_PATH)
-  build_benchmark(ossl_1_0_bm ${OPENSSL_1_0_INSTALL_DIR}/include ${OPENSSL_1_0_LIB_PATH})
+  build_benchmark(ossl_1_0_bm ${OPENSSL_1_0_INSTALL_DIR})
   target_compile_options(ossl_1_0_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_1_0_BENCHMARK)
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/ or lib64/
 if(OPENSSL_3_0_INSTALL_DIR)
+  build_benchmark(ossl_3_0_bm ${OPENSSL_3_0_INSTALL_DIR})
+  target_compile_options(ossl_3_0_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_3_0_BENCHMARK)
   if(NOT MSVC)
     # The low-level function calls are deprecated for OpenSSL 3.0. We should revisit using these in the future,
     # but disabling the warnings works for now
-    add_definitions("-Wno-deprecated-declarations")
+    target_compile_options(ossl_3_0_bm PUBLIC -Wno-deprecated-declarations)
+
   endif ()
-  find_library(OPENSSL_3_0_LIB_PATH crypto PATHS ${OPENSSL_3_0_INSTALL_DIR}/lib64/ ${OPENSSL_3_0_INSTALL_DIR}/lib/ NO_DEFAULT_PATH)
-  build_benchmark(ossl_3_0_bm ${OPENSSL_3_0_INSTALL_DIR}/include ${OPENSSL_3_0_LIB_PATH})
-  target_compile_options(ossl_3_0_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_3_0_BENCHMARK)
 endif()
 
-
 if(BORINGSSL_INSTALL_DIR)
-  find_library(BORINGSSL_LIB_PATH crypto PATHS ${OPENSSL_1_0_INSTALL_DIR}/build/crypto NO_DEFAULT_PATH)
-  build_benchmark(bssl_bm ${BORINGSSL_INSTALL_DIR}/include ${BORINGSSL_LIB_PATH})
+  build_benchmark(bssl_bm ${BORINGSSL_INSTALL_DIR})
 endif()

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -20,7 +20,8 @@ add_executable(
   transport_common.cc
 )
 
-target_include_directories(bssl PUBLIC ${AWSLC_INSTALL_DIR}/include ${AWSLC_INSTALL_DIR}/include/internal/tool)
+target_include_directories(bssl PUBLIC ../include)
+target_compile_options(bssl PUBLIC -DINTERNAL_TOOL)
 
 add_dependencies(bssl global_target)
 
@@ -58,14 +59,15 @@ function(build_benchmark target_name additional_include_dir lib_crypto)
   # include directory
   target_include_directories(${target_name} PUBLIC ${additional_include_dir} ${AWSLC_INSTALL_DIR}/include/internal/tool)
   target_link_libraries(${target_name} ${lib_crypto} ${LIBRT_FLAG})
+  if(NOT MSVC AND NOT ANDROID)
+    target_link_libraries(${target_name} pthread dl)
+  endif()
+
 endfunction()
 
 if(AWSLC_INSTALL_DIR)
-  build_benchmark(awslc_bm ${AWSLC_INSTALL_DIR}/include crypto)
-
-  if(NOT CMAKE_BUILD_TYPE)
-    target_compile_options(awslc_bm PUBLIC -DCMAKE_BUILD_TYPE_DEBUG)
-  endif()
+  find_library(AWS_LC_LIB_PATH crypto PATHS ${AWSLC_INSTALL_DIR}/lib/ NO_DEFAULT_PATH)
+  build_benchmark(awslc_bm ${AWSLC_INSTALL_DIR}/include ${AWS_LC_LIB_PATH})
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/
@@ -74,22 +76,14 @@ endif()
 if(OPENSSL_1_1_INSTALL_DIR)
   find_library(OPENSSL_1_1_LIB_PATH crypto PATHS ${OPENSSL_1_1_INSTALL_DIR}/lib/ NO_DEFAULT_PATH)
   build_benchmark(ossl_1_1_bm ${OPENSSL_1_1_INSTALL_DIR}/include ${OPENSSL_1_1_LIB_PATH})
-
   target_compile_options(ossl_1_1_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_1_1_BENCHMARK)
-  if(NOT MSVC AND NOT ANDROID)
-    target_link_libraries(ossl_1_1_bm pthread dl)
-  endif()
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/
 if(OPENSSL_1_0_INSTALL_DIR)
   find_library(OPENSSL_1_0_LIB_PATH crypto PATHS ${OPENSSL_1_0_INSTALL_DIR}/lib/ NO_DEFAULT_PATH)
   build_benchmark(ossl_1_0_bm ${OPENSSL_1_0_INSTALL_DIR}/include ${OPENSSL_1_0_LIB_PATH})
-
   target_compile_options(ossl_1_0_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_1_0_BENCHMARK)
-  if(NOT MSVC AND NOT ANDROID)
-    target_link_libraries(ossl_1_0_bm pthread dl)
-  endif()
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/ or lib64/
@@ -101,20 +95,11 @@ if(OPENSSL_3_0_INSTALL_DIR)
   endif ()
   find_library(OPENSSL_3_0_LIB_PATH crypto PATHS ${OPENSSL_3_0_INSTALL_DIR}/lib64/ ${OPENSSL_3_0_INSTALL_DIR}/lib/ NO_DEFAULT_PATH)
   build_benchmark(ossl_3_0_bm ${OPENSSL_3_0_INSTALL_DIR}/include ${OPENSSL_3_0_LIB_PATH})
-
-
   target_compile_options(ossl_3_0_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_3_0_BENCHMARK)
-  if(NOT MSVC AND NOT ANDROID)
-    target_link_libraries(ossl_3_0_bm pthread dl)
-  endif()
 endif()
 
-# This expects a directory in which the includes are in include/ and the BoringSSL artifacts are in build/
+
 if(BORINGSSL_INSTALL_DIR)
   find_library(BORINGSSL_LIB_PATH crypto PATHS ${OPENSSL_1_0_INSTALL_DIR}/build/crypto NO_DEFAULT_PATH)
   build_benchmark(bssl_bm ${BORINGSSL_INSTALL_DIR}/include ${BORINGSSL_LIB_PATH})
-
-  if(NOT MSVC AND NOT ANDROID)
-    target_link_libraries(bssl_bm pthread)
-  endif()
 endif()

--- a/tool/bssl_bm.h
+++ b/tool/bssl_bm.h
@@ -26,8 +26,10 @@
 #include <openssl/trust_token.h>
 #include <openssl/cipher.h>
 
+#if defined(INTERNAL_TOOL)
 #include <../crypto/ec_extra/internal.h>
 #include <../crypto/trust_token/internal.h>
+#endif
 
 #define BM_NAMESPACE bssl
 #define BM_ECDSA_size(key) ECDSA_size(key)

--- a/tool/ossl_bm.h
+++ b/tool/ossl_bm.h
@@ -80,21 +80,4 @@ OSSL_MAKE_DELETER(EVP_MD_CTX, EVP_MD_CTX_destroy)
 #endif
 } // namespace ossl
 
-// align_pointer returns |ptr|, advanced to |alignment|. |alignment| must be a
-// power of two, and |ptr| must have at least |alignment - 1| bytes of scratch
-// space.
-static inline void *align_pointer(void *ptr, size_t alignment) {
-  // |alignment| must be a power of two.
-  assert(alignment != 0 && (alignment & (alignment - 1)) == 0);
-  // Instead of aligning |ptr| as a |uintptr_t| and casting back, compute the
-  // offset and advance in pointer space. C guarantees that casting from pointer
-  // to |uintptr_t| and back gives the same pointer, but general
-  // integer-to-pointer conversions are implementation-defined. GCC does define
-  // it in the useful way, but this makes fewer assumptions.
-  uintptr_t offset = (0u - (uintptr_t)ptr) & (alignment - 1);
-  ptr = (char *)ptr + offset;
-  assert(((uintptr_t)ptr & (alignment - 1)) == 0);
-  return ptr;
-}
-
 #endif //OPENSSL_HEADER_TOOL_OSSLBM_H

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -42,6 +42,25 @@ OPENSSL_MSVC_PRAGMA(warning(pop))
 #include <time.h>
 #endif
 
+#if !defined(INTERNAL_TOOL)
+// align_pointer returns |ptr|, advanced to |alignment|. |alignment| must be a
+// power of two, and |ptr| must have at least |alignment - 1| bytes of scratch
+// space.
+static inline void *align_pointer(void *ptr, size_t alignment) {
+  // |alignment| must be a power of two.
+  assert(alignment != 0 && (alignment & (alignment - 1)) == 0);
+  // Instead of aligning |ptr| as a |uintptr_t| and casting back, compute the
+  // offset and advance in pointer space. C guarantees that casting from pointer
+  // to |uintptr_t| and back gives the same pointer, but general
+  // integer-to-pointer conversions are implementation-defined. GCC does define
+  // it in the useful way, but this makes fewer assumptions.
+  uintptr_t offset = (0u - (uintptr_t)ptr) & (alignment - 1);
+  ptr = (char *)ptr + offset;
+  assert(((uintptr_t)ptr & (alignment - 1)) == 0);
+  return ptr;
+}
+#endif
+
 static inline void *BM_memset(void *dst, int c, size_t n) {
   if (n == 0) {
     return dst;
@@ -487,13 +506,13 @@ static bool SpeedAEADChunk(const EVP_AEAD *aead, std::string name,
 
   uint8_t *const in =
       static_cast<uint8_t *>(align_pointer(in_storage.get(), kAlignment));
-  OPENSSL_memset(in, 0, chunk_len);
+  BM_memset(in, 0, chunk_len);
   uint8_t *const out =
       static_cast<uint8_t *>(align_pointer(out_storage.get(), kAlignment));
-  OPENSSL_memset(out, 0, chunk_len + overhead_len);
+  BM_memset(out, 0, chunk_len + overhead_len);
   uint8_t *const tag =
       static_cast<uint8_t *>(align_pointer(tag_storage.get(), kAlignment));
-  OPENSSL_memset(tag, 0, overhead_len);
+  BM_memset(tag, 0, overhead_len);
   uint8_t *const in2 =
       static_cast<uint8_t *>(align_pointer(in2_storage.get(), kAlignment));
 
@@ -1367,6 +1386,7 @@ static bool SpeedHRSS(const std::string &selected) {
   return true;
 }
 
+#if defined(INTERNAL_TOOL)
 static bool SpeedHashToCurve(const std::string &selected) {
   if (!selected.empty() && selected.find("hashtocurve") == std::string::npos) {
     return true;
@@ -1406,6 +1426,7 @@ static bool SpeedHashToCurve(const std::string &selected) {
 
   return true;
 }
+#endif
 
 static bool SpeedBase64(const std::string &selected) {
   if (!selected.empty() && selected.find("base64") == std::string::npos) {
@@ -1472,6 +1493,7 @@ static bool SpeedSipHash(const std::string &selected) {
   return true;
 }
 
+#if defined(INTERNAL_TOOL)
 static TRUST_TOKEN_PRETOKEN *trust_token_pretoken_dup(
     TRUST_TOKEN_PRETOKEN *in) {
   TRUST_TOKEN_PRETOKEN *out =
@@ -1709,6 +1731,7 @@ static bool SpeedTrustToken(std::string name, const TRUST_TOKEN_METHOD *method,
   return true;
 }
 #endif
+#endif
 
 #if defined(BORINGSSL_FIPS)
 static bool SpeedSelfTest(const std::string &selected) {
@@ -1895,6 +1918,7 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedRSAKeyGen(selected) ||
      !SpeedHRSS(selected) ||
      !SpeedHash(EVP_blake2b256(), "BLAKE2b-256", selected) ||
+#if defined(INTERNAL_TOOL)
      !SpeedHashToCurve(selected) ||
      !SpeedTrustToken("TrustToken-Exp1-Batch1", TRUST_TOKEN_experiment_v1(), 1, selected) ||
      !SpeedTrustToken("TrustToken-Exp1-Batch10", TRUST_TOKEN_experiment_v1(), 10, selected) ||
@@ -1902,6 +1926,7 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedTrustToken("TrustToken-Exp2VOPRF-Batch10", TRUST_TOKEN_experiment_v2_voprf(), 10, selected) ||
      !SpeedTrustToken("TrustToken-Exp2PMB-Batch1", TRUST_TOKEN_experiment_v2_pmb(), 1, selected) ||
      !SpeedTrustToken("TrustToken-Exp2PMB-Batch10", TRUST_TOKEN_experiment_v2_pmb(), 10, selected) ||
+#endif
      !SpeedBase64(selected) ||
      !SpeedSipHash(selected)
 #endif


### PR DESCRIPTION
### Description of changes: 
This fixes an issue when building the benchmark with libcrypto that happens to be AWS-LC. This is useful to test AWS-LC FIPS when new benchmarks are added to mainline that we want to run against an existing FIPS branch. Previously when building the `awslc_bm` we passed in just `crypto` which results in CMake using the `crypto` defined in crypto/CMakeLists.txt, not the libcrypto in `AWSLC_INSTALL_DIR`. This change uses the same pattern as OpenSSL which uses find_library to only search in `AWSLC_INSTALL_DIR`.

### Call-outs:
Two of the existing benchmarks (trust token and hash to curve) require internal header files. These were already disabled when building with OpenSSL. Currently we don't care a ton about these two functions so I disabled them for external AWS-LC benchmark builds.

Also update run_benchmark_build_tests.sh to suppress some of OpenSSL's build output, previously it was 27,000 lines long and kills the CodeBuild output.

### Testing:
tests/ci/run_benchmark_build_tests.sh is run by https://github.com/awslabs/aws-lc/blob/main/tests/ci/codebuild/linux-x86/run_bm_build_test.yml as a part of the normal linux x86 builds. 

Before our CI included:
```
-- Building awslc_bm benchmark using header files from /codebuild/output/src747165175/src/github.com/awslabs/aws-lc/../libcrypto_install_dir/aws_lc/include and libcrypto from crypto.
135
```

After:
```
-- Building awslc_bm benchmark using header files from /codebuild/output/src925441200/src/github.com/awslabs/aws-lc/../libcrypto_install_dir/aws-lc-fips/include and libcrypto from /codebuild/output/src925441200/src/github.com/awslabs/libcrypto_install_dir/aws-lc-fips/lib/libcrypto.a.
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
