### PR TITLE
Model compiler flags better for compiler feature probing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,11 +260,6 @@ if (GCC)
 endif ()
 
 if(GCC OR CLANG)
-  check_compiler("stdalign_check.c" AWS_LC_STDALIGN_AVAILABLE)
-  check_compiler("builtin_swap_check.c" AWS_LC_BUILTIN_SWAP_SUPPORTED)
-  if(FIPS AND NOT APPLE)
-    check_compiler("linux_u32.c" AWS_LC_URANDOM_U32)
-  endif()
   # Note clang-cl is odd and sets both CLANG and MSVC. We base our configuration
   # primarily on our normal Clang one.
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
@@ -357,6 +352,12 @@ if(GCC OR CLANG)
 
   if(GCC AND "4.8" VERSION_GREATER CMAKE_C_COMPILER_VERSION AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "4.1.3")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-array-bounds")
+  endif()
+
+  check_compiler("stdalign_check.c" AWS_LC_STDALIGN_AVAILABLE)
+  check_compiler("builtin_swap_check.c" AWS_LC_BUILTIN_SWAP_SUPPORTED)
+  if(FIPS AND NOT APPLE)
+    check_compiler("linux_u32.c" AWS_LC_URANDOM_U32)
   endif()
 
 elseif(MSVC)

--- a/tests/compiler_features_tests/builtin_swap_check.c
+++ b/tests/compiler_features_tests/builtin_swap_check.c
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-// Builtin swap was added in GCC 4.8 https://gcc.gnu.org/gcc-4.8/changes.html. Recent versions of Clang pretend to be
-// 4.2 but they do support the builtin swap functions.
+// Builtin swap was added in GCC 4.8 https://gcc.gnu.org/gcc-4.8/changes.html.
+// Recent versions of Clang pretend to be 4.2 but they do support the builtin
+// swap functions.
 
 #include <stdint.h>
+#include <stdlib.h>
 
-int main() {
+int main(int argc, char **argv) {
     uint16_t test16 = 0;
     test16 = __builtin_bswap16(test16);
 
@@ -15,4 +17,6 @@ int main() {
 
     uint64_t test64 = 0;
     test64 = __builtin_bswap64(test64);
+
+    return EXIT_SUCCESS;
 }

--- a/tests/compiler_features_tests/linux_u32.c
+++ b/tests/compiler_features_tests/linux_u32.c
@@ -1,16 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-// This file is to check if <linux/random.h> can be included.
-// Currently, I assume the compiler error is caused by '__u32' is not defined.
-// Background:
-// crypto/fipsmodule/rand/urandom.c includes below Linux header file for FIPS.
-// Some old Linux OS does not define '__u32', and then reports below error.
+// This file checks if <linux/random.h> can be included. Currently, we assume
+// that the compiler error is caused by '__u32' not being defined.
+// Theory:
+// crypto/fipsmodule/rand/urandom.c includes the <linux/random.h> Linux header.
+// Some old Linux OS does not define '__u32' causing the following error:
 // /usr/include/linux/random.h:38:2: error: unknown type name '__u32'
 // __u32 buf[0];
 // ^
 #include <linux/random.h>
 
-int main() {
-    return 0;
+int main(int argc, char **argv) {
+    return EXIT_SUCCESS;
 }

--- a/tests/compiler_features_tests/stdalign_check.c
+++ b/tests/compiler_features_tests/stdalign_check.c
@@ -1,14 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-// Old versions of GCC don't support __has_include which could be used to check for stdalign.h, try to compile this
-// instead.
+// Old versions of GCC don't support __has_include which could be used to check
+// for stdalign.h, try to compile this instead.
 
 #include <stdalign.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <stdlib.h>
 
-int main() {
+int main(int argc, char **argv) {
     alignas(8) uint8_t test[16];
     size_t alignment = alignof(uint8_t);
+
+    test[0] = 0;
+
+    // Try to eliminate dead store optimisation and similar
+    if (alignment == 1000 && test[0] != 0) {
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
### Issues:

CryptoAlg-1476

### Description of changes: 

Compiler flags are not yet populated during compiler feature probing for `gcc`/`clang`. Better model compiler flags during compiler feature probing by moving the probing to succeed it.

This also better models the `bb` environment.

Also fix-up comments for all feature probes and correct some issues discovered when adding more compiler diagnostics.

### Testing:

See CryptoAlg-1476 for some additional tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
