### PR TITLE
Zeroise private random data on the stack before returning

### DIFF
--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -1996,7 +1996,7 @@ void ED25519_keypair_from_seed(uint8_t out_public_key[32],
   ge_p3_tobytes(out_public_key, &A);
 
   OPENSSL_memcpy(out_private_key, seed, ED25519_SEED_LEN);
-  OPENSSL_memcpy(out_private_key + 32, out_public_key, 32);
+  OPENSSL_memcpy(out_private_key + ED25519_SEED_LEN, out_public_key, 32);
 }
 
 

--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -1874,10 +1874,13 @@ static void sc_muladd(uint8_t *s, const uint8_t *a, const uint8_t *b,
   s[31] = s11 >> 17;
 }
 
-void ED25519_keypair(uint8_t out_public_key[32], uint8_t out_private_key[64]) {
-  uint8_t seed[32];
-  RAND_bytes(seed, 32);
+#define ED25519_SEED_LEN 32
+
+void ED25519_keypair(uint8_t out_public_key[ED25519_SEED_LEN], uint8_t out_private_key[64]) {
+  uint8_t seed[ED25519_SEED_LEN];
+  RAND_bytes(seed, ED25519_SEED_LEN);
   ED25519_keypair_from_seed(out_public_key, out_private_key, seed);
+  OPENSSL_cleanse(seed, ED25519_SEED_LEN);
 }
 
 int ED25519_sign(uint8_t out_sig[64], const uint8_t *message,
@@ -1982,9 +1985,9 @@ int ED25519_verify(const uint8_t *message, size_t message_len,
 
 void ED25519_keypair_from_seed(uint8_t out_public_key[32],
                                uint8_t out_private_key[64],
-                               const uint8_t seed[32]) {
+                               const uint8_t seed[ED25519_SEED_LEN]) {
   uint8_t az[SHA512_DIGEST_LENGTH];
-  SHA512(seed, 32, az);
+  SHA512(seed, ED25519_SEED_LEN, az);
 
   az[0] &= 248;
   az[31] &= 127;
@@ -1994,7 +1997,7 @@ void ED25519_keypair_from_seed(uint8_t out_public_key[32],
   x25519_ge_scalarmult_base(&A, az);
   ge_p3_tobytes(out_public_key, &A);
 
-  OPENSSL_memcpy(out_private_key, seed, 32);
+  OPENSSL_memcpy(out_private_key, seed, ED25519_SEED_LEN);
   OPENSSL_memcpy(out_private_key + 32, out_public_key, 32);
 }
 

--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -1874,9 +1874,7 @@ static void sc_muladd(uint8_t *s, const uint8_t *a, const uint8_t *b,
   s[31] = s11 >> 17;
 }
 
-#define ED25519_SEED_LEN 32
-
-void ED25519_keypair(uint8_t out_public_key[ED25519_SEED_LEN], uint8_t out_private_key[64]) {
+void ED25519_keypair(uint8_t out_public_key[32], uint8_t out_private_key[64]) {
   uint8_t seed[ED25519_SEED_LEN];
   RAND_bytes(seed, ED25519_SEED_LEN);
   ED25519_keypair_from_seed(out_public_key, out_private_key, seed);

--- a/crypto/curve25519/spake25519.c
+++ b/crypto/curve25519/spake25519.c
@@ -439,6 +439,8 @@ int SPAKE2_generate_msg(SPAKE2_CTX *ctx, uint8_t *out, size_t *out_len,
   *out_len = sizeof(ctx->my_msg);
   ctx->state = spake2_state_msg_generated;
 
+  OPENSSL_cleanse(private_tmp, 64);
+
   return 1;
 }
 

--- a/crypto/dsa/dsa.c
+++ b/crypto/dsa/dsa.c
@@ -458,6 +458,7 @@ err:
   }
 
   BN_MONT_CTX_free(mont);
+  OPENSSL_cleanse(seed, SHA256_DIGEST_LENGTH);
 
   return ok;
 }

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -392,6 +392,8 @@ void RAND_bytes_with_additional_data(uint8_t *out, size_t out_len,
       CRYPTO_STATIC_MUTEX_unlock_write(thread_states_list_lock_bss_get());
     }
 #endif
+    OPENSSL_cleanse(seed, CTR_DRBG_ENTROPY_LEN);
+    OPENSSL_cleanse(personalization, CTR_DRBG_ENTROPY_LEN);
   }
 
   if (state->calls >= kReseedInterval ||
@@ -425,6 +427,8 @@ void RAND_bytes_with_additional_data(uint8_t *out, size_t out_len,
     }
     state->calls = 0;
     state->fork_generation = fork_generation;
+    OPENSSL_cleanse(seed, CTR_DRBG_ENTROPY_LEN);
+    OPENSSL_cleanse(add_data_for_reseed, CTR_DRBG_ENTROPY_LEN);
   } else {
 #if defined(BORINGSSL_FIPS)
     CRYPTO_STATIC_MUTEX_lock_read(state_clear_all_lock_bss_get());
@@ -454,6 +458,8 @@ void RAND_bytes_with_additional_data(uint8_t *out, size_t out_len,
   if (state == &stack_state) {
     CTR_DRBG_clear(&state->drbg);
   }
+
+  OPENSSL_cleanse(additional_data, 32);
 
 #if defined(BORINGSSL_FIPS)
   CRYPTO_STATIC_MUTEX_unlock_read(state_clear_all_lock_bss_get());

--- a/include/openssl/curve25519.h
+++ b/include/openssl/curve25519.h
@@ -71,6 +71,7 @@ OPENSSL_EXPORT void X25519_public_from_private(uint8_t out_public_value[32],
 #define ED25519_PRIVATE_KEY_LEN 64
 #define ED25519_PUBLIC_KEY_LEN 32
 #define ED25519_SIGNATURE_LEN 64
+#define ED25519_SEED_LEN 32
 
 // ED25519_keypair sets |out_public_key| and |out_private_key| to a freshly
 // generated, public–private key pair.


### PR DESCRIPTION
CryptoAlg-1524

### Description of changes: 

Zeroise private random data immediately after use. This is just good secret value hygiene.

Most is stack-allocated. So, good changes it would be overwritten fairly quickly anyway. Looked in both `/crypto` and `/ssl`, grepping my way through.

### Testing:

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
