### PR TITLE
Move client-side session reuse counter

### DIFF
--- a/ssl/handshake_client.cc
+++ b/ssl/handshake_client.cc
@@ -1869,6 +1869,12 @@ static enum ssl_hs_wait_t do_finish_client_handshake(SSL_HANDSHAKE *hs) {
     ssl_update_cache(ssl);
   }
 
+  if (ssl->s3->session_reused) {
+    // Update client side session hit counter on successfully reused sessions.
+    ssl_update_counter(ssl->session_ctx.get(), ssl->session_ctx->stats.sess_hit,
+                       true);
+  }
+
   hs->state = state_done;
   return ssl_hs_ok;
 }

--- a/ssl/ssl_session.cc
+++ b/ssl/ssl_session.cc
@@ -907,11 +907,6 @@ void ssl_update_cache(SSL *ssl) {
       (ctx->session_cache_mode & mode) != mode) {
     return;
   }
-  // Update client side session hit counter on successfully reused sessions.
-  if (SSL_SESSION_is_resumable(session) && !mode) {
-    ssl_update_counter(ssl->session_ctx.get(),
-                        ssl->session_ctx->stats.sess_hit, true);
-  }
 
   // Clients never use the internal session cache.
   if (ssl->server &&

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -6234,6 +6234,7 @@ TEST_P(SSLVersionTest, SessionPropertiesThreads) {
   }
   // Session has been resumed twice.
   EXPECT_EQ(SSL_CTX_sess_hits(server_ctx_.get()), 2);
+  EXPECT_EQ(SSL_CTX_sess_hits(client_ctx_.get()), 2);
 }
 #endif  // OPENSSL_THREADS
 
@@ -7809,6 +7810,9 @@ TEST_P(SSLVersionTest, SameKeyResume) {
                                      server_ctx2.get(), config));
   EXPECT_TRUE(SSL_session_reused(client.get()));
   EXPECT_TRUE(SSL_session_reused(server.get()));
+
+  // By this point, the session has been resumed twice on the client side.
+  EXPECT_EQ(SSL_CTX_sess_hits(client_ctx_.get()), 2);
 }
 
 TEST_P(SSLVersionTest, DifferentKeyNoResume) {


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1462` and `V804867912`

### Description of changes: 
Scrutinize found that the client-side's session reuse counter was unreachable. This moves the counter to a more suitable place and adds tests to verify that.

### Call-outs:
N/A

### Testing:
Added the counter at the bottom of tests where client sessions have been reused

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
