### PR TITLE
fix bindgen feature for aws-lc-sys

### DIFF
--- a/bindings/rust/aws-lc-sys-template/Cargo.toml
+++ b/bindings/rust/aws-lc-sys-template/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0 OR ISC"
 rust-version = "1.57.0"
 include = [
     "build.rs",
+    "build_bindgen.rs",
     "Cargo.toml",
     "deps/aws-lc/**/*.c",
     "deps/aws-lc/**/*.cc",

--- a/bindings/rust/generate/generate.sh
+++ b/bindings/rust/generate/generate.sh
@@ -44,7 +44,7 @@ done
 shift $((OPTIND - 1))
 
 # TODO: Match AWS-LC's Github release version when this is more stable.
-AWS_LC_SYS_VERSION="0.2.1"
+AWS_LC_SYS_VERSION="0.2.2"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 AWS_LC_DIR=$( cd -- "${SCRIPT_DIR}/../../../" &> /dev/null && pwd)


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
The `build_bindgen` file wasn't being published properly along with the crate. This fixes that.

### Call-outs:
N/A

### Testing:
Tested by running `cargo package --no-verify` on the generated directory. Then ran `cargo test --features generate_bindings` on the produced package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
