### PR TITLE
suggested change to print_hex

### DIFF
--- a/crypto/evp_extra/print.c
+++ b/crypto/evp_extra/print.c
@@ -66,7 +66,12 @@
 
 static int print_hex(BIO *bp, const uint8_t *data, size_t len, int off) {
   for (size_t i = 0; i < len; i++) {
-    if ((i % 15) == 0) {
+    if (i == 0) {
+      if (!BIO_indent(bp, off + 4, 128)) {
+        return 0;
+      }
+    }
+    else if ((i % 15) == 0) {
       if (BIO_puts(bp, "\n") <= 0 ||  //
           !BIO_indent(bp, off + 4, 128)) {
         return 0;


### PR DESCRIPTION
### Description of changes: 

Currently, due to how the logic is written the `print_hex` function will append an extra blank link at the start of printing.  This is unconventional and is not consistent with other printed decodings. This change removes the unintentional blank line.

Current:
```
Subject Public Key Info:
            Public Key Algorithm: DILITHIUM3
                Public-Key: (1952 bit)

                    81:20:92:2f:8b:08:4a:87:a2:ec:69:5a:94:5f:0d:
                    42:9f:ed:0f:90:f0:4d:11:81:53:d3:f9:31:23:41:
                    ...
```

Fixed:
```
Subject Public Key Info:
            Public Key Algorithm: DILITHIUM3
                Public-Key: (1952 bit)
                    81:20:92:2f:8b:08:4a:87:a2:ec:69:5a:94:5f:0d:
                    42:9f:ed:0f:90:f0:4d:11:81:53:d3:f9:31:23:41:
                    ...
```

If there is a more concise way to perform the same logic I encourage a suggestion.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
