### PR TITLE
HKDF_Expand now has a funcitoning service indicator

### DIFF
--- a/crypto/fipsmodule/hkdf/hkdf.c
+++ b/crypto/fipsmodule/hkdf/hkdf.c
@@ -60,7 +60,7 @@ int HKDF_extract(uint8_t *out_key, size_t *out_len, const EVP_MD *digest,
   // https://tools.ietf.org/html/rfc5869#section-2.2
   int ret = 0;
 
-  // We have to avoid the underlying HKDF services updating the indicator
+  // We have to avoid the underlying HMAC services updating the indicator
   // state, so we lock the state here.
   FIPS_service_indicator_lock_state();
 
@@ -134,6 +134,8 @@ int HKDF_expand(uint8_t *out_key, size_t out_len, const EVP_MD *digest,
 
 out:
   FIPS_service_indicator_unlock_state();
+  HKDFExpand_verify_service_indicator(digest);
+
   HMAC_CTX_cleanup(&hmac);
   if (ret != 1) {
     OPENSSL_PUT_ERROR(HKDF, ERR_R_HMAC_LIB);

--- a/crypto/fipsmodule/service_indicator/internal.h
+++ b/crypto/fipsmodule/service_indicator/internal.h
@@ -47,6 +47,7 @@ void EVP_PKEY_keygen_verify_service_indicator(const EVP_PKEY *pkey);
 void HMAC_verify_service_indicator(const EVP_MD *evp_md);
 void HKDF_verify_service_indicator(const EVP_MD *evp_md, const uint8_t *salt,
     size_t salt_len, size_t info_len);
+void HKDFExpand_verify_service_indicator(const EVP_MD *evp_md);
 void PBKDF2_verify_service_indicator(const EVP_MD *evp_md, size_t password_len,
                                      size_t salt_len, unsigned iterations);
 void SSHKDF_verify_service_indicator(const EVP_MD *evp_md);
@@ -98,6 +99,9 @@ OPENSSL_INLINE void HKDF_verify_service_indicator(
     OPENSSL_UNUSED const uint8_t *salt,
     OPENSSL_UNUSED size_t salt_len,
     OPENSSL_UNUSED size_t info_len) {}
+
+OPENSSL_INLINE void HKDFExpand_verify_service_indicator(
+    OPENSSL_UNUSED const EVP_MD *evp_md) {}
 
 OPENSSL_INLINE void PBKDF2_verify_service_indicator(
     OPENSSL_UNUSED const EVP_MD *evp_md, OPENSSL_UNUSED size_t password_len,

--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -380,6 +380,21 @@ void HKDF_verify_service_indicator(const EVP_MD *evp_md,
   }
 }
 
+void HKDFExpand_verify_service_indicator(const EVP_MD *evp_md) {
+  // HKDF_expand is a "KBKDF in Feedback Mode" per NIST SP800-108r1 with SHA 1,
+  // SHA224, SHA256, SHA384, and SHA512 is approved.
+  switch (evp_md->type) {
+    case NID_sha1:
+    case NID_sha224:
+    case NID_sha256:
+    case NID_sha384:
+    case NID_sha512:
+      FIPS_service_indicator_update_state();
+      break;
+    default:
+      break;
+  }
+}
 void PBKDF2_verify_service_indicator(const EVP_MD *evp_md, size_t password_len,
                                     size_t salt_len, unsigned iterations) {
   // PBKDF with SHA1, SHA224, SHA256, SHA384, and SHA512 are approved.


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-1343

### Description of changes: 
`HKDF_expand()` is a FIPS-approved "KDF in Feedback Mode" (per NIST SP800-108r1); this change adds a service indicator (and service indicator test) so we can get it FIPS certified.

CryptoAlg-1436 will add NIST test vectors from the "KDF in Feedback Mode" CAVP files to unit test `HKDF_expand()` on its own.

### Call-outs:
See CryptoAlg-1198 for the reason for this addition.

### Testing:
Ran full suite of unit tests after updating the service indicator code and service indicator tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
