### PR TITLE
Jitter: re-establish time_backwards

### DIFF
--- a/third_party/jitterentropy/jitterentropy-base.c
+++ b/third_party/jitterentropy/jitterentropy-base.c
@@ -472,6 +472,18 @@ int jent_time_entropy_init(unsigned int enable_notime)
 		jent_gcd_add_value(delta_history, delta, i);
 	}
 
+	/*
+	 * we allow up to three times the time running backwards.
+	 * CLOCK_REALTIME is affected by adjtime and NTP operations. Thus,
+	 * if such an operation just happens to interfere with our test, it
+	 * should not fail. The value of 3 should cover the NTP case being
+	 * performed during our test run.
+	 */
+	if (time_backwards > 3) {
+		ret = ENOMONOTONIC;
+		goto out;
+	}
+
 	/* First, did we encounter a health test failure? */
 	if ((health_test_result = jent_health_failure(ec))) {
 		ret = (health_test_result & JENT_RCT_FAILURE) ? ERCT : EHEALTH;


### PR DESCRIPTION
### Issues:
N/A

### Description of changes:
 
Jitter: re-establish time_backwards

The check for time_backwards was accidentally lost in the code update
for 3.1.0 version of Jitter. This was fixed in upstream in:
  https://github.com/smuellerDD/jitterentropy-library/commit/4ca4173b74afe5d99d852317c21666b2a7e6eca1

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
