### PR TITLE
Different symbols prefix for FIPS crate

### DIFF
--- a/bindings/rust/aws-lc-fips-sys-template/build/main.rs
+++ b/bindings/rust/aws-lc-fips-sys-template/build/main.rs
@@ -98,7 +98,7 @@ fn get_platform_output_path() -> PathBuf {
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn prefix_string() -> String {
-    format!("aws_lc_{}", VERSION.to_string().replace('.', "_"))
+    format!("aws_lc_fips_{}", VERSION.to_string().replace('.', "_"))
 }
 
 fn test_perl_command() -> bool {

--- a/bindings/rust/generate/generate-fips.sh
+++ b/bindings/rust/generate/generate-fips.sh
@@ -94,7 +94,7 @@ mkdir -p "${TMP_DIR}"
 determine_generate_version
 
 # Crate preparation.
-if [[ ! -r "${SYMBOLS_FILE}" ]] || [[! -d "${AWS_LC_FIPS_DIR}" ]]; then
+if [[ ! -r "${SYMBOLS_FILE}" || ! -d "${AWS_LC_FIPS_DIR}" ]]; then
   # Symbols file must be consistent with AWS-LC source directory
   rm -f "${SYMBOLS_FILE}"
   rm -rf "${AWS_LC_FIPS_DIR}"

--- a/bindings/rust/generate/generate.sh
+++ b/bindings/rust/generate/generate.sh
@@ -87,7 +87,7 @@ mkdir -p "${TMP_DIR}"
 determine_generate_version
 
 # Crate preparation.
-if [[ ! -r "${SYMBOLS_FILE}" ]] || [[! -d "${AWS_LC_SRC_DIR}" ]]; then
+if [[ ! -r "${SYMBOLS_FILE}" || ! -d "${AWS_LC_SRC_DIR}" ]]; then
   # Symbols file must be consistent with AWS-LC source directory
   rm -f "${SYMBOLS_FILE}"
   rm -rf "${AWS_LC_SRC_DIR}"

--- a/tests/ci/docker_images/rust/README.md
+++ b/tests/ci/docker_images/rust/README.md
@@ -23,3 +23,9 @@ $ sudo yum install -y qemu-system-aarch64 qemu-system-x86 qemu-user-binfmt
 $ docker buildx create --name=container --driver=docker-container --use
 $ docker run --privileged --rm tonistiigi/binfmt --install all
 ```
+
+This may periodically need to be reset:
+```
+$ docker run --privileged --rm tonistiigi/binfmt --uninstall arm64,arm,riscv64,mips64le,s390x,ppc64le,mips64
+$ docker run --privileged --rm tonistiigi/binfmt --install all
+```


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Use distinct prefix in `aws-lc-fips-sys` to avoid potential symbol conflict in clients.
* Fix bug in script.

### Call-outs:
N/A

### Testing:
I generated the `aws-lc-fips-sys` crate and checked the resulting symbols:
```
❯ nm -g target/debug/build/aws-lc-fips-sys-e53936c72cf350ee/out/build/crypto/libaws_lc_fips_0_5_0crypto.a | head 

a_bitstr.c.o:
                 U __assert_fail
0000000000000000 T aws_lc_fips_0_5_0_ASN1_BIT_STRING_check
                 U aws_lc_fips_0_5_0_ASN1_BIT_STRING_free
0000000000000000 T aws_lc_fips_0_5_0_ASN1_BIT_STRING_get_bit
0000000000000000 T aws_lc_fips_0_5_0_asn1_bit_string_length
                 U aws_lc_fips_0_5_0_ASN1_BIT_STRING_new
0000000000000000 T aws_lc_fips_0_5_0_ASN1_BIT_STRING_num_bytes
0000000000000000 T aws_lc_fips_0_5_0_ASN1_BIT_STRING_set
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
