### PR TITLE
API diff during Rust crate generation

### DIFF
--- a/bindings/rust/generate/_generate_all_bindings_flavors.sh
+++ b/bindings/rust/generate/_generate_all_bindings_flavors.sh
@@ -8,7 +8,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 AWS_LC_DIR=$( cd -- "${SCRIPT_DIR}/../../../" &> /dev/null && pwd)
 
 if [[ "${GENERATE_FIPS}" -eq 0 ]]; then
-  CRATE_NAME="aws-lc-sys"
 
    ## macos x86_64 bindings
   if [[ ! "${OSTYPE}" == "darwin"* ]]; then
@@ -42,7 +41,6 @@ if [[ "${GENERATE_FIPS}" -eq 0 ]]; then
 
   popd
 else
-  CRATE_NAME="aws-lc-fips-sys"
 
   pushd "${AWS_LC_DIR}"
 

--- a/bindings/rust/generate/generate.sh
+++ b/bindings/rust/generate/generate.sh
@@ -10,9 +10,8 @@ IGNORE_UPSTREAM=0
 IGNORE_MACOS=0
 SKIP_TEST=0
 GENERATE_FIPS=0
-
-# TODO: Match AWS-LC's Github release version when this is more stable.
-AWS_LC_SYS_VERSION="0.3.1"
+CRATE_NAME="aws-lc-sys"
+CRATE_VERSION="" # User prompted for version when empty
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 AWS_LC_DIR=$( cd -- "${SCRIPT_DIR}/../../../" &> /dev/null && pwd)
@@ -35,7 +34,7 @@ function prepare_crate_dir {
   mkdir -p "${CRATE_AWS_LC_DIR}"/
 
   cp -r "${CRATE_TEMPLATE_DIR}"/* "${CRATE_DIR}"/
-  perl -pi -e "s/__AWS_LC_SYS_VERSION__/${AWS_LC_SYS_VERSION}/g" "${CRATE_DIR}"/Cargo.toml
+  perl -pi -e "s/__AWS_LC_SYS_VERSION__/${CRATE_VERSION}/g" "${CRATE_DIR}"/Cargo.toml
 
   cp -r "${AWS_LC_DIR}"/crypto  \
         "${AWS_LC_DIR}"/ssl \
@@ -76,10 +75,16 @@ check_branch
 check_running_on_macos
 mkdir -p "${TMP_DIR}"
 
+determine_generate_version
+
 # Crate preparation.
 prepare_crate_dir
 create_prefix_headers
-source "${SCRIPT_DIR}"/_generate_all_bindings_flavors.sh 
+
+public_api_diff
+
+
+source "${SCRIPT_DIR}"/_generate_all_bindings_flavors.sh
 
 # Crate testing.
 if [[ ${SKIP_TEST} -eq 1 ]]; then

--- a/bindings/rust/publish/_publish_tools.sh
+++ b/bindings/rust/publish/_publish_tools.sh
@@ -4,16 +4,6 @@
 function publish_options {
 	while getopts "d:sp" option; do
 	  case ${option} in
-	  d )
-	    # For example:
-	    # ./publish.sh -d 0.1.1
-	    PREV_VERSION="$OPTARG"
-	    ;;
-	  # The public API diff should only be skipped if releasing a new major version
-	  # (or a new minor version when the major version number is 0).
-	  s )
-	    SKIP_DIFF=1
-	    ;;
 	  p )
 	    PUBLISH=1
 	    ;;
@@ -55,14 +45,6 @@ function run_prepublish_checks_linux {
 }
 
 function publish_crate {
-	local crate="$@"
-	if [[ "${SKIP_DIFF}" -eq 0 ]]; then
-	  if [[ "${PREV_VERSION}" == "0" ]]; then
-	    echo Aborting. Must specify previous crate version for API diff.
-	    exit 1;
-	  fi
-	  cargo public-api --deny changed --deny removed --diff-published "${crate}@${PREV_VERSION}"
-	fi
 	cargo publish --dry-run --allow-dirty --no-verify
 
 	if [[ ${PUBLISH} -eq 1 ]]; then

--- a/bindings/rust/publish/publish.sh
+++ b/bindings/rust/publish/publish.sh
@@ -24,5 +24,5 @@ find_completion_marker ${COMPLETION_MARKER}
 pushd "${CRATE_DIR}"
 remove_internal_feature
 run_prepublish_checks "${CRATE_NAME}"
-publish_crate "${CRATE_NAME}"
+publish_crate
 popd

--- a/tests/ci/docker_images/rust/build_images.sh
+++ b/tests/ci/docker_images/rust/build_images.sh
@@ -6,13 +6,19 @@
 # Build images from AWS-LC GitHub repo #
 ########################################
 
-# Ubuntu systems might not have "jq" installed:
+# Linux hosts might not have "jq" installed.
+
+# Ubuntu:
 # sudo apt-get install jq
+
+# Amazon Linux:
+# sudo yum install jq
+
 
 # Log Docker hub limit https://docs.docker.com/docker-hub/download-rate-limit/#how-can-i-check-my-current-rate
 TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
 curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
 
-docker build -t rust:linux-386 linux-386
-docker build -t rust:linux-arm64 linux-arm64
-docker build -t rust:linux-x86_64 linux-x86_64
+docker build -t rust:linux-386 linux-386 --load
+docker build -t rust:linux-arm64 linux-arm64 --load
+docker build -t rust:linux-x86_64 linux-x86_64 --load


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* During Rust crate generation, prompt user for version to compile into binary.
* Perform API-diff during crate generation process.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
Generated both `aws-lc-sys` and `aws-lc-fips-sys` crates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
