### PR TITLE
Turn on static FIPS build for Android CI

### DIFF
--- a/tests/ci/android/AWSLCAndroidTestRunner/app/build.gradle
+++ b/tests/ci/android/AWSLCAndroidTestRunner/app/build.gradle
@@ -13,7 +13,11 @@ android {
     def test_apk_tag = ''
     // FIPS only works with arm64 for Android.
     if (project.hasProperty('FIPS')) {
-        cmake_args += '-DFIPS=1,-DBUILD_SHARED_LIBS=1,-DCMAKE_BUILD_TYPE=Release'
+        cmake_args += '-DFIPS=1,-DCMAKE_BUILD_TYPE=Release'
+        // Shared build. If not set, the build is static.
+        if(project.hasProperty('Shared')) {
+            cmake_args += ',-DBUILD_SHARED_LIBS=1'
+        }
         specific_abis = 'arm64-v8a'
         main_apk_tag += '_fips'
         test_apk_tag += '_fips'

--- a/tests/ci/cdk/cdk/codebuild/github_ci_android_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_android_omnibus.yaml
@@ -35,8 +35,15 @@ batch:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_MEDIUM
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_android_latest
-    - identifier: ubuntu2004_android_fips
-      buildspec: ./tests/ci/codebuild/android/run_android_fips.yml
+    - identifier: ubuntu2004_android_fips_shared_release
+      buildspec: ./tests/ci/codebuild/android/run_android_fips_shared.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_MEDIUM
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_android_latest
+    - identifier: ubuntu2004_android_fips_static_release
+      buildspec: ./tests/ci/codebuild/android/run_android_fips_static.yml
       env:
         type: LINUX_CONTAINER
         privileged-mode: true

--- a/tests/ci/codebuild/android/run_android_fips_shared.yml
+++ b/tests/ci/codebuild/android/run_android_fips_shared.yml
@@ -1,0 +1,14 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - chmod +x ./tests/ci/android/AWSLCAndroidTestRunner/gradlew
+      - cd tests/ci/
+      - python3 -m venv .env && . .env/bin/activate && pip install -r requirements.txt
+      - >
+        ./kickoff_devicefarm_job.sh
+        --test-name "AWS-LC Android FIPS ${CODEBUILD_WEBHOOK_TRIGGER} ${CODEBUILD_RESOLVED_SOURCE_VERSION}"
+        --fips true
+        --shared true
+        --action start-job

--- a/tests/ci/codebuild/android/run_android_fips_static.yml
+++ b/tests/ci/codebuild/android/run_android_fips_static.yml
@@ -10,4 +10,5 @@ phases:
         ./kickoff_devicefarm_job.sh
         --test-name "AWS-LC Android FIPS ${CODEBUILD_WEBHOOK_TRIGGER} ${CODEBUILD_RESOLVED_SOURCE_VERSION}"
         --fips true
+        --shared false
         --action start-job


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
The Android static FIPS build has confirmed to be working now.

### Call-outs:
N/A

### Testing:
Device Farm in Android CI 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
