### PR TITLE
Improve X.509 GeneralName parsing.

### DIFF
--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -3548,6 +3548,8 @@ TEST(X509Test, GeneralName)  {
       {0x82, 0x01, 0x61},
       // [2 PRIMITIVE] { "b" }
       {0x82, 0x01, 0x62},
+      // [3] {}. Regression test for CVE-2023-0286.
+      {0xa3, 0x00},
       // [4] {
       //   SEQUENCE {
       //     SET {

--- a/crypto/x509v3/v3_genn.c
+++ b/crypto/x509v3/v3_genn.c
@@ -130,7 +130,7 @@ int GENERAL_NAME_cmp(const GENERAL_NAME *a, const GENERAL_NAME *b) {
 
   switch (a->type) {
     case GEN_X400:
-      return ASN1_TYPE_cmp(a->d.x400Address, b->d.x400Address);
+      return ASN1_STRING_cmp(a->d.x400Address, b->d.x400Address);
 
     case GEN_EDIPARTY:
       return edipartyname_cmp(a->d.ediPartyName, b->d.ediPartyName);

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -177,7 +177,7 @@ typedef struct GENERAL_NAME_st {
     OTHERNAME *otherName;  // otherName
     ASN1_IA5STRING *rfc822Name;
     ASN1_IA5STRING *dNSName;
-    ASN1_TYPE *x400Address;
+    ASN1_STRING *x400Address;
     X509_NAME *directoryName;
     EDIPARTYNAME *ediPartyName;
     ASN1_IA5STRING *uniformResourceIdentifier;
@@ -189,7 +189,6 @@ typedef struct GENERAL_NAME_st {
     X509_NAME *dirn;        // dirn
     ASN1_IA5STRING *ia5;    // rfc822Name, dNSName, uniformResourceIdentifier
     ASN1_OBJECT *rid;       // registeredID
-    ASN1_TYPE *other;       // x400Address
   } d;
 } GENERAL_NAME;
 


### PR DESCRIPTION
### Issues:

V819878264

### Description of changes: 

Fixes a type confusion related to CVE-2023-0286.

### Testing:

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.