### PR TITLE
Add ARM AL2022 CI

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -207,3 +207,35 @@ batch:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2_gcc-7x_latest
+
+    - identifier: amazonlinux2022_gcc11x_aarch
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_posix_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2022_gcc-11x_latest
+
+    - identifier: amazonlinux2022_clang14x_aarch
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_posix_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2022_clang-11x_latest
+
+    - identifier: amazonlinux2022_clang14x_aarch_fips
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_fips_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2022_clang-11x_latest
+
+    - identifier: amazonlinux2022_gcc11x_aarch_fips
+      buildspec: ./tests/ci/codebuild/linux-aarch/run_fips_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2022_gcc-11x_latest

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -222,7 +222,7 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2022_clang-11x_latest
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2022_clang-14x_latest
 
     - identifier: amazonlinux2022_clang14x_aarch_fips
       buildspec: ./tests/ci/codebuild/linux-aarch/run_fips_tests.yml
@@ -230,7 +230,7 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2022_clang-11x_latest
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2022_clang-14x_latest
 
     - identifier: amazonlinux2022_gcc11x_aarch_fips
       buildspec: ./tests/ci/codebuild/linux-aarch/run_fips_tests.yml

--- a/tests/ci/docker_images/linux-aarch/amazonlinux-2022_base/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/amazonlinux-2022_base/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+FROM arm64v8/amazonlinux:2022
+
+SHELL ["/bin/bash", "-c"]
+
+# Install Valgrind for Valgrind test target even though it is not needed for the base test target.
+RUN set -ex && \
+    yum -y update && yum install -y \
+    cmake3 \
+    ninja-build \
+    perl \
+    golang \
+    which \
+    git \
+    ca-certificates \
+    wget \
+    valgrind \
+    unzip && \
+    # Based on https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install --bin-dir /usr/bin && \
+    rm -rf awscliv2.zip aws/ && \
+    yum clean packages && \
+    yum clean metadata && \
+    yum clean all && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/yum
+
+ENV GO111MODULE=on
+# Avoid "Use -buildvcs=false to disable VCS stamping." errors due to newer versions of Go
+ENV GOFLAGS="-buildvcs=false"

--- a/tests/ci/docker_images/linux-aarch/amazonlinux-2022_clang-14x/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/amazonlinux-2022_clang-14x/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+FROM amazonlinux-2022-aarch:base
+
+SHELL ["/bin/bash", "-c"]
+
+# clang 14.0.5 is the latest version versions `yum --showduplicates list clang`
+RUN set -ex && \
+    yum -y update && yum install -y \
+    clang && \
+    yum clean packages && \
+    yum clean metadata && \
+    yum clean all && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/yum
+
+ENV CC=clang
+ENV CXX=clang++

--- a/tests/ci/docker_images/linux-aarch/amazonlinux-2022_gcc-11x/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/amazonlinux-2022_gcc-11x/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+FROM amazonlinux-2022-aarch:base
+
+SHELL ["/bin/bash", "-c"]
+
+# gcc 11.3.1 is the latest version versions `yum --showduplicates list gcc`
+RUN set -ex && \
+    yum -y update && yum install -y \
+    gcc \
+    gcc-c++ && \
+    yum clean packages && \
+    yum clean metadata && \
+    yum clean all && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/yum
+
+ENV CC=gcc
+ENV CXX=g++

--- a/tests/ci/docker_images/linux-aarch/build_images.sh
+++ b/tests/ci/docker_images/linux-aarch/build_images.sh
@@ -9,6 +9,9 @@ curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ra
 docker build -t amazonlinux-2-aarch:base amazonlinux-2_base
 docker build -t amazonlinux-2-aarch:gcc-7x amazonlinux-2_gcc-7x
 docker build -t amazonlinux-2-aarch:clang-7x amazonlinux-2_clang-7x
+docker build -t amazonlinux-2022-aarch:base amazonlinux-2022_base
+docker build -t amazonlinux-2022-aarch:gcc-11x amazonlinux-2022_gcc-11x
+docker build -t amazonlinux-2022-aarch:clang-14x amazonlinux-2022_clang-14x
 docker build -t ubuntu-20.04-aarch:base ubuntu-20.04_base
 docker build -t ubuntu-20.04-aarch:gcc-7x ubuntu-20.04_gcc-7x
 docker build -t ubuntu-20.04-aarch:gcc-8x ubuntu-20.04_gcc-8x

--- a/tests/ci/docker_images/linux-aarch/push_images.sh
+++ b/tests/ci/docker_images/linux-aarch/push_images.sh
@@ -17,6 +17,8 @@ $(aws ecr get-login --no-include-email --region us-west-2)
 # Tag images with date to help find old images, CodeBuild uses the latest tag and gets updated automatically
 tag_and_push_img 'amazonlinux-2-aarch:gcc-7x' "${ECS_REPO}:amazonlinux-2_gcc-7x"
 tag_and_push_img 'amazonlinux-2-aarch:clang-7x' "${ECS_REPO}:amazonlinux-2_clang-7x"
+tag_and_push_img 'amazonlinux-2022-aarch:gcc-11x' "${ECS_REPO}:amazonlinux-2022_gcc-11x"
+tag_and_push_img 'amazonlinux-2022-aarch:clang-14x' "${ECS_REPO}:amazonlinux-2022_clang-14x"
 tag_and_push_img 'ubuntu-20.04-aarch:gcc-7x' "${ECS_REPO}:ubuntu-20.04_gcc-7x"
 tag_and_push_img 'ubuntu-20.04-aarch:gcc-8x' "${ECS_REPO}:ubuntu-20.04_gcc-8x"
 tag_and_push_img 'ubuntu-20.04-aarch:clang-7x' "${ECS_REPO}:ubuntu-20.04_clang-7x"


### PR DESCRIPTION
### Description of changes: 
This is a follow up of https://github.com/awslabs/aws-lc/pull/745 which adds ARM CI coverage. The ARM static gcc FIPS build is still skipped because run_fips_tests.sh always skips the static build on ARM and will be addressed in https://github.com/awslabs/aws-lc/pull/744.

### Call-outs:
* Static FIPS build with GCC 11 is not tested

### Testing:
Built images locally and ran test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
