### PR TITLE
Increment API Version

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -194,7 +194,7 @@ extern "C" {
 #define SSLEAY_VERSION_NUMBER OPENSSL_VERSION_NUMBER
 
 // BORINGSSL_API_VERSION is replaced with AWSLC_API_VERSION to avoid users interpreting AWSLC as BoringSSL.
-// Below are BorringSSL's comments on BORINGSSL_API_VERSION.
+// Below are BoringSSL's comments on BORINGSSL_API_VERSION.
 // BORINGSSL_API_VERSION is a positive integer that increments as BoringSSL
 // changes over time. The value itself is not meaningful. It will be incremented
 // whenever is convenient to coordinate an API change with consumers. This will
@@ -204,7 +204,7 @@ extern "C" {
 // against multiple revisions of BoringSSL at the same time. It is not
 // recommended to do so for longer than is necessary.
 
-#define AWSLC_API_VERSION 19
+#define AWSLC_API_VERSION 20
 
 // This string tracks the most current production release version on Github
 // https://github.com/awslabs/aws-lc/releases.


### PR DESCRIPTION
### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving,
explain why this change is necessary.

This increments `AWSLC_API_VERSION` so that S2N's build can determine whether or not AWS-LC has a usable Kyber implementation. Long-term we aim to remove S2N's private Kyber implementation and standardize on the one provided by AWS-LC.

[Related PR in S2N](https://github.com/aws/s2n-tls/pull/3634)

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

- Checked that `AWSLC_API_VERSION` 19 predates the requisite change, so we needed to increment this version number to affect the S2N build

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

- Built the changes and ran unit tests on Mac and Ubuntu.
- Used resulting AWS-LC build in an S2N build and validated that the change had the intended effect.
- More testing details in the related PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
