### PR TITLE
Bump release FIPS version to v1.0.3

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2138,7 +2138,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.0.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.0.3");
 }
 
 #else
@@ -2183,6 +2183,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.0.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.0.3");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -206,7 +206,7 @@ extern "C" {
 // In order to keep track of any changes to AWLC we introduce a string that tracks with the public Github
 // release version at https://github.com/awslabs/aws-lc
 
-#define AWSLC_VERSION_NUMBER_STRING "1.0.2"
+#define AWSLC_VERSION_NUMBER_STRING "1.0.3"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Issues:

V819878264

### Description of changes: 

Prepare new release by bumping release version number string to `1.0.3`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
