### PR TITLE
Create a variable per benchmark built to avoid CMake caching the result of find_library

### DIFF
--- a/tests/ci/build_run_benchmarks.sh
+++ b/tests/ci/build_run_benchmarks.sh
@@ -25,29 +25,23 @@ git clone https://github.com/awslabs/aws-lc.git aws-lc-prod
 
 # build AWSLC pr
 mkdir -p "${PR_FOLDER_NAME}"/build
-mkdir -p "${PR_FOLDER_NAME}"/install
 ${CMAKE_COMMAND} -B"${PR_FOLDER_NAME}"/build -H"${PR_FOLDER_NAME}" -GNinja -DCMAKE_BUILD_TYPE=Release \
-  -DAWSLC_INSTALL_DIR="${AWSLC_PR_ROOT}"/install \
-  -DCMAKE_INSTALL_PREFIX="${AWSLC_PR_ROOT}"/install \
   -DBUILD_TESTING=OFF
 ninja -C "${PR_FOLDER_NAME}"/build
 
 # build FIPS compliant version of AWSLC pr
 mkdir -p "${PR_FOLDER_NAME}"/fips_build
-mkdir -p "${PR_FOLDER_NAME}"/fips_install
-${CMAKE_COMMAND} -B"${PR_FOLDER_NAME}"/fips_build -H"${PR_FOLDER_NAME}" -GNinja -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DAWSLC_INSTALL_DIR="${AWSLC_PR_ROOT}"/fips_install -DBUILD_SHARED_LIBS=TRUE -DCMAKE_INSTALL_PREFIX="${AWSLC_PR_ROOT}"/fips_install
+${CMAKE_COMMAND} -B"${PR_FOLDER_NAME}"/fips_build -H"${PR_FOLDER_NAME}" -GNinja -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=TRUE
 ninja -C "${PR_FOLDER_NAME}"/fips_build
 
 # build AWSLC prod
 mkdir -p aws-lc-prod/build
-mkdir -p aws-lc-prod/install
-${CMAKE_COMMAND} -Baws-lc-prod/build -Haws-lc-prod -GNinja -DCMAKE_BUILD_TYPE=Release -DAWSLC_INSTALL_DIR="${AWSLC_PROD_ROOT}/install" -DCMAKE_INSTALL_PREFIX="${AWSLC_PROD_ROOT}/install" -DBUILD_TESTING=OFF
+${CMAKE_COMMAND} -Baws-lc-prod/build -Haws-lc-prod -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
 ninja -C aws-lc-prod/build
 
 #build FIPS compliant version of AWSLC prod
 mkdir -p aws-lc-prod/fips_build
-mkdir -p aws-lc-prod/fips_install
-${CMAKE_COMMAND} -Baws-lc-prod/fips_build -Haws-lc-prod -GNinja -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DAWSLC_INSTALL_DIR="${AWSLC_PROD_ROOT}/fips_install" -DBUILD_SHARED_LIBS=TRUE -DCMAKE_INSTALL_PREFIX="${AWSLC_PROD_ROOT}/fips_install"
+${CMAKE_COMMAND} -Baws-lc-prod/fips_build -Haws-lc-prod -GNinja -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=TRUE
 ninja -C aws-lc-prod/fips_build
 
 ./"${PR_FOLDER_NAME}"/build/tool/awslc_bm -timeout 1 -json > aws-lc-pr_bm.json

--- a/tests/ci/build_run_benchmarks.sh
+++ b/tests/ci/build_run_benchmarks.sh
@@ -44,17 +44,17 @@ mkdir -p aws-lc-prod/fips_build
 ${CMAKE_COMMAND} -Baws-lc-prod/fips_build -Haws-lc-prod -GNinja -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=TRUE
 ninja -C aws-lc-prod/fips_build
 
-./"${PR_FOLDER_NAME}"/build/tool/awslc_bm -timeout 1 -json > aws-lc-pr_bm.json
-./"${PR_FOLDER_NAME}"/fips_build/tool/awslc_bm -timeout 1 -json > aws-lc-pr_fips_bm.json
+./"${PR_FOLDER_NAME}"/build/tool/bssl speed -timeout 1 -json > aws-lc-pr_bm.json
+./"${PR_FOLDER_NAME}"/fips_build/tool/bssl speed -timeout 1 -json > aws-lc-pr_fips_bm.json
 
-./aws-lc-prod/build/tool/awslc_bm -timeout 1 -json > aws-lc-prod_bm.json
-./aws-lc-prod/fips_build/tool/awslc_bm -timeout 1 -json > aws-lc-prod_fips_bm.json
+./aws-lc-prod/build/tool/bssl speed -timeout 1 -json > aws-lc-prod_bm.json
+./aws-lc-prod/fips_build/tool/bssl speed -timeout 1 -json > aws-lc-prod_fips_bm.json
 
 
-./"${PR_FOLDER_NAME}"/build/tool/awslc_bm -filter trusttoken -timeout 1 -json > aws-lc-pr_tt_bm.json
-./"${PR_FOLDER_NAME}"/fips_build/tool/awslc_bm -filter trusttoken -timeout 1 -json > aws-lc-pr_tt_fips_bm.json
-./aws-lc-prod/build/tool/awslc_bm -filter trusttoken -timeout 1 -json > aws-lc-prod_tt_bm.json
-./aws-lc-prod/fips_build/tool/awslc_bm -filter trusttoken -timeout 1 -json > aws-lc-prod_tt_fips_bm.json
+./"${PR_FOLDER_NAME}"/build/tool/bssl speed -filter trusttoken -timeout 1 -json > aws-lc-pr_tt_bm.json
+./"${PR_FOLDER_NAME}"/fips_build/tool/bssl speed -filter trusttoken -timeout 1 -json > aws-lc-pr_tt_fips_bm.json
+./aws-lc-prod/build/tool/bssl speed -filter trusttoken -timeout 1 -json > aws-lc-prod_tt_bm.json
+./aws-lc-prod/fips_build/tool/bssl speed -filter trusttoken -timeout 1 -json > aws-lc-prod_tt_fips_bm.json
 
 # convert results from .json to .csv
 python3 "${PR_FOLDER_NAME}"/tests/ci/benchmark_framework/convert_json_to_csv.py aws-lc-pr_bm.json

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -47,8 +47,8 @@ install(TARGETS bssl
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 function(build_benchmark target_name install_path)
-  find_library(lib_crypto crypto PATHS ${install_path}/lib/ ${install_path}/lib64/ NO_DEFAULT_PATH)
-  message("-- Building ${target_name} benchmark using header files from ${install_path}/include and libcrypto from ${lib_crypto}.")
+  find_library(libcrypto-${target_name} crypto PATHS ${install_path}/lib/ ${install_path}/lib64/ NO_DEFAULT_PATH)
+  message(STATUS "Building ${target_name} benchmark using header files from ${install_path}/include and libcrypto from ${libcrypto-${target_name}}.")
   add_executable(
           ${target_name}
           speed.cc
@@ -59,7 +59,7 @@ function(build_benchmark target_name install_path)
   # Link with the internal tool directory for shared headers with the rest of the tool instead of the top level AWS-LC
   # include directory
   target_include_directories(${target_name} PUBLIC ${install_path}/include ${AWSLC_INSTALL_DIR}/include/internal/tool)
-  target_link_libraries(${target_name} ${lib_crypto} ${LIBRT_FLAG})
+  target_link_libraries(${target_name} ${libcrypto-${target_name}} ${LIBRT_FLAG})
   if(NOT MSVC AND NOT ANDROID)
     target_link_libraries(${target_name} pthread dl)
   endif()


### PR DESCRIPTION
### Description of changes: 
In https://github.com/awslabs/aws-lc/pull/686 we changed the tool CMakeList to find the libcrypto library as a part of the build_benchmark function. However, by default CMake caches the result of the find library call and if multiple libcryptos are passed in only the first is used. To get around that create a new variable per libcrypto so CMake doesn't cache the result, CMake 3.21 add a [NO_CACHE](https://cmake.org/cmake/help/latest/command/find_library.html) option to avoid this behavior that we can use in the future.

Also specify the [message as status so it gets printed to stdout](https://cmake.org/cmake/help/latest/command/message.html) and captured by the logs.

Fix build_run_benchmarks.sh so it uses the "locally" built `bssl` executable that gets built as a part of the overall AWS-LC build. There is no need to build the local code a second time to make a targeted awslc_bm.

### Call-outs:
This wasn't caught in the `run_benchmark_build_tests.sh` integ test because it only builds one benchmark at a time instead of multiple.

### Testing:
Canary is is happy now:
```
-- Building awslc_bm benchmark using header files from /home/ec2-user/canary/install-AWS-LC-FIPS-2022-11-02/include and libcrypto from /home/ec2-user/canary/install-AWS-LC-FIPS-2022-11-02/lib64/libcrypto.a.
-- Building ossl_1_1_bm benchmark using header files from /home/ec2-user/canary/install-OpenSSL-1-1-1/include and libcrypto from /home/ec2-user/canary/install-OpenSSL-1-1-1/lib/libcrypto.so.
-- Building ossl_3_0_bm benchmark using header files from /home/ec2-user/canary/install-OpenSSL-3-0/include and libcrypto from /home/ec2-user/canary/install-OpenSSL-3-0/lib/libcrypto.so.

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
