### PR TITLE
Enable AES-256-XTS benchmark for OpenSSL 1.0.* which does support it

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -727,7 +727,6 @@ static bool SpeedAESBlock(const std::string &name, unsigned bits,
   return true;
 }
 
-#if !defined(OPENSSL_1_0_BENCHMARK)
 static bool SpeedAES256XTS(const std::string &name, //const size_t in_len,
                            const std::string &selected) {
   if (!selected.empty() && name.find(selected) == std::string::npos) {
@@ -797,7 +796,6 @@ static bool SpeedAES256XTS(const std::string &name, //const size_t in_len,
 
   return true;
 }
-#endif
 
 static bool SpeedHashChunk(const EVP_MD *md, std::string name,
                            size_t chunk_len) {
@@ -1891,10 +1889,7 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedAESGCM(EVP_aes_128_gcm(), "EVP-AES-128-GCM", kTLSADLen, selected) ||
      !SpeedAESGCM(EVP_aes_192_gcm(), "EVP-AES-192-GCM", kTLSADLen, selected) ||
      !SpeedAESGCM(EVP_aes_256_gcm(), "EVP-AES-256-GCM", kTLSADLen, selected) ||
-     // OpenSSL 1.0 doesn't support AES-XTS
-#if !defined(OPENSSL_1_0_BENCHMARK)
      !SpeedAES256XTS("AES-256-XTS", selected) ||
-#endif
      // OpenSSL 3.0 doesn't allow MD4 calls
 #if !defined(OPENSSL_3_0_BENCHMARK)
      !SpeedHash(EVP_md4(), "MD4", selected) ||


### PR DESCRIPTION
### Description of changes: 
Enable the existing AES-256-XTS benchmark that works with OpenSSL 1.0.2. Thanks to Craig for noticing we were missing this data and that OpenSSL already supports it.  

### Testing:
```
ossl_1_0_bm -filter XTS
Did 7435000 AES-256-XTS init and encrypt (16 bytes) operations in 1000062us (7434539.1 ops/sec): 119.0 MB/s
Did 5887000 AES-256-XTS init and encrypt (256 bytes) operations in 1000142us (5886164.2 ops/sec): 1506.9 MB/s
Did 2648000 AES-256-XTS init and encrypt (1350 bytes) operations in 1000018us (2647952.3 ops/sec): 3574.7 MB/s
Did 608000 AES-256-XTS init and encrypt (8192 bytes) operations in 1001113us (607324.0 ops/sec): 4975.2 MB/s
Did 319000 AES-256-XTS init and encrypt (16384 bytes) operations in 1001200us (318617.7 ops/sec): 5220.2 MB/s
Did 7394000 AES-256-XTS init and decrypt (16 bytes) operations in 1000125us (7393075.9 ops/sec): 118.3 MB/s
Did 6246750 AES-256-XTS init and decrypt (256 bytes) operations in 1000027us (6246581.3 ops/sec): 1599.1 MB/s
Did 2578000 AES-256-XTS init and decrypt (1350 bytes) operations in 1000025us (2577935.6 ops/sec): 3480.2 MB/s
Did 619000 AES-256-XTS init and decrypt (8192 bytes) operations in 1000472us (618708.0 ops/sec): 5068.5 MB/s
Did 321000 AES-256-XTS init and decrypt (16384 bytes) operations in 1002549us (320183.9 ops/sec): 5245.9 MB/s

ldd tool/ossl_1_0_bm
	libcrypto.so.1.0.0 => /workplace/oss/install-openssl-102/lib/libcrypto.so.1.0.0 (0x00007efdc09af000)

bssl speed -filter XTS
Did 8011000 AES-256-XTS init and encrypt (16 bytes) operations in 1000097us (8010223.0 ops/sec): 128.2 MB/s
Did 6229000 AES-256-XTS init and encrypt (256 bytes) operations in 1000095us (6228408.3 ops/sec): 1594.5 MB/s
Did 2760000 AES-256-XTS init and encrypt (1350 bytes) operations in 1000048us (2759867.5 ops/sec): 3725.8 MB/s
Did 554000 AES-256-XTS init and encrypt (8192 bytes) operations in 1001010us (553441.0 ops/sec): 4533.8 MB/s
Did 315000 AES-256-XTS init and encrypt (16384 bytes) operations in 1000747us (314764.9 ops/sec): 5157.1 MB/s
Did 9204000 AES-256-XTS init and decrypt (16 bytes) operations in 1000011us (9203898.8 ops/sec): 147.3 MB/s
Did 6946000 AES-256-XTS init and decrypt (256 bytes) operations in 1000097us (6945326.3 ops/sec): 1778.0 MB/s
Did 2694000 AES-256-XTS init and decrypt (1350 bytes) operations in 1000271us (2693270.1 ops/sec): 3635.9 MB/s
Did 608000 AES-256-XTS init and decrypt (8192 bytes) operations in 1000041us (607975.1 ops/sec): 4980.5 MB/s
Did 318000 AES-256-XTS init and decrypt (16384 bytes) operations in 1000263us (317916.4 ops/sec): 5208.7 MB/s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
