### PR TITLE
Bump aws-lc-sys version number

### DIFF
--- a/bindings/rust/generate/generate.sh
+++ b/bindings/rust/generate/generate.sh
@@ -43,7 +43,8 @@ done
 
 shift $((OPTIND - 1))
 
-AWS_LC_SYS_VERSION="0.2.0"
+# TODO: Match AWS-LC's Github release version when this is more stable.
+AWS_LC_SYS_VERSION="0.2.1"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 AWS_LC_DIR=$( cd -- "${SCRIPT_DIR}/../../../" &> /dev/null && pwd)


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1422`

### Description of changes: 
Bumping version number for a new public crate version

### Call-outs:
N/A

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
generation script

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
