### PR TITLE
Update TimeFunction to avoid FIPS self check time affecting results

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -163,13 +163,11 @@ static uint64_t g_timeout_seconds = 1;
 static std::vector<size_t> g_chunk_lengths = {16, 256, 1350, 8192, 16384};
 
 static bool TimeFunction(TimeResults *results, std::function<bool()> func) {
-#if defined(BORINGSSL_FIPS)
-  // The first time |func| is called an expensive self checks might run that
+  // The first time |func| is called an expensive self check might run that
   // will skew the iterations between checks calculation
   if (!func()) {
     return false;
   }
-#endif
   // total_us is the total amount of time that we'll aim to measure a function
   // for.
   const uint64_t total_us = g_timeout_seconds * 1000000;


### PR DESCRIPTION
### Description of changes: 
Before the total time would include the time take to run |func| one additional time over the number of times reported by |done|, depending on the function number of calls can be millions or just a few thousand which can skew the results. 

The bigger issue is for FIPS builds this could run a self check the first time which is very slow and skews the results. This is a particular problem if you attempt to filter and only run a subset of the benchmarks. This self check will only be run once per algorithm so the order of tests  (or what tests are run) run can change the results.

### Testing:
Before our FIPS RSA sign look like:
```
./tool/bssl speed -filter RSA
Did 2298 RSA 2048 signing operations in 1000330us (2297.2 ops/sec)
Did 2301 RSA 2048 signing operations in 1001189us (2298.3 ops/sec)
Did 2268 RSA 2048 signing operations in 1000084us (2267.8 ops/sec)
```
After:
```
./tool/bssl speed -filter RSA
Did 2387 RSA 2048 signing operations in 1009993us (2363.4 ops/sec)
Did 2508 RSA 2048 signing operations in 1052288us (2383.4 ops/sec)
Did 2430 RSA 2048 signing operations in 1026412us (2367.5 ops/sec)
```
It looks like RSA signing is now doing ~100 more operations per second, but in reality this is closer to what AWS-LC-FIPS customers would see.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
