### PR TITLE
Silence a GCC 12 -Warray-bounds false positive warning.

### DIFF
--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -1295,7 +1295,7 @@ static int ipv6_from_asc(unsigned char v6[16], const char *in)
             return 0;
     } else {
         /* If '::' must have less than 16 bytes */
-        if (v6stat.total == 16)
+        if (v6stat.total >= 16)
             return 0;
         /* More than three zeroes is an error */
         if (v6stat.zero_cnt > 3)


### PR DESCRIPTION
GCC 12 triggers a -Warray-bounds false positive in crypto/x509v3's IPv6 parser. Although v6stat.total cannot exceed 16 because of the callback, GCC doesn't know this and seems to get confused. Checking >= 16 seems to silence it.

The change copied from aws-lc main branch, commit:
  26c4d4d3244345d3f513e53dd1af71ec5663f502

### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving,
explain why this change is necessary.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
