### PR TITLE
RSA_check_fips param _should_ be const

### DIFF
--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -966,7 +966,7 @@ int RSA_check_fips(const RSA *key) {
     return 0;
   }
 
-  if (!RSA_sign(NID_sha256, data, sizeof(data), sig, &sig_len, key)) {
+  if (!RSA_sign(NID_sha256, data, sizeof(data), sig, &sig_len, (RSA*) key)) {
     OPENSSL_PUT_ERROR(RSA, ERR_R_INTERNAL_ERROR);
     ret = 0;
     goto cleanup;
@@ -974,7 +974,7 @@ int RSA_check_fips(const RSA *key) {
   if (boringssl_fips_break_test("RSA_PWCT")) {
     data[0] = ~data[0];
   }
-  if (!RSA_verify(NID_sha256, data, sizeof(data), sig, sig_len, key)) {
+  if (!RSA_verify(NID_sha256, data, sizeof(data), sig, sig_len, (RSA*) key)) {
     OPENSSL_PUT_ERROR(RSA, ERR_R_INTERNAL_ERROR);
     ret = 0;
   }

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -902,7 +902,7 @@ DEFINE_LOCAL_DATA(BIGNUM, g_small_factors) {
   out->flags = BN_FLG_STATIC_DATA;
 }
 
-int RSA_check_fips(RSA *key) {
+int RSA_check_fips(const RSA *key) {
   if (RSA_is_opaque(key)) {
     // Opaque keys can't be checked.
     OPENSSL_PUT_ERROR(RSA, RSA_R_PUBLIC_KEY_VALIDATION_FAILED);

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -473,7 +473,7 @@ OPENSSL_EXPORT int RSA_check_key(const RSA *rsa);
 // RSA_check_fips performs public key validity tests on |key|. It returns one if
 // they pass and zero otherwise. Opaque keys always fail. This function does not
 // mutate |rsa| for thread-safety purposes and may be used concurrently.
-OPENSSL_EXPORT int RSA_check_fips(RSA *key);
+OPENSSL_EXPORT int RSA_check_fips(const RSA *key);
 
 // RSA_verify_PKCS1_PSS_mgf1 verifies that |EM| is a correct PSS padding of
 // |mHash|, where |mHash| is a digest produced by |Hash|. |EM| must point to


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
The `RSA *key` parameter to `RSA_check_fips` should be `const`.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
