### PR TITLE
Rust - include generated-src in crate

### DIFF
--- a/bindings/rust/aws-lc-sys-template/Cargo.toml
+++ b/bindings/rust/aws-lc-sys-template/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/awslabs/aws-lc"
 license = "Apache-2.0"
+rust-version = "1.57.0"
 include = [
     "build.rs",
     "Cargo.toml",
@@ -26,7 +27,6 @@ include = [
 asan = []
 
 [build-dependencies]
-cmake = "0.1.48"
 bindgen = "0.61"
 regex = "1"
 dunce = "1.0"

--- a/bindings/rust/aws-lc-sys-template/build.rs
+++ b/bindings/rust/aws-lc-sys-template/build.rs
@@ -245,7 +245,11 @@ fn load_env_var(var_name: &str) -> String {
 }
 
 fn build_aws_lc() -> Result<PathBuf, &'static str> {
-    let Some(cmake_cmd) = find_cmake_command() else {
+    let cmake_cmd: &OsStr;
+    if let Some(cmd) = find_cmake_command() {
+        // This can be a let-else as-of Rust 1.65
+        cmake_cmd = cmd;
+    } else {
         return Err("Missing dependency: cmake");
     };
 

--- a/bindings/rust/aws-lc-sys-template/build.rs
+++ b/bindings/rust/aws-lc-sys-template/build.rs
@@ -16,7 +16,7 @@
 // Modifications Copyright Amazon.com, Inc. or its affiliates. See GitHub history for details.
 
 use bindgen::callbacks::ParseCallbacks;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -173,12 +173,6 @@ fn get_platform_output_path() -> PathBuf {
     PathBuf::new()
 }
 
-fn get_cmake_config() -> cmake::Config {
-    let pwd = env::current_dir().unwrap();
-
-    cmake::Config::new(pwd.join(AWS_LC_PATH))
-}
-
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn prefix_string() -> String {
@@ -192,14 +186,6 @@ fn test_command(executable: &OsStr, args: &[&OsStr]) -> bool {
     false
 }
 
-fn test_perl_command() -> bool {
-    test_command("perl".as_ref(), &["--version".as_ref()])
-}
-
-fn test_go_command() -> bool {
-    test_command("go".as_ref(), &["version".as_ref()])
-}
-
 fn find_cmake_command() -> Option<&'static OsStr> {
     if test_command("cmake3".as_ref(), &["--version".as_ref()]) {
         Some("cmake3".as_ref())
@@ -210,26 +196,37 @@ fn find_cmake_command() -> Option<&'static OsStr> {
     }
 }
 
-fn prepare_cmake_build(build_prefix: Option<&str>) -> cmake::Config {
-    let mut cmake_cfg = get_cmake_config();
+fn prepare_cmake_args(
+    aws_lc_path: &Path,
+    build_prefix: Option<&str>,
+) -> Result<Vec<OsString>, &'static str> {
+    let mut args: Vec<OsString> = vec![
+        OsString::from("-DBUILD_TESTING=OFF"),
+        OsString::from("-DBUILD_LIBSSL=OFF"),
+        OsString::from("-DDISABLE_PERL=ON"),
+        OsString::from("-DDISABLE_GO=ON"),
+        aws_lc_path.as_os_str().into(),
+    ];
 
     let opt_level = env::var("OPT_LEVEL").unwrap_or_else(|_| "0".to_string());
-    if opt_level.ne("0") {
-        if opt_level.eq("1") || opt_level.eq("2") {
-            cmake_cfg.define("CMAKE_BUILD_TYPE", "relwithdebinfo");
-        } else {
-            cmake_cfg.define("CMAKE_BUILD_TYPE", "release");
-        }
+    if opt_level.eq("0") {
+        args.push(OsString::from("-DCMAKE_BUILD_TYPE=debug"));
+    } else if opt_level.eq("1") || opt_level.eq("2") {
+        args.push(OsString::from("-DCMAKE_BUILD_TYPE=relwithdebinfo"));
+    } else {
+        args.push(OsString::from("-DCMAKE_BUILD_TYPE=release"));
     }
 
     if let Some(symbol_prefix) = build_prefix {
-        cmake_cfg.define("BORINGSSL_PREFIX", symbol_prefix);
-        let pwd = env::current_dir().unwrap();
-        let include_path = pwd.join(AWS_LC_PATH).join("include");
-        cmake_cfg.define(
-            "BORINGSSL_PREFIX_HEADERS",
-            include_path.display().to_string(),
-        );
+        args.push(OsString::from(format!(
+            "-DBORINGSSL_PREFIX={}",
+            symbol_prefix
+        )));
+        let include_path = aws_lc_path.join("include");
+        args.push(OsString::from(format!(
+            "-DBORINGSSL_PREFIX_HEADERS={}",
+            include_path.display()
+        )));
     }
 
     if cfg!(feature = "asan") {
@@ -237,16 +234,66 @@ fn prepare_cmake_build(build_prefix: Option<&str>) -> cmake::Config {
         env::set_var("CXX", "/usr/bin/clang++");
         env::set_var("ASM", "/usr/bin/clang");
 
-        cmake_cfg.define("ASAN", "1");
+        args.push(OsString::from("-DASAN=1"));
     }
 
-    cmake_cfg
+    Ok(args)
 }
 
-fn build_aws_lc() -> PathBuf {
-    let mut cmake_cfg = prepare_cmake_build(Some(&prefix_string()));
+fn load_env_var(var_name: &str) -> String {
+    env::var(var_name).unwrap_or_else(|_| panic!("Missing Environment variable: {}", var_name))
+}
 
-    cmake_cfg.build_target("crypto").build()
+fn build_aws_lc() -> Result<PathBuf, &'static str> {
+    let Some(cmake_cmd) = find_cmake_command() else {
+        return Err("Missing dependency: cmake");
+    };
+
+    let pwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let aws_lc_path = pwd.join(AWS_LC_PATH);
+
+    let out_dir = PathBuf::from(load_env_var("OUT_DIR"));
+    let build_dir = out_dir.join("build");
+    if !build_dir.exists() {
+        fs::create_dir_all(build_dir.clone()).unwrap();
+    }
+
+    let mut setup_command = Command::new(cmake_cmd);
+
+    setup_command.args(prepare_cmake_args(&aws_lc_path, Some(&prefix_string()))?);
+    setup_command.current_dir(&build_dir);
+    println!("running: {:?}", setup_command);
+    let output = setup_command
+        .output()
+        .map_err(|_| "cmake setup command failed")?;
+
+    if !output.status.success() {
+        eprintln!("{}", String::from_utf8(output.stderr).unwrap());
+        return Err("cmake setup command unsuccessful");
+    }
+
+    let mut build_command = Command::new(cmake_cmd);
+    build_command.args(&[
+        OsString::from("--build"),
+        OsString::from("."),
+        OsString::from("--target"),
+        OsString::from("crypto"),
+    ]);
+    build_command.current_dir(&build_dir);
+
+    println!("running: {:?}", build_command);
+    let output = build_command
+        .output()
+        .map_err(|_| "cmake build command failed")?;
+    if !output.status.success() {
+        eprintln!("-- stdout --");
+        eprintln!("{}", String::from_utf8(output.stdout).unwrap());
+        eprintln!("-- stderr --");
+        eprintln!("{}", String::from_utf8(output.stderr).unwrap());
+        return Err("cmake build command unsuccessful.");
+    }
+
+    Ok(out_dir)
 }
 
 fn main() -> Result<(), String> {
@@ -254,15 +301,6 @@ fn main() -> Result<(), String> {
     use crate::OutputLibType::Static;
 
     let mut missing_dependency = false;
-    if !test_go_command() {
-        eprintln!("Missing dependency: go-lang");
-        missing_dependency = true;
-    }
-
-    if !test_perl_command() {
-        eprintln!("Missing dependency: perl");
-        missing_dependency = true;
-    }
 
     if let Some(cmake_cmd) = find_cmake_command() {
         env::set_var("CMAKE", cmake_cmd);
@@ -284,10 +322,10 @@ fn main() -> Result<(), String> {
     let builder = prepare_bindings_builder(&manifest_dir, Some(&prefix));
     let bindings = builder.generate().expect("Unable to generate bindings.");
     bindings
-        .write_to_file(&bindings_file)
+        .write_to_file(bindings_file)
         .expect("Unable to write bindings to file.");
 
-    let aws_lc_dir = build_aws_lc();
+    let aws_lc_dir = build_aws_lc()?;
 
     let lib_file = Crypto.locate_file(&aws_lc_dir, Static, None);
     let prefixed_lib_file = Crypto.locate_file(&aws_lc_dir, Static, Some(&prefix));

--- a/bindings/rust/generate/generate.sh
+++ b/bindings/rust/generate/generate.sh
@@ -43,7 +43,7 @@ done
 
 shift $((OPTIND - 1))
 
-AWS_LC_SYS_VERSION="0.1.2"
+AWS_LC_SYS_VERSION="0.2.0"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 AWS_LC_DIR=$( cd -- "${SCRIPT_DIR}/../../../" &> /dev/null && pwd)


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Added `generated-src` to the crate, removing need for Perl and Golang.
* Removed `ssl` and other unnecessary files. Verified crate size is now ~5MB.
* Removed dependence on `cmake-rs` so that build options can be passed prior to build path.
* Updated `aws-lc-sys` crate version to `0.2.0`
* Added verification of backwards compatible public api to the `publish.sh` script.
* Set minimum supported rust version to 1.57.0.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
* Ran the generate/publish scripts (but didn't publish).  Verified crate size if ~4.8MB:
```
➜ du -h tmp/aws-lc-sys/target/package/aws-lc-sys-0.2.0.crate 
4.8M	tmp/aws-lc-sys/target/package/aws-lc-sys-0.2.0.crate
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
