### PR TITLE
Fix the code signing issue on M1 Macs when NO_ASM=1 (#697)

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -533,7 +533,10 @@ if(FIPS_SHARED)
     # libcrypto.dylib it crashes because the signature is not valid. To work
     # around this we add an ad-hoc signature to `libcrypto.dylib` after the
     # FIPS integrity hash is injected.
-    if (APPLE AND ARCH STREQUAL "aarch64")
+    #
+    # Note: we use CMAKE_SYSTEM_PROCESSOR directly instead of the ARCH variable
+    # because if NO_ASM build flag is defined then ARCH is set to "generic".
+    if (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64.*|ARM64|aarch64")
       add_custom_command(
         TARGET crypto POST_BUILD
         COMMAND codesign -s - $<TARGET_FILE:crypto>


### PR DESCRIPTION
PR #693 added a `codesign` post-build command to be executed when building the FIPS module on an M1 mac. The command was done only if `ARCH` is "aarch64". However, when `NO_ASM` build flag is defined the `ARCH` variable is set to "generic" instead and the `codesign` command is not called. This commit fixes the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
