### PR TITLE
Enable debug symbols for Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -787,8 +787,8 @@ if(BUILD_TESTING)
   target_include_directories(boringssl_gtest PRIVATE third_party/googletest)
 
   if(MSVC)
-    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-    set_property(TARGET boringssl_gtest APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+    # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+    set_property(TARGET boringssl_gtest APPEND PROPERTY LINK_FLAGS /DEBUG:FULL/)
   endif()
 
   include_directories(third_party/googletest/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -788,7 +788,7 @@ if(BUILD_TESTING)
 
   if(MSVC)
     # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-    set_property(TARGET boringssl_gtest APPEND PROPERTY LINK_FLAGS /DEBUG:FULL/)
+    target_link_options(boringssl_gtest PUBLIC /DEBUG:FULL)
   endif()
 
   include_directories(third_party/googletest/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -786,6 +786,11 @@ if(BUILD_TESTING)
   endif()
   target_include_directories(boringssl_gtest PRIVATE third_party/googletest)
 
+  if(MSVC)
+    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+    set_property(TARGET boringssl_gtest APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+  endif()
+
   include_directories(third_party/googletest/include)
 
   # Declare a dummy target to build all unit tests. Test targets should inject

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -533,7 +533,7 @@ function(build_libcrypto name module_source)
   
   if(MSVC)
     # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-    set_property(TARGET ${name} APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
+    target_link_options(${name} PUBLIC /DEBUG:FULL)
   endif()
 endfunction()
 
@@ -546,7 +546,7 @@ if(FIPS_SHARED)
     build_libcrypto(precrypto $<TARGET_OBJECTS:fipsmodule>)
     add_executable(fips_empty_main fipsmodule/fips_empty_main.c)
     # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-    set_property(TARGET boringssl_gtest APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
+    target_link_options(boringssl_gtest PUBLIC /DEBUG:FULL)
 
     target_link_libraries(fips_empty_main PUBLIC precrypto)
     add_custom_command(OUTPUT generated_fips_shared_support.c
@@ -658,7 +658,7 @@ if(BUILD_TESTING)
 
   if(MSVC)
     # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-    set_property(TARGET ${RANDOM_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
+    target_link_options(${RANDOM_TEST_EXEC} PUBLIC /DEBUG:FULL)
   endif()
 
   # When using CPU Jitter as the entropy source (only in FIPS build)
@@ -765,8 +765,8 @@ if(BUILD_TESTING)
   add_dependencies(all_tests ${CRYPTO_TEST_EXEC})
 
   if(MSVC)
-  # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-  set_property(TARGET ${CRYPTO_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
+    # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+    target_link_options(${CRYPTO_TEST_EXEC} PUBLIC /DEBUG:FULL)
   endif()
 
 endif()

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -532,8 +532,8 @@ function(build_libcrypto name module_source)
           $<INSTALL_INTERFACE:include>)
   
   if(MSVC)
-    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-    set_property(TARGET ${name} APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+    # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+    set_property(TARGET ${name} APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
   endif()
 endfunction()
 
@@ -545,8 +545,8 @@ if(FIPS_SHARED)
     # correct value in generated_fips_shared_support.c. See FIPS.md for a full explanation of the process
     build_libcrypto(precrypto $<TARGET_OBJECTS:fipsmodule>)
     add_executable(fips_empty_main fipsmodule/fips_empty_main.c)
-    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-    set_property(TARGET boringssl_gtest APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+    # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+    set_property(TARGET boringssl_gtest APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
 
     target_link_libraries(fips_empty_main PUBLIC precrypto)
     add_custom_command(OUTPUT generated_fips_shared_support.c
@@ -657,8 +657,8 @@ if(BUILD_TESTING)
   )
 
   if(MSVC)
-    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-    set_property(TARGET ${RANDOM_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+    # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+    set_property(TARGET ${RANDOM_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
   endif()
 
   # When using CPU Jitter as the entropy source (only in FIPS build)
@@ -765,8 +765,8 @@ if(BUILD_TESTING)
   add_dependencies(all_tests ${CRYPTO_TEST_EXEC})
 
   if(MSVC)
-  # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-  set_property(TARGET ${CRYPTO_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+  # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+  set_property(TARGET ${CRYPTO_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
   endif()
 
 endif()

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -530,6 +530,11 @@ function(build_libcrypto name module_source)
   target_include_directories(${name} SYSTEM PUBLIC
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
           $<INSTALL_INTERFACE:include>)
+  
+  if(MSVC)
+    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+    set_property(TARGET ${name} APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+  endif()
 endfunction()
 
 if(FIPS_SHARED)
@@ -540,6 +545,9 @@ if(FIPS_SHARED)
     # correct value in generated_fips_shared_support.c. See FIPS.md for a full explanation of the process
     build_libcrypto(precrypto $<TARGET_OBJECTS:fipsmodule>)
     add_executable(fips_empty_main fipsmodule/fips_empty_main.c)
+    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+    set_property(TARGET boringssl_gtest APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+
     target_link_libraries(fips_empty_main PUBLIC precrypto)
     add_custom_command(OUTPUT generated_fips_shared_support.c
             COMMAND ${GO_EXECUTABLE} run
@@ -648,6 +656,11 @@ if(BUILD_TESTING)
     fipsmodule/rand/urandom_test.cc
   )
 
+  if(MSVC)
+    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+    set_property(TARGET ${RANDOM_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+  endif()
+
   # When using CPU Jitter as the entropy source (only in FIPS build)
   # urandom_test should not be performed so we pass the compilation flag
   # and handle it in urandom_test.cc
@@ -750,6 +763,12 @@ if(BUILD_TESTING)
     target_link_libraries(${CRYPTO_TEST_EXEC} ws2_32)
   endif()
   add_dependencies(all_tests ${CRYPTO_TEST_EXEC})
+
+  if(MSVC)
+  # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+  set_property(TARGET ${CRYPTO_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+  endif()
+
 endif()
 
 install(TARGETS crypto

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -43,6 +43,12 @@ add_library(
   tls13_server.cc
   ssl_decrepit.c
 )
+
+if(MSVC)
+  # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+  set_property(TARGET ssl APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+endif()
+
 target_compile_definitions(ssl PRIVATE BORINGSSL_IMPLEMENTATION)
 add_dependencies(ssl global_target)
 
@@ -62,6 +68,11 @@ if(BUILD_TESTING)
 
     $<TARGET_OBJECTS:boringssl_gtest_main>
   )
+  
+  if(MSVC)
+    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+    set_property(TARGET ${SSL_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+  endif()
 
   add_dependencies(${SSL_TEST_EXEC} global_target)
 

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -46,7 +46,7 @@ add_library(
 
 if(MSVC)
   # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-  set_property(TARGET ssl APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
+  target_link_options(ssl PUBLIC /DEBUG:FULL)
 endif()
 
 target_compile_definitions(ssl PRIVATE BORINGSSL_IMPLEMENTATION)
@@ -71,7 +71,7 @@ if(BUILD_TESTING)
   
   if(MSVC)
     # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-    set_property(TARGET ${SSL_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
+    target_link_options(${SSL_TEST_EXEC} PUBLIC /DEBUG:FULL)
   endif()
 
   add_dependencies(${SSL_TEST_EXEC} global_target)

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -45,8 +45,8 @@ add_library(
 )
 
 if(MSVC)
-  # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-  set_property(TARGET ssl APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+  # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+  set_property(TARGET ssl APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
 endif()
 
 target_compile_definitions(ssl PRIVATE BORINGSSL_IMPLEMENTATION)
@@ -70,8 +70,8 @@ if(BUILD_TESTING)
   )
   
   if(MSVC)
-    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-    set_property(TARGET ${SSL_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+    # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+    set_property(TARGET ${SSL_TEST_EXEC} APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
   endif()
 
   add_dependencies(${SSL_TEST_EXEC} global_target)

--- a/ssl/test/CMakeLists.txt
+++ b/ssl/test/CMakeLists.txt
@@ -14,6 +14,11 @@ add_executable(
   test_state.cc
 )
 
+if(MSVC)
+  # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+  set_property(TARGET bssl_shim APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+endif()
+
 add_dependencies(bssl_shim global_target)
 
 target_link_libraries(bssl_shim test_support_lib ssl crypto)

--- a/ssl/test/CMakeLists.txt
+++ b/ssl/test/CMakeLists.txt
@@ -15,8 +15,8 @@ add_executable(
 )
 
 if(MSVC)
-  # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-  set_property(TARGET bssl_shim APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+  # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+  set_property(TARGET bssl_shim APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
 endif()
 
 add_dependencies(bssl_shim global_target)

--- a/ssl/test/CMakeLists.txt
+++ b/ssl/test/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(
 
 if(MSVC)
   # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-  set_property(TARGET bssl_shim APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
+  target_link_options(bssl_shim PUBLIC /DEBUG:FULL)
 endif()
 
 add_dependencies(bssl_shim global_target)

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -44,8 +44,8 @@ else()
 endif()
 
 if(MSVC)
-# If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-set_property(TARGET bssl APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
+  # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+  target_link_options(bssl PUBLIC /DEBUG:FULL)
 endif()
 
 install(TARGETS bssl
@@ -70,8 +70,8 @@ function(build_benchmark target_name install_path)
   endif()
 
   if(MSVC)
-  # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-  set_property(TARGET ${target_name} APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
+    # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+    target_link_options(${target_name} PUBLIC /DEBUG:FULL)
   endif()
 
 endfunction()

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -43,6 +43,11 @@ else()
   endif()
 endif()
 
+if(MSVC)
+# If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+set_property(TARGET bssl APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+endif()
+
 install(TARGETS bssl
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -62,6 +67,11 @@ function(build_benchmark target_name install_path)
   target_link_libraries(${target_name} ${libcrypto-${target_name}} ${LIBRT_FLAG})
   if(NOT MSVC AND NOT ANDROID)
     target_link_libraries(${target_name} pthread dl)
+  endif()
+
+  if(MSVC)
+  # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+  set_property(TARGET ${target_name} APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
   endif()
 
 endfunction()

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -44,8 +44,8 @@ else()
 endif()
 
 if(MSVC)
-# If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-set_property(TARGET bssl APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+# If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+set_property(TARGET bssl APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
 endif()
 
 install(TARGETS bssl
@@ -70,8 +70,8 @@ function(build_benchmark target_name install_path)
   endif()
 
   if(MSVC)
-  # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-  set_property(TARGET ${target_name} APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+  # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+  set_property(TARGET ${target_name} APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
   endif()
 
 endfunction()

--- a/util/fipstools/acvp/modulewrapper/CMakeLists.txt
+++ b/util/fipstools/acvp/modulewrapper/CMakeLists.txt
@@ -8,6 +8,11 @@ if(FIPS)
     modulewrapper.cc
   )
 
+  if(MSVC)
+    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
+    set_property(TARGET modulewrapper APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+  endif()
+
   add_dependencies(modulewrapper global_target)
 
   target_link_libraries(modulewrapper crypto)

--- a/util/fipstools/acvp/modulewrapper/CMakeLists.txt
+++ b/util/fipstools/acvp/modulewrapper/CMakeLists.txt
@@ -10,7 +10,7 @@ if(FIPS)
 
   if(MSVC)
     # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
-    set_property(TARGET modulewrapper APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
+    target_link_options(modulewrapper PUBLIC /DEBUG:FULL)
   endif()
 
   add_dependencies(modulewrapper global_target)

--- a/util/fipstools/acvp/modulewrapper/CMakeLists.txt
+++ b/util/fipstools/acvp/modulewrapper/CMakeLists.txt
@@ -9,8 +9,8 @@ if(FIPS)
   )
 
   if(MSVC)
-    # If we're building for MSVC then we want to enable the /DEBUG:ALL flag for the debug symbols
-    set_property(TARGET modulewrapper APPEND PROPERTY LINK_FLAGS /DEBUG:ALL)
+    # If we're building for MSVC then we want to enable the /DEBUG:FULL flag for the debug symbols
+    set_property(TARGET modulewrapper APPEND PROPERTY LINK_FLAGS /DEBUG:FULL)
   endif()
 
   add_dependencies(modulewrapper global_target)


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving,
explain why this change is necessary.

When evaluating the Windows FIPS build, ATSEC uses debug symbols as part of their process. However, AWS-LC currently doesn't output the necessary debug symbols for them to conduct their work. This change enables the debug linker option that allows debug symbols to be created with the build.

### Call-outs:
N/A

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Tested by ensuring the build works and produces the correct output on Windows, and that it still builds correctly on MacOS and Ubuntu.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
