### PR TITLE
Update Rust crate bindgen

### DIFF
--- a/bindings/rust/aws-lc-fips-sys-template/Cargo.toml
+++ b/bindings/rust/aws-lc-fips-sys-template/Cargo.toml
@@ -33,7 +33,7 @@ ssl = []
 
 [build-dependencies]
 cmake = "0.1.48"
-bindgen = { version = "0.61", optional = true }
+bindgen = { version = "0.64.0", optional = true }
 regex = "1"
 dunce = "1.0"
 cfg_aliases = "0.1.1"

--- a/bindings/rust/aws-lc-fips-sys-template/build/bindgen.rs
+++ b/bindings/rust/aws-lc-fips-sys-template/build/bindgen.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright Amazon.com, Inc. or its affiliates. See GitHub history for details.
 
 use crate::get_include_path;
-use bindgen::callbacks::ParseCallbacks;
+use bindgen::callbacks::{ParseCallbacks, ItemInfo};
 use std::fmt::Debug;
 use std::path::Path;
 
@@ -21,10 +21,10 @@ impl StripPrefixCallback {
 
 #[cfg(feature = "bindgen")]
 impl ParseCallbacks for StripPrefixCallback {
-    fn generated_name_override(&self, name: &str) -> Option<String> {
+    fn generated_name_override(&self, item_info: ItemInfo<'_>) -> Option<String> {
         self.remove_prefix.as_ref().and_then(|s| {
             let prefix = format!("{}_", s);
-            name.strip_prefix(prefix.as_str()).map(String::from)
+            item_info.name.strip_prefix(prefix.as_str()).map(String::from)
         })
     }
 }

--- a/bindings/rust/aws-lc-sys-template/Cargo.toml
+++ b/bindings/rust/aws-lc-sys-template/Cargo.toml
@@ -32,7 +32,7 @@ ssl = []
 
 [build-dependencies]
 cmake = "0.1.48"
-bindgen = { version = "0.61", optional = true }
+bindgen = { version = "0.64.0", optional = true }
 regex = "1"
 dunce = "1.0"
 cfg_aliases = "0.1.1"

--- a/bindings/rust/aws-lc-sys-template/build/bindgen.rs
+++ b/bindings/rust/aws-lc-sys-template/build/bindgen.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright Amazon.com, Inc. or its affiliates. See GitHub history for details.
 
 use crate::get_include_path;
-use bindgen::callbacks::ParseCallbacks;
+use bindgen::callbacks::{ParseCallbacks, ItemInfo};
 use std::fmt::Debug;
 use std::path::Path;
 
@@ -21,10 +21,10 @@ impl StripPrefixCallback {
 
 #[cfg(feature = "bindgen")]
 impl ParseCallbacks for StripPrefixCallback {
-    fn generated_name_override(&self, name: &str) -> Option<String> {
+    fn generated_name_override(&self, item_info: ItemInfo<'_>) -> Option<String> {
         self.remove_prefix.as_ref().and_then(|s| {
             let prefix = format!("{}_", s);
-            name.strip_prefix(prefix.as_str()).map(String::from)
+            item_info.name.strip_prefix(prefix.as_str()).map(String::from)
         })
     }
 }

--- a/bindings/rust/generate/generate-fips.sh
+++ b/bindings/rust/generate/generate-fips.sh
@@ -30,9 +30,7 @@ source "${SCRIPT_DIR}"/_generation_tools.sh
 # Clone the FIPS branch in local.
 function clone_fips_branch {
   pushd "${TMP_DIR}"
-  rm -rf aws-lc
   git clone -b ${AWS_LC_FIPS_BRANCH} --depth 1 --single-branch https://github.com/awslabs/aws-lc.git
-  AWS_LC_COMMIT_HASH=$(git -C ${AWS_LC_FIPS_DIR} log -n 1 --pretty=format:"%H" HEAD)
   popd
 }
 
@@ -96,7 +94,14 @@ mkdir -p "${TMP_DIR}"
 determine_generate_version
 
 # Crate preparation.
-clone_fips_branch
+if [[ ! -r "${SYMBOLS_FILE}" ]] || [[! -d "${AWS_LC_FIPS_DIR}" ]]; then
+  # Symbols file must be consistent with AWS-LC source directory
+  rm -f "${SYMBOLS_FILE}"
+  rm -rf "${AWS_LC_FIPS_DIR}"
+  clone_fips_branch
+fi
+AWS_LC_COMMIT_HASH=$(git -C ${AWS_LC_FIPS_DIR} log -n 1 --pretty=format:"%H" HEAD)
+
 prepare_crate_dir
 create_prefix_headers
 

--- a/bindings/rust/generate/generate.sh
+++ b/bindings/rust/generate/generate.sh
@@ -29,9 +29,7 @@ source "${SCRIPT_DIR}"/_generation_tools.sh
 # Clone the main branch in local.
 function clone_main_branch {
   pushd "${TMP_DIR}"
-  rm -rf aws-lc
   git clone -b main --depth 1 --single-branch https://github.com/awslabs/aws-lc.git
-  AWS_LC_COMMIT_HASH=$(git -C ${AWS_LC_SRC_DIR} log -n 1 --pretty=format:"%H" HEAD)
   popd
 }
 
@@ -89,7 +87,14 @@ mkdir -p "${TMP_DIR}"
 determine_generate_version
 
 # Crate preparation.
-clone_main_branch
+if [[ ! -r "${SYMBOLS_FILE}" ]] || [[! -d "${AWS_LC_SRC_DIR}" ]]; then
+  # Symbols file must be consistent with AWS-LC source directory
+  rm -f "${SYMBOLS_FILE}"
+  rm -rf "${AWS_LC_SRC_DIR}"
+  clone_main_branch
+fi
+AWS_LC_COMMIT_HASH=$(git -C ${AWS_LC_SRC_DIR} log -n 1 --pretty=format:"%H" HEAD)
+
 prepare_crate_dir
 create_prefix_headers
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Updated to bindgen 0.64 -- this fixes the problem of prefixes appearing on the bindings of external variables.
* Updated generation logic to ensure that the symbols file (used for prefixing) aligns with the AWS-LC source being used.

### Call-outs:
N/A

### Testing:
I generated both the `aws-lc-sys` (cfbc38bfbd72cfb1a680d0483381b2e93b9a3e73) and `aws-lc-fips-sys` (da2a8839affb1db4d9e3b361182c9bee16f48976) crates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
